### PR TITLE
#70 Extend MappaInvokeMethod to accept MappaContext parameters

### DIFF
--- a/.cursor/rules/mappa-development-workflow.mdc
+++ b/.cursor/rules/mappa-development-workflow.mdc
@@ -19,6 +19,8 @@ The development environment uses **PowerShell**. All commands run in the termina
 - **Always** create numbered TODOs that mirror the plan.
 - Maintain a **1:1 mapping** between TODOs and plan steps: each TODO must correspond to exactly one plan step, and vice versa.
 - **Step numbers must match TODO numbers** (e.g. plan step `3.` ↔ TODO `3`).
+- Plan steps must follow the **Code** project order below, but only include projects that require changes — do **not** add empty steps for unchanged projects.
+- Step numbers are **sequential** (1, 2, 3, …) across the included projects; they do **not** need to match the fixed project position numbers in the Code list (e.g. if **Mappa** and **Mappa.Tests** need no changes, the first step may be **Mappa.Generator** numbered as step `1`).
 - Generated code **must compile** and **all tests must pass** before finishing.
 
 ## Code

--- a/Documentation/mappa-attributes.md
+++ b/Documentation/mappa-attributes.md
@@ -9,12 +9,12 @@ This is the list of attributes provided:
 - `MappaUseProperty`: When mapping structured types (`class`, `struct` and `records`) allows specifying which property uses from the source property for a target property or constructor parameter;
 - `MappaIgnoreTargetProperty`: When mapping structured types (`class`, `struct` and `records`) via an empty constructor allows excluding a target property from property-initializer mapping; has no effect when mapping uses a constructor with parameters;
 - `MappaAssignFromContext`:  When mapping structured types (`class`, `struct` and `records`) allows specifying which value from the context of type `MappaContext` use for a target property or constructor parameter;
-- `MappaInvokeMethodAttribute`: When mapping structured types (`class`, `struct` and `records`) allows specifying that a property or attribute should be mapped by invoking a method; methods may be declared on the mapper **or an accessible base class**, on a type specified in the attribute **or its base classes**, or on a field or property declared on the mapper **or an accessible base class** (methods on the field or property type **and its base classes** are also considered);
+- `MappaInvokeMethodAttribute`: When mapping structured types (`class`, `struct` and `records`) allows specifying that a property or attribute should be mapped by invoking a method; methods may be declared on the mapper **or an accessible base class**, on a type specified in the attribute **or its base classes**, or on a field or property declared on the mapper **or an accessible base class** (methods on the field or property type **and its base classes** are also considered); invoked methods can optionally accept a `MappaContext` parameter (as the last parameter when combined with source and/or source-property arguments) when the map method provides one;
 - `MappaAssignFromConstant`: When mapping structured types (`class`, `struct` and `records`) allows specifying a constant value for a target property or constructor parameter;
 - `MappaTypeMapping`: When mapping structured types (`class`, `struct` and `records`) or interfaces it allows to define the target type depending on the source type.
 - `MappaTypeMappingDefault`: Describe the default behavior for polymorphic methods defined via `MappaTypeMappingDefault`.
 
-The [Mappa](https://www.nuget.org/packages/Mappa/) package also provides the `MappaContext` class that can be used to pass contextual values to mappers via the `MappaAssignFromContext` attribute.
+The [Mappa](https://www.nuget.org/packages/Mappa/) package also provides the `MappaContext` class that can be used to pass contextual values to mappers via the `MappaAssignFromContext` attribute or to methods invoked via the `MappaInvokeMethodAttribute` attribute.
 
 Via `MappaSettings` the following settings can be identified:
 - `DateTimeFormat`: the format to use to map `string`s into `System.DateTime` and vice versa;

--- a/Mappa.Generator.Tests/MappaInvokeMethodAttributeTests.MappaContext.cs
+++ b/Mappa.Generator.Tests/MappaInvokeMethodAttributeTests.MappaContext.cs
@@ -1,0 +1,947 @@
+// <copyright file="MappaInvokeMethodAttributeTests.MappaContext.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using Mappa.Generator.Diagnostics;
+using Mappa.Generator.Tests.Assertions;
+using Mappa.Generator.Tests.Assertions.Extensions;
+
+namespace Mappa.Generator.Tests;
+
+/// <summary>
+/// Integration tests for <see cref="MappaInvokeMethodAttribute"/> with <see cref="MappaContext"/>.
+/// </summary>
+public sealed partial class MappaInvokeMethodAttributeTests
+{
+    /// <summary>
+    /// Test <see cref="MappaInvokeMethodAttribute"/> targeting a local method with
+    /// three parameters: source type, source property type, and <see cref="MappaContext"/>.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    [IntegrationTest]
+    public async Task CanMapUsingNonStaticLocalMethodWithThreeParametersIncludingMappaContext()
+    {
+        const string sourceCode = """
+                                  #nullable enable
+                                  using Mappa;
+                                  using Mappa.Attributes;
+
+                                  namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                  public class Source
+                                  {
+                                      public int PropertyA { get; set; }
+                                      public int PropertyB { get; set; }
+                                  }
+
+                                  public class Target
+                                  {
+                                      public string PropertyA { get; set; }
+                                      public long PropertyB { get; set; }
+                                  }
+
+                                  [Mappa]
+                                  public sealed partial class Mapper
+                                  {
+                                      [MappaInvokeMethodAttribute(nameof(Target.PropertyA), nameof(CustomMapPropertyA))]
+                                      public partial Target Map(Source input, MappaContext context);
+
+                                      [MappaIgnore]
+                                      public string CustomMapPropertyA(Source source, int propertyA, MappaContext mappaContext)
+                                      {
+                                          return $"{source.PropertyB}/{propertyA}/{mappaContext.Keys.Count}";
+                                      }
+                                  }
+                                  #nullable restore
+                                  """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .NotHaveDiagnostics()
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethodWithContext(
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                NullableAnnotation.NotAnnotated,
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Source",
+                NullableAnnotation.NotAnnotated,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(5)
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(int).ToString(),
+                                "__mappa_tmp_1",
+                                initializationAssertions => initializationAssertions.BeMemberAccessExpressionSyntax("input.PropertyA"));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(string).ToString(),
+                                "__mappa_tmp_2",
+                                initializationAssertions => initializationAssertions.BeInvocationExpressionSyntax(
+                                    "this.CustomMapPropertyA",
+                                    firstParameterAssertions => firstParameterAssertions.BeIdentifierNameSyntax("input"),
+                                    secondParameterAssertions => secondParameterAssertions.BeIdentifierNameSyntax("__mappa_tmp_1"),
+                                    thirdParameterAssertions => thirdParameterAssertions.BeIdentifierNameSyntax("context")));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(int).ToString(),
+                                "__mappa_tmp_3",
+                                initializationAssertions => initializationAssertions.BeMemberAccessExpressionSyntax("input.PropertyB"));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                                "__mappa_tmp_4",
+                                initializationAssertions =>
+                                {
+                                    initializationAssertions.BeObjectCreationExpressionSyntax(
+                                        "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                                        ("PropertyA", initAssertions => initAssertions.BeIdentifierNameSyntax("__mappa_tmp_2")),
+                                        ("PropertyB", initAssertions => initAssertions.BeIdentifierNameSyntax("__mappa_tmp_3")));
+                                });
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeReturnStatement("__mappa_tmp_4");
+                        });
+                });
+    }
+
+    /// <summary>
+    /// Test <see cref="MappaInvokeMethodAttribute"/> targeting a local method with
+    /// source type and <see cref="MappaContext"/> parameters.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    [IntegrationTest]
+    public async Task CanMapUsingNonStaticLocalMethodWithSourceAndMappaContext()
+    {
+        const string sourceCode = """
+                                  #nullable enable
+                                  using Mappa;
+                                  using Mappa.Attributes;
+
+                                  namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                  public class Source
+                                  {
+                                      public int PropertyA { get; set; }
+                                      public int PropertyB { get; set; }
+                                  }
+
+                                  public class Target
+                                  {
+                                      public string PropertyA { get; set; }
+                                      public long PropertyB { get; set; }
+                                  }
+
+                                  [Mappa]
+                                  public sealed partial class Mapper
+                                  {
+                                      [MappaInvokeMethodAttribute(nameof(Target.PropertyA), nameof(CustomMapPropertyA))]
+                                      public partial Target Map(Source input, MappaContext context);
+
+                                      [MappaIgnore]
+                                      public string CustomMapPropertyA(Source source, MappaContext mappaContext)
+                                      {
+                                          return $"{source.PropertyB}/{mappaContext.Keys.Count}";
+                                      }
+                                  }
+                                  #nullable restore
+                                  """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .NotHaveDiagnostics()
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethodWithContext(
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                NullableAnnotation.NotAnnotated,
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Source",
+                NullableAnnotation.NotAnnotated,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(5)
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(int).ToString(),
+                                "__mappa_tmp_1",
+                                initializationAssertions => initializationAssertions.BeMemberAccessExpressionSyntax("input.PropertyA"));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(string).ToString(),
+                                "__mappa_tmp_2",
+                                initializationAssertions => initializationAssertions.BeInvocationExpressionSyntax(
+                                    "this.CustomMapPropertyA",
+                                    firstParameterAssertions => firstParameterAssertions.BeIdentifierNameSyntax("input"),
+                                    secondParameterAssertions => secondParameterAssertions.BeIdentifierNameSyntax("context")));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(int).ToString(),
+                                "__mappa_tmp_3",
+                                initializationAssertions => initializationAssertions.BeMemberAccessExpressionSyntax("input.PropertyB"));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                                "__mappa_tmp_4",
+                                initializationAssertions =>
+                                {
+                                    initializationAssertions.BeObjectCreationExpressionSyntax(
+                                        "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                                        ("PropertyA", initAssertions => initAssertions.BeIdentifierNameSyntax("__mappa_tmp_2")),
+                                        ("PropertyB", initAssertions => initAssertions.BeIdentifierNameSyntax("__mappa_tmp_3")));
+                                });
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeReturnStatement("__mappa_tmp_4");
+                        });
+                });
+    }
+
+    /// <summary>
+    /// Test <see cref="MappaInvokeMethodAttribute"/> targeting a local method with
+    /// a single <see cref="MappaContext"/> parameter.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    [IntegrationTest]
+    public async Task CanMapUsingNonStaticLocalMethodWithMappaContextOnly()
+    {
+        const string sourceCode = """
+                                  #nullable enable
+                                  using Mappa;
+                                  using Mappa.Attributes;
+
+                                  namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                  public class Source
+                                  {
+                                      public int PropertyA { get; set; }
+                                      public int PropertyB { get; set; }
+                                  }
+
+                                  public class Target
+                                  {
+                                      public string PropertyA { get; set; }
+                                      public long PropertyB { get; set; }
+                                  }
+
+                                  [Mappa]
+                                  public sealed partial class Mapper
+                                  {
+                                      [MappaInvokeMethodAttribute(nameof(Target.PropertyA), nameof(CustomMapPropertyA))]
+                                      public partial Target Map(Source input, MappaContext context);
+
+                                      [MappaIgnore]
+                                      public string CustomMapPropertyA(MappaContext mappaContext)
+                                      {
+                                          return mappaContext.Keys.Count.ToString();
+                                      }
+                                  }
+                                  #nullable restore
+                                  """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .NotHaveDiagnostics()
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethodWithContext(
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                NullableAnnotation.NotAnnotated,
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Source",
+                NullableAnnotation.NotAnnotated,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(5)
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(int).ToString(),
+                                "__mappa_tmp_1",
+                                initializationAssertions => initializationAssertions.BeMemberAccessExpressionSyntax("input.PropertyA"));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(string).ToString(),
+                                "__mappa_tmp_2",
+                                initializationAssertions => initializationAssertions.BeInvocationExpressionSyntax(
+                                    "this.CustomMapPropertyA",
+                                    firstParameterAssertions => firstParameterAssertions.BeIdentifierNameSyntax("context")));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(int).ToString(),
+                                "__mappa_tmp_3",
+                                initializationAssertions => initializationAssertions.BeMemberAccessExpressionSyntax("input.PropertyB"));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                                "__mappa_tmp_4",
+                                initializationAssertions =>
+                                {
+                                    initializationAssertions.BeObjectCreationExpressionSyntax(
+                                        "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                                        ("PropertyA", initAssertions => initAssertions.BeIdentifierNameSyntax("__mappa_tmp_2")),
+                                        ("PropertyB", initAssertions => initAssertions.BeIdentifierNameSyntax("__mappa_tmp_3")));
+                                });
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeReturnStatement("__mappa_tmp_4");
+                        });
+                });
+    }
+
+    /// <summary>
+    /// Test <see cref="MappaInvokeMethodAttribute"/> still maps using source and source-property
+    /// parameters when the map method provides <see cref="MappaContext"/> but the invoked method does not use it.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    [IntegrationTest]
+    public async Task CanMapUsingNonStaticLocalMethodWithTwoParametersWhenMapMethodProvidesMappaContext()
+    {
+        const string sourceCode = """
+                                  #nullable enable
+                                  using Mappa;
+                                  using Mappa.Attributes;
+
+                                  namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                  public class Source
+                                  {
+                                      public int PropertyA { get; set; }
+                                      public int PropertyB { get; set; }
+                                  }
+
+                                  public class Target
+                                  {
+                                      public string PropertyA { get; set; }
+                                      public long PropertyB { get; set; }
+                                  }
+
+                                  [Mappa]
+                                  public sealed partial class Mapper
+                                  {
+                                      [MappaInvokeMethodAttribute(nameof(Target.PropertyA), nameof(CustomMapPropertyA))]
+                                      public partial Target Map(Source input, MappaContext context);
+
+                                      [MappaIgnore]
+                                      public string CustomMapPropertyA(Source source, int propertyA)
+                                      {
+                                          return $"{source.PropertyB}/{propertyA}";
+                                      }
+                                  }
+                                  #nullable restore
+                                  """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .NotHaveDiagnostics()
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethodWithContext(
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                NullableAnnotation.NotAnnotated,
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Source",
+                NullableAnnotation.NotAnnotated,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(5)
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(int).ToString(),
+                                "__mappa_tmp_1",
+                                initializationAssertions => initializationAssertions.BeMemberAccessExpressionSyntax("input.PropertyA"));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(string).ToString(),
+                                "__mappa_tmp_2",
+                                initializationAssertions => initializationAssertions.BeInvocationExpressionSyntax(
+                                    "this.CustomMapPropertyA",
+                                    firstParameterAssertions => firstParameterAssertions.BeIdentifierNameSyntax("input"),
+                                    secondParameterAssertions => secondParameterAssertions.BeIdentifierNameSyntax("__mappa_tmp_1")));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(int).ToString(),
+                                "__mappa_tmp_3",
+                                initializationAssertions => initializationAssertions.BeMemberAccessExpressionSyntax("input.PropertyB"));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                                "__mappa_tmp_4",
+                                initializationAssertions =>
+                                {
+                                    initializationAssertions.BeObjectCreationExpressionSyntax(
+                                        "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                                        ("PropertyA", initAssertions => initAssertions.BeIdentifierNameSyntax("__mappa_tmp_2")),
+                                        ("PropertyB", initAssertions => initAssertions.BeIdentifierNameSyntax("__mappa_tmp_3")));
+                                });
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeReturnStatement("__mappa_tmp_4");
+                        });
+                });
+    }
+
+    /// <summary>
+    /// Test method resolution prefers a three-parameter exact match over a two-parameter exact match
+    /// when <see cref="MappaContext"/> is available.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    [IntegrationTest]
+    public async Task CanSelectThreeParameterExactOverTwoParameterExactWhenContextAvailable()
+    {
+        const string sourceCode = """
+                                  #nullable enable
+                                  using Mappa;
+                                  using Mappa.Attributes;
+
+                                  namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                  public class Source
+                                  {
+                                      public int PropertyA { get; set; }
+                                      public int PropertyB { get; set; }
+                                  }
+
+                                  public class Target
+                                  {
+                                      public string PropertyA { get; set; }
+                                      public long PropertyB { get; set; }
+                                  }
+
+                                  [Mappa]
+                                  public sealed partial class Mapper
+                                  {
+                                      [MappaInvokeMethodAttribute(nameof(Target.PropertyA), nameof(CustomMapPropertyA))]
+                                      public partial Target Map(Source input, MappaContext context);
+
+                                      [MappaIgnore]
+                                      public string CustomMapPropertyA(Source source, int propertyA, MappaContext mappaContext) => "three";
+
+                                      [MappaIgnore]
+                                      public string CustomMapPropertyA(Source source, int propertyA) => "two";
+                                  }
+                                  #nullable restore
+                                  """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .NotHaveDiagnostics()
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethodWithContext(
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                NullableAnnotation.NotAnnotated,
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Source",
+                NullableAnnotation.NotAnnotated,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(5)
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(int).ToString(),
+                                "__mappa_tmp_1",
+                                initializationAssertions => initializationAssertions.BeMemberAccessExpressionSyntax("input.PropertyA"));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(string).ToString(),
+                                "__mappa_tmp_2",
+                                initializationAssertions => initializationAssertions.BeInvocationExpressionSyntax(
+                                    "this.CustomMapPropertyA",
+                                    firstParameterAssertions => firstParameterAssertions.BeIdentifierNameSyntax("input"),
+                                    secondParameterAssertions => secondParameterAssertions.BeIdentifierNameSyntax("__mappa_tmp_1"),
+                                    thirdParameterAssertions => thirdParameterAssertions.BeIdentifierNameSyntax("context")));
+                        });
+                });
+    }
+
+    /// <summary>
+    /// Test method resolution prefers a two-parameter source-and-property match over source-and-context
+    /// when <see cref="MappaContext"/> is available.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    [IntegrationTest]
+    public async Task CanSelectTwoParameterExactOverSourceWithContextWhenContextAvailable()
+    {
+        const string sourceCode = """
+                                  #nullable enable
+                                  using Mappa;
+                                  using Mappa.Attributes;
+
+                                  namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                  public class Source
+                                  {
+                                      public int PropertyA { get; set; }
+                                      public int PropertyB { get; set; }
+                                  }
+
+                                  public class Target
+                                  {
+                                      public string PropertyA { get; set; }
+                                      public long PropertyB { get; set; }
+                                  }
+
+                                  [Mappa]
+                                  public sealed partial class Mapper
+                                  {
+                                      [MappaInvokeMethodAttribute(nameof(Target.PropertyA), nameof(CustomMapPropertyA))]
+                                      public partial Target Map(Source input, MappaContext context);
+
+                                      [MappaIgnore]
+                                      public string CustomMapPropertyA(Source source, int propertyA) => "two";
+
+                                      [MappaIgnore]
+                                      public string CustomMapPropertyA(Source source, MappaContext mappaContext) => "source-context";
+                                  }
+                                  #nullable restore
+                                  """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .NotHaveDiagnostics()
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethodWithContext(
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                NullableAnnotation.NotAnnotated,
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Source",
+                NullableAnnotation.NotAnnotated,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(5)
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(int).ToString(),
+                                "__mappa_tmp_1",
+                                initializationAssertions => initializationAssertions.BeMemberAccessExpressionSyntax("input.PropertyA"));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(string).ToString(),
+                                "__mappa_tmp_2",
+                                initializationAssertions => initializationAssertions.BeInvocationExpressionSyntax(
+                                    "this.CustomMapPropertyA",
+                                    firstParameterAssertions => firstParameterAssertions.BeIdentifierNameSyntax("input"),
+                                    secondParameterAssertions => secondParameterAssertions.BeIdentifierNameSyntax("__mappa_tmp_1")));
+                        });
+                });
+    }
+
+    /// <summary>
+    /// Test method resolution prefers source-and-context over source-only
+    /// when <see cref="MappaContext"/> is available.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    [IntegrationTest]
+    public async Task CanSelectSourceWithContextOverSourceOnlyWhenContextAvailable()
+    {
+        const string sourceCode = """
+                                  #nullable enable
+                                  using Mappa;
+                                  using Mappa.Attributes;
+
+                                  namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                  public class Source
+                                  {
+                                      public int PropertyA { get; set; }
+                                      public int PropertyB { get; set; }
+                                  }
+
+                                  public class Target
+                                  {
+                                      public string PropertyA { get; set; }
+                                      public long PropertyB { get; set; }
+                                  }
+
+                                  [Mappa]
+                                  public sealed partial class Mapper
+                                  {
+                                      [MappaInvokeMethodAttribute(nameof(Target.PropertyA), nameof(CustomMapPropertyA))]
+                                      public partial Target Map(Source input, MappaContext context);
+
+                                      [MappaIgnore]
+                                      public string CustomMapPropertyA(Source source, MappaContext mappaContext) => "source-context";
+
+                                      [MappaIgnore]
+                                      public string CustomMapPropertyA(Source source) => "source";
+                                  }
+                                  #nullable restore
+                                  """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .NotHaveDiagnostics()
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethodWithContext(
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                NullableAnnotation.NotAnnotated,
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Source",
+                NullableAnnotation.NotAnnotated,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(5)
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(int).ToString(),
+                                "__mappa_tmp_1",
+                                initializationAssertions => initializationAssertions.BeMemberAccessExpressionSyntax("input.PropertyA"));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(string).ToString(),
+                                "__mappa_tmp_2",
+                                initializationAssertions => initializationAssertions.BeInvocationExpressionSyntax(
+                                    "this.CustomMapPropertyA",
+                                    firstParameterAssertions => firstParameterAssertions.BeIdentifierNameSyntax("input"),
+                                    secondParameterAssertions => secondParameterAssertions.BeIdentifierNameSyntax("context")));
+                        });
+                });
+    }
+
+    /// <summary>
+    /// Test method resolution prefers source-only over context-only
+    /// when <see cref="MappaContext"/> is available.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    [IntegrationTest]
+    public async Task CanSelectSourceOnlyOverContextOnlyWhenBothAvailable()
+    {
+        const string sourceCode = """
+                                  #nullable enable
+                                  using Mappa;
+                                  using Mappa.Attributes;
+
+                                  namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                  public class Source
+                                  {
+                                      public int PropertyA { get; set; }
+                                      public int PropertyB { get; set; }
+                                  }
+
+                                  public class Target
+                                  {
+                                      public string PropertyA { get; set; }
+                                      public long PropertyB { get; set; }
+                                  }
+
+                                  [Mappa]
+                                  public sealed partial class Mapper
+                                  {
+                                      [MappaInvokeMethodAttribute(nameof(Target.PropertyA), nameof(CustomMapPropertyA))]
+                                      public partial Target Map(Source input, MappaContext context);
+
+                                      [MappaIgnore]
+                                      public string CustomMapPropertyA(Source source) => "source";
+
+                                      [MappaIgnore]
+                                      public string CustomMapPropertyA(MappaContext mappaContext) => "context";
+                                  }
+                                  #nullable restore
+                                  """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .NotHaveDiagnostics()
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethodWithContext(
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                NullableAnnotation.NotAnnotated,
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Source",
+                NullableAnnotation.NotAnnotated,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(5)
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(int).ToString(),
+                                "__mappa_tmp_1",
+                                initializationAssertions => initializationAssertions.BeMemberAccessExpressionSyntax("input.PropertyA"));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(string).ToString(),
+                                "__mappa_tmp_2",
+                                initializationAssertions => initializationAssertions.BeInvocationExpressionSyntax(
+                                    "this.CustomMapPropertyA",
+                                    firstParameterAssertions => firstParameterAssertions.BeIdentifierNameSyntax("input")));
+                        });
+                });
+    }
+
+    /// <summary>
+    /// Test method resolution prefers context-only over no-parameter
+    /// when <see cref="MappaContext"/> is available.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    [IntegrationTest]
+    public async Task CanSelectContextOnlyOverNoParametersWhenContextAvailable()
+    {
+        const string sourceCode = """
+                                  #nullable enable
+                                  using Mappa;
+                                  using Mappa.Attributes;
+
+                                  namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                  public class Source
+                                  {
+                                      public int PropertyA { get; set; }
+                                      public int PropertyB { get; set; }
+                                  }
+
+                                  public class Target
+                                  {
+                                      public string PropertyA { get; set; }
+                                      public long PropertyB { get; set; }
+                                  }
+
+                                  [Mappa]
+                                  public sealed partial class Mapper
+                                  {
+                                      [MappaInvokeMethodAttribute(nameof(Target.PropertyA), nameof(CustomMapPropertyA))]
+                                      public partial Target Map(Source input, MappaContext context);
+
+                                      [MappaIgnore]
+                                      public string CustomMapPropertyA(MappaContext mappaContext) => "context";
+
+                                      [MappaIgnore]
+                                      public string CustomMapPropertyA() => "none";
+                                  }
+                                  #nullable restore
+                                  """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .NotHaveDiagnostics()
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethodWithContext(
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                NullableAnnotation.NotAnnotated,
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Source",
+                NullableAnnotation.NotAnnotated,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(5)
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(int).ToString(),
+                                "__mappa_tmp_1",
+                                initializationAssertions => initializationAssertions.BeMemberAccessExpressionSyntax("input.PropertyA"));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(string).ToString(),
+                                "__mappa_tmp_2",
+                                initializationAssertions => initializationAssertions.BeInvocationExpressionSyntax(
+                                    "this.CustomMapPropertyA",
+                                    firstParameterAssertions => firstParameterAssertions.BeIdentifierNameSyntax("context")));
+                        });
+                });
+    }
+
+    /// <summary>
+    /// Test method resolution falls back to source-only when the map method does not provide
+    /// <see cref="MappaContext"/> even if a source-and-context overload exists.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    [IntegrationTest]
+    public async Task CanFallBackToSourceOnlyWhenContextUnavailable()
+    {
+        const string sourceCode = """
+                                  #nullable enable
+                                  using Mappa;
+                                  using Mappa.Attributes;
+
+                                  namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                  public class Source
+                                  {
+                                      public int PropertyA { get; set; }
+                                      public int PropertyB { get; set; }
+                                  }
+
+                                  public class Target
+                                  {
+                                      public string PropertyA { get; set; }
+                                      public long PropertyB { get; set; }
+                                  }
+
+                                  [Mappa]
+                                  public sealed partial class Mapper
+                                  {
+                                      [MappaInvokeMethodAttribute(nameof(Target.PropertyA), nameof(CustomMapPropertyA))]
+                                      public partial Target Map(Source input);
+
+                                      [MappaIgnore]
+                                      public string CustomMapPropertyA(Source source, MappaContext mappaContext) => "source-context";
+
+                                      [MappaIgnore]
+                                      public string CustomMapPropertyA(Source source) => "source";
+                                  }
+                                  #nullable restore
+                                  """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .NotHaveDiagnostics()
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                NullableAnnotation.NotAnnotated,
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Source",
+                NullableAnnotation.NotAnnotated,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(5)
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(int).ToString(),
+                                "__mappa_tmp_1",
+                                initializationAssertions => initializationAssertions.BeMemberAccessExpressionSyntax("input.PropertyA"));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(string).ToString(),
+                                "__mappa_tmp_2",
+                                initializationAssertions => initializationAssertions.BeInvocationExpressionSyntax(
+                                    "this.CustomMapPropertyA",
+                                    firstParameterAssertions => firstParameterAssertions.BeIdentifierNameSyntax("input")));
+                        });
+                });
+    }
+
+    /// <summary>
+    /// Test a diagnostic is reported when only context-requiring overloads exist
+    /// and the map method does not provide <see cref="MappaContext"/>.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    [IntegrationTest]
+    public async Task CannotMapWhenOnlyContextRequiringOverloadExistsAndMapMethodHasNoContext()
+    {
+        const string sourceCode = """
+                                  #nullable enable
+                                  using Mappa;
+                                  using Mappa.Attributes;
+
+                                  namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                  public class Source
+                                  {
+                                      public int PropertyA { get; set; }
+                                      public int PropertyB { get; set; }
+                                  }
+
+                                  public class Target
+                                  {
+                                      public string PropertyA { get; set; }
+                                      public long PropertyB { get; set; }
+                                  }
+
+                                  [Mappa]
+                                  public sealed partial class Mapper
+                                  {
+                                      [MappaInvokeMethodAttribute(nameof(Target.PropertyA), nameof(CustomMapPropertyA))]
+                                      public partial Target Map(Source input);
+
+                                      [MappaIgnore]
+                                      public string CustomMapPropertyA(Source source, MappaContext mappaContext) => "source-context";
+                                  }
+                                  #nullable restore
+                                  """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .HaveDiagnostics(2)
+            .HaveDiagnostic(MappaDiagnosticDescriptors.CannotDetectSuitableMethodToInvokeForParameter, "CustomMapPropertyA", "Mappa.Generator.Tests.UnitTests.SourceCode.Mapper", "PropertyA")
+            .HaveDiagnostic(MappaDiagnosticDescriptors.CannotMapNonRequiredProperty, "Mappa.Generator.Tests.UnitTests.SourceCode.Target", "PropertyA");
+    }
+}

--- a/Mappa.Generator.Tests/MappaInvokeMethodAttributeTests.cs
+++ b/Mappa.Generator.Tests/MappaInvokeMethodAttributeTests.cs
@@ -12,7 +12,7 @@ namespace Mappa.Generator.Tests;
 /// <summary>
 /// Unit tests for <see cref="MappaInvokeMethodAttribute"/> usage.
 /// </summary>
-public sealed class MappaInvokeMethodAttributeTests
+public sealed partial class MappaInvokeMethodAttributeTests
     : MappaGeneratorAbstractUnitTests
 {
     /// <summary>

--- a/Mappa.Generator/Algorithm/StrategyDetectors/ConstructorMapStrategyDetector.cs
+++ b/Mappa.Generator/Algorithm/StrategyDetectors/ConstructorMapStrategyDetector.cs
@@ -651,7 +651,6 @@ internal sealed class ConstructorMapStrategyDetector
         }
     }
 
-    // TODO [#70] Add support for MappaAssignFromContext.
     private bool TryGetStrategyForPropertyOrArgumentUsingAttributesOnMethod(
         string targetName,
         ITypeSymbol targetType,
@@ -860,7 +859,8 @@ internal sealed class ConstructorMapStrategyDetector
                 sourceClassType,
                 sourceProperty,
                 this.context.IsNullableEnabled(),
-                MethodDetectorMethodStaticRequirement.NotStatic);
+                MethodDetectorMethodStaticRequirement.NotStatic,
+                rootMethod);
         }
         else if (mappaInvokeMethodAttribute.ClassType is not null)
         {
@@ -883,7 +883,8 @@ internal sealed class ConstructorMapStrategyDetector
                 sourceClassType,
                 sourceProperty,
                 this.context.IsNullableEnabled(),
-                MethodDetectorMethodStaticRequirement.Static);
+                MethodDetectorMethodStaticRequirement.Static,
+                rootMethod);
         }
         else
         {
@@ -902,7 +903,8 @@ internal sealed class ConstructorMapStrategyDetector
                 sourceClassType,
                 sourceProperty,
                 this.context.IsNullableEnabled(),
-                staticRequirement);
+                staticRequirement,
+                rootMethod);
         }
 
         if (method is null)
@@ -918,6 +920,10 @@ internal sealed class ConstructorMapStrategyDetector
             return;
         }
 
+        var contextParameterName = method.MethodHasMappaContextParameter(this.compilation)
+            ? rootMethod.MaybeGetMappaContextParameterName()
+            : null;
+
         strategy = new MappaInvokeMethodAttributeStrategy(
             targetType,
             sourceClassType,
@@ -925,7 +931,8 @@ internal sealed class ConstructorMapStrategyDetector
             fieldOrProperty,
             method,
             sourceProperty,
-            this.context.MapMethod.NullableEnabled);
+            this.context.MapMethod.NullableEnabled,
+            contextParameterName);
 
         var usePropertyAttributes = mapMethod
             .GetAttributes<MappaUsePropertyAttribute>()
@@ -956,7 +963,8 @@ internal sealed class ConstructorMapStrategyDetector
             ITypeSymbol sourceClassType,
             IPropertySymbol? sourceProperty,
             bool nullableEnabled,
-            MethodDetectorMethodStaticRequirement isStatic)
+            MethodDetectorMethodStaticRequirement isStatic,
+            MapMethod rootMapMethod)
         {
             var methodsWithTheRightNameAndReturnType = methods
                 .Where(method =>
@@ -972,104 +980,211 @@ internal sealed class ConstructorMapStrategyDetector
                     })
                 .ToArray();
 
-            // No method found :( .
             if (methodsWithTheRightNameAndReturnType.Length == 0)
             {
                 return null;
             }
 
-            // If multiple methods are available first look for one having
-            // two parameters, first one being type source class
-            // and the second being the source property
-            if (sourceProperty is not null)
+            var rootProvidesMappaContext = rootMapMethod.ProvideMappaContextWhenInvoked();
+
+            bool IsExactSourceType(ITypeSymbol parameterType)
+                => parameterType.IsEqualTo(sourceClassType, nullableEnabled);
+
+            bool IsImplicitSourceType(ITypeSymbol parameterType)
+                => IsExactSourceType(parameterType) ||
+                   compilation.HasImplicitConversion(sourceClassType, parameterType);
+
+            bool IsExactSourcePropertyType(ITypeSymbol parameterType)
+                => sourceProperty is not null &&
+                   parameterType.IsEqualTo(sourceProperty.Type, nullableEnabled);
+
+            bool IsImplicitSourcePropertyType(ITypeSymbol parameterType)
+                => sourceProperty is not null &&
+                   (IsExactSourcePropertyType(parameterType) ||
+                    compilation.HasImplicitConversion(sourceProperty.Type, parameterType));
+
+            // Tier 1: source (exact), sourceProperty (exact), MappaContext.
+            if (rootProvidesMappaContext && sourceProperty is not null)
             {
-                var methodWithTwoParameters = Array.Find(
+                var match = Array.Find(
                     methodsWithTheRightNameAndReturnType,
-                    method => method.Parameters.Length == 2 &&
-                                method.Parameters[0].Type.IsEqualTo(sourceClassType, nullableEnabled) &&
-                                method.Parameters[1].Type.IsEqualTo(sourceProperty.Type, nullableEnabled));
-                if (methodWithTwoParameters is not null)
+                    method => method.Parameters.Length == 3 &&
+                              IsExactSourceType(method.Parameters[0].Type) &&
+                              IsExactSourcePropertyType(method.Parameters[1].Type) &&
+                              method.ParameterIsMappaContext(compilation, 2));
+                if (match is not null)
                 {
-                    return methodWithTwoParameters;
+                    return match;
                 }
             }
 
-            // Then look for one having
-            // two parameters, first one being implicitly convertible from source class
-            // and the second being implicitly convertible from source property
+            // Tier 2: source (exact), sourceProperty (exact).
             if (sourceProperty is not null)
             {
-                var methodWithTwoParameters = Array.Find(
+                var match = Array.Find(
                     methodsWithTheRightNameAndReturnType,
                     method => method.Parameters.Length == 2 &&
-                              (method.Parameters[0].Type.IsEqualTo(sourceClassType, nullableEnabled) || compilation.HasImplicitConversion(sourceClassType, method.Parameters[0].Type)) &&
-                              (method.Parameters[1].Type.IsEqualTo(sourceProperty.Type, nullableEnabled) || compilation.HasImplicitConversion(sourceProperty.Type, method.Parameters[1].Type)));
-                if (methodWithTwoParameters is not null)
+                              IsExactSourceType(method.Parameters[0].Type) &&
+                              IsExactSourcePropertyType(method.Parameters[1].Type));
+                if (match is not null)
                 {
-                    return methodWithTwoParameters;
+                    return match;
                 }
             }
 
-            // Then look for one having
-            // one parameter being equal to the type of source class.
-            var methodWithOneParamOfTypeClassType = Array.Find(
-                    methodsWithTheRightNameAndReturnType,
-                    method => method.Parameters.Length == 1 && method.Parameters[0].Type.IsEqualTo(sourceClassType, nullableEnabled));
-            if (methodWithOneParamOfTypeClassType is not null)
+            // Tier 3: source (implicit), sourceProperty (implicit), MappaContext.
+            if (rootProvidesMappaContext && sourceProperty is not null)
             {
-                return methodWithOneParamOfTypeClassType;
+                var match = Array.Find(
+                    methodsWithTheRightNameAndReturnType,
+                    method => method.Parameters.Length == 3 &&
+                              IsImplicitSourceType(method.Parameters[0].Type) &&
+                              IsImplicitSourcePropertyType(method.Parameters[1].Type) &&
+                              method.ParameterIsMappaContext(compilation, 2));
+                if (match is not null)
+                {
+                    return match;
+                }
             }
 
-            // Then look for one having
-            // one parameter being implicitly convertible to the type of source class.
-            var methodWithOneParamOfTypeImplicitConvertibleClassType = Array.Find(
+            // Tier 4: source (implicit), sourceProperty (implicit).
+            if (sourceProperty is not null)
+            {
+                var match = Array.Find(
+                    methodsWithTheRightNameAndReturnType,
+                    method => method.Parameters.Length == 2 &&
+                              IsImplicitSourceType(method.Parameters[0].Type) &&
+                              IsImplicitSourcePropertyType(method.Parameters[1].Type));
+                if (match is not null)
+                {
+                    return match;
+                }
+            }
+
+            // Tier 5: source (exact), MappaContext.
+            if (rootProvidesMappaContext)
+            {
+                var match = Array.Find(
+                    methodsWithTheRightNameAndReturnType,
+                    method => method.Parameters.Length == 2 &&
+                              IsExactSourceType(method.Parameters[0].Type) &&
+                              method.ParameterIsMappaContext(compilation, 1));
+                if (match is not null)
+                {
+                    return match;
+                }
+            }
+
+            // Tier 6: source (exact).
+            var tier6Match = Array.Find(
+                methodsWithTheRightNameAndReturnType,
+                method => method.Parameters.Length == 1 &&
+                          IsExactSourceType(method.Parameters[0].Type));
+            if (tier6Match is not null)
+            {
+                return tier6Match;
+            }
+
+            // Tier 7: source (implicit), MappaContext.
+            if (rootProvidesMappaContext)
+            {
+                var match = Array.Find(
+                    methodsWithTheRightNameAndReturnType,
+                    method => method.Parameters.Length == 2 &&
+                              IsImplicitSourceType(method.Parameters[0].Type) &&
+                              method.ParameterIsMappaContext(compilation, 1));
+                if (match is not null)
+                {
+                    return match;
+                }
+            }
+
+            // Tier 8: source (implicit).
+            var tier8Match = Array.Find(
                 methodsWithTheRightNameAndReturnType,
                 method => method.Parameters.Length == 1 &&
                           compilation.HasImplicitConversion(sourceClassType, method.Parameters[0].Type));
-            if (methodWithOneParamOfTypeImplicitConvertibleClassType is not null)
+            if (tier8Match is not null)
             {
-                return methodWithOneParamOfTypeImplicitConvertibleClassType;
+                return tier8Match;
             }
 
-            // Then look for one having
-            // one parameter being equal to the type of the source property.
-            if (sourceProperty is not null)
+            // Tier 9: sourceProperty (exact), MappaContext.
+            if (rootProvidesMappaContext && sourceProperty is not null)
             {
-                var methodWithOneParamOfTypeSourceType = Array.Find(
+                var match = Array.Find(
                     methodsWithTheRightNameAndReturnType,
-                    method => method.Parameters.Length == 1 &&
-                              method.Parameters[0].Type.IsEqualTo(sourceProperty.Type, nullableEnabled));
-                if (methodWithOneParamOfTypeSourceType is not null)
+                    method => method.Parameters.Length == 2 &&
+                              IsExactSourcePropertyType(method.Parameters[0].Type) &&
+                              method.ParameterIsMappaContext(compilation, 1));
+                if (match is not null)
                 {
-                    return methodWithOneParamOfTypeSourceType;
+                    return match;
                 }
             }
 
-            // Then look for one having
-            // one parameter being implicitly convertible from the type of the source property.
+            // Tier 10: sourceProperty (exact).
             if (sourceProperty is not null)
             {
-                var methodWithOneParamOfTypeConvertibleFromSourceType = Array.Find(
+                var match = Array.Find(
+                    methodsWithTheRightNameAndReturnType,
+                    method => method.Parameters.Length == 1 &&
+                              IsExactSourcePropertyType(method.Parameters[0].Type));
+                if (match is not null)
+                {
+                    return match;
+                }
+            }
+
+            // Tier 11: sourceProperty (implicit), MappaContext.
+            if (rootProvidesMappaContext && sourceProperty is not null)
+            {
+                var match = Array.Find(
+                    methodsWithTheRightNameAndReturnType,
+                    method => method.Parameters.Length == 2 &&
+                              IsImplicitSourcePropertyType(method.Parameters[0].Type) &&
+                              method.ParameterIsMappaContext(compilation, 1));
+                if (match is not null)
+                {
+                    return match;
+                }
+            }
+
+            // Tier 12: sourceProperty (implicit).
+            if (sourceProperty is not null)
+            {
+                var match = Array.Find(
                     methodsWithTheRightNameAndReturnType,
                     method => method.Parameters.Length == 1 &&
                               compilation.HasImplicitConversion(sourceProperty.Type, method.Parameters[0].Type));
-                if (methodWithOneParamOfTypeConvertibleFromSourceType is not null)
+                if (match is not null)
                 {
-                    return methodWithOneParamOfTypeConvertibleFromSourceType;
+                    return match;
                 }
             }
 
-            // Then look for one having
-            // no parameters.
-            var methodWithNoParameters = Array.Find(
-                 methodsWithTheRightNameAndReturnType,
-                 method => method.Parameters.Length == 0);
-            if (methodWithNoParameters is not null)
+            // Tier 13: MappaContext.
+            if (rootProvidesMappaContext)
             {
-                return methodWithNoParameters;
+                var match = Array.Find(
+                    methodsWithTheRightNameAndReturnType,
+                    method => method.Parameters.Length == 1 &&
+                              method.ParameterIsMappaContext(compilation, 0));
+                if (match is not null)
+                {
+                    return match;
+                }
             }
 
-            // No method has been identified.
+            // Tier 14: no parameters.
+            var tier14Match = Array.Find(
+                methodsWithTheRightNameAndReturnType,
+                method => method.Parameters.Length == 0);
+            if (tier14Match is not null)
+            {
+                return tier14Match;
+            }
+
             return null;
         }
     }

--- a/Mappa.Generator/Builders/Strategies/MappaInvokeMethodAttributeStrategyBuilder.cs
+++ b/Mappa.Generator/Builders/Strategies/MappaInvokeMethodAttributeStrategyBuilder.cs
@@ -57,40 +57,60 @@ internal sealed class MappaInvokeMethodAttributeStrategyBuilder
         return accessor;
     }
 
-    // TODO [#70] Support method with MappaContext.
     private string GetParameters(string source, MappaBuilderContext context)
     {
-        switch (this.strategy.Method.Parameters.Length)
+        var compilation = context.Compilation;
+        var method = this.strategy.Method;
+        var compositeSource = context.GetCompositeTypeSourceName();
+
+        switch (method.Parameters.Length)
         {
             case 0:
                 return string.Empty;
 
-            case 1:
+            case 3:
+                return $"{compositeSource}, {source}, {this.GetContextArgument()}";
 
-                if (this.strategy.Method.Parameters[0].Type.IsEqualTo(this.strategy.SourceType, this.strategy.IsNullableEnabled) ||
-                    context.Compilation.HasImplicitConversion(this.strategy.SourceType, this.strategy.Method.Parameters[0].Type))
+            case 2:
+                if (method.ParameterIsMappaContext(compilation, 1))
                 {
-                    return context.GetCompositeTypeSourceName();
+                    if (method.Parameters[0].Type.IsEqualTo(this.strategy.SourceType, this.strategy.IsNullableEnabled) ||
+                        compilation.HasImplicitConversion(this.strategy.SourceType, method.Parameters[0].Type))
+                    {
+                        return $"{compositeSource}, {this.GetContextArgument()}";
+                    }
+
+                    return $"{source}, {this.GetContextArgument()}";
+                }
+
+                return $"{compositeSource}, {source}";
+
+            case 1:
+                if (method.ParameterIsMappaContext(compilation, 0))
+                {
+                    return this.GetContextArgument();
+                }
+
+                if (method.Parameters[0].Type.IsEqualTo(this.strategy.SourceType, this.strategy.IsNullableEnabled) ||
+                    compilation.HasImplicitConversion(this.strategy.SourceType, method.Parameters[0].Type))
+                {
+                    return compositeSource;
                 }
 
                 if (this.strategy.SourceProperty is not null &&
-                    (this.strategy.Method.Parameters[0].Type.IsEqualTo(this.strategy.SourceProperty.Type, this.strategy.IsNullableEnabled) ||
-                    context.Compilation.HasImplicitConversion(this.strategy.SourceProperty.Type, this.strategy.Method.Parameters[0].Type)))
+                    (method.Parameters[0].Type.IsEqualTo(this.strategy.SourceProperty.Type, this.strategy.IsNullableEnabled) ||
+                    compilation.HasImplicitConversion(this.strategy.SourceProperty.Type, method.Parameters[0].Type)))
                 {
-                    return $"{source}";
-                }
-
-                throw new MappaGeneratorException("Unexpected parameter type");
-
-            case 2:
-                if (this.strategy.SourceProperty is not null)
-                {
-                    return $"{context.GetCompositeTypeSourceName()}, {source}";
+                    return source;
                 }
 
                 break;
         }
 
-        throw new MappaGeneratorException("Unsupported number of parameters.");
+        throw new MappaGeneratorException("Unexpected parameter type");
     }
+
+    private string GetContextArgument()
+        => this.strategy.ContextParameterName
+           ?? throw new MappaGeneratorException("Invoked method requires MappaContext but the root map method does not provide one.");
 }

--- a/Mappa.Generator/Extensions/InvokeMethodSourcePropertyUsage.cs
+++ b/Mappa.Generator/Extensions/InvokeMethodSourcePropertyUsage.cs
@@ -34,6 +34,11 @@ internal static class InvokeMethodSourcePropertyUsage
                 return false;
 
             case 1:
+                if (method.ParameterIsMappaContext(compilation, 0))
+                {
+                    return false;
+                }
+
                 if (method.Parameters[0].Type.IsEqualTo(sourceClassType, nullableEnabled) ||
                     compilation.HasImplicitConversion(sourceClassType, method.Parameters[0].Type))
                 {
@@ -45,6 +50,22 @@ internal static class InvokeMethodSourcePropertyUsage
                         compilation.HasImplicitConversion(sourceProperty.Type, method.Parameters[0].Type));
 
             case 2:
+                if (method.ParameterIsMappaContext(compilation, 1))
+                {
+                    if (method.Parameters[0].Type.IsEqualTo(sourceClassType, nullableEnabled) ||
+                        compilation.HasImplicitConversion(sourceClassType, method.Parameters[0].Type))
+                    {
+                        return false;
+                    }
+
+                    return sourceProperty is not null &&
+                           (method.Parameters[0].Type.IsEqualTo(sourceProperty.Type, nullableEnabled) ||
+                            compilation.HasImplicitConversion(sourceProperty.Type, method.Parameters[0].Type));
+                }
+
+                return sourceProperty is not null;
+
+            case 3:
                 return sourceProperty is not null;
 
             default:

--- a/Mappa.Generator/Extensions/MethodSymbolExtensions.cs
+++ b/Mappa.Generator/Extensions/MethodSymbolExtensions.cs
@@ -86,6 +86,65 @@ internal static class MethodSymbolExtensions
     }
 
     /// <summary>
+    /// Gets the <see cref="MappaContext"/> type from the compilation.
+    /// </summary>
+    /// <param name="compilation">The compilation.</param>
+    /// <returns>The <see cref="MappaContext"/> type, or <c>null</c> if not found.</returns>
+    internal static INamedTypeSymbol? GetMappaContextType(this Compilation compilation)
+        => compilation.GetTypeByMetadataName(MappaContextTypeFullName);
+
+    /// <summary>
+    /// Returns <c>true</c> if <paramref name="type"/> is <see cref="MappaContext"/>.
+    /// </summary>
+    /// <param name="type">The type to validate.</param>
+    /// <param name="compilation">The compilation.</param>
+    /// <returns><c>true</c> if the type is <see cref="MappaContext"/>.</returns>
+    internal static bool IsMappaContextType(this ITypeSymbol type, Compilation compilation)
+    {
+        var mappaContextType = compilation.GetMappaContextType();
+        return mappaContextType is not null && SymbolEqualityComparer.Default.Equals(mappaContextType, type);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> if the parameter at <paramref name="index"/> is of type <see cref="MappaContext"/>.
+    /// </summary>
+    /// <param name="methodSymbol">The method to validate.</param>
+    /// <param name="compilation">The compilation.</param>
+    /// <param name="index">The parameter index.</param>
+    /// <returns><c>true</c> if the parameter is of type <see cref="MappaContext"/>.</returns>
+    internal static bool ParameterIsMappaContext(
+        this IMethodSymbol methodSymbol,
+        Compilation compilation,
+        int index)
+    {
+        if (index < 0 || index >= methodSymbol.Parameters.Length)
+        {
+            return false;
+        }
+
+        return methodSymbol.Parameters[index].Type.IsMappaContextType(compilation);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> if the method has at least one parameter of type <see cref="MappaContext"/>.
+    /// </summary>
+    /// <param name="methodSymbol">The method to validate.</param>
+    /// <param name="compilation">The compilation.</param>
+    /// <returns><c>true</c> if the method has a <see cref="MappaContext"/> parameter.</returns>
+    internal static bool MethodHasMappaContextParameter(this IMethodSymbol methodSymbol, Compilation compilation)
+    {
+        for (var index = 0; index < methodSymbol.Parameters.Length; index++)
+        {
+            if (methodSymbol.ParameterIsMappaContext(compilation, index))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Returns <c>true</c> if the second parameter of the method is
     /// of type <see cref="MappaContext"/>.
     /// </summary>
@@ -102,9 +161,7 @@ internal static class MethodSymbolExtensions
             return true;
         }
 
-        var secondParameterType = methodSymbol.Parameters[1].Type;
-        var mappaContextType = compilation.GetTypeByMetadataName(MappaContextTypeFullName);
-        return SymbolEqualityComparer.Default.Equals(mappaContextType, secondParameterType);
+        return methodSymbol.ParameterIsMappaContext(compilation, 1);
     }
 
     /// <summary>

--- a/Mappa.Generator/Models/Strategies/MappaInvokeMethodAttributeStrategy.cs
+++ b/Mappa.Generator/Models/Strategies/MappaInvokeMethodAttributeStrategy.cs
@@ -20,6 +20,7 @@ namespace Mappa.Generator.Models.Strategies;
 /// <param name="method">The method to be invoked.</param>
 /// <param name="sourceProperty">The optional source property to be used by the method.</param>
 /// <param name="isNullableEnabled"><c>true</c> if nullable is enabled at this invocation point.</param>
+/// <param name="contextParameterName">The name of the root map method <see cref="MappaContext"/> parameter, if required.</param>
 internal sealed class MappaInvokeMethodAttributeStrategy(
     ITypeSymbol targetType,
     ITypeSymbol sourceClassType,
@@ -27,7 +28,8 @@ internal sealed class MappaInvokeMethodAttributeStrategy(
     ISymbol? fieldOrProperty,
     IMethodSymbol method,
     IPropertySymbol? sourceProperty,
-    bool isNullableEnabled)
+    bool isNullableEnabled,
+    string? contextParameterName)
           : MapStrategy(targetType, sourceClassType)
 {
     /// <summary>
@@ -54,6 +56,11 @@ internal sealed class MappaInvokeMethodAttributeStrategy(
     /// Gets a value indicating whether <c>nullable</c> is enabled for reference types.
     /// </summary>
     internal bool IsNullableEnabled { get; } = isNullableEnabled;
+
+    /// <summary>
+    /// Gets the name of the root map method <see cref="MappaContext"/> parameter when the invoked method requires it.
+    /// </summary>
+    internal string? ContextParameterName { get; } = contextParameterName;
 
     /// <inheritdoc/>
     internal override IMappaStrategyBuilder GetBuilder() => new MappaInvokeMethodAttributeStrategyBuilder(this);

--- a/Mappa.Samples.Aot/Runners/MappaInvokeMethodAttributeMappersRunner.cs
+++ b/Mappa.Samples.Aot/Runners/MappaInvokeMethodAttributeMappersRunner.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Stefano Anelli. All rights reserved.
 // </copyright>
 
+using Mappa;
 using Mappa.Samples;
 using Mappa.Samples.Models;
 
@@ -180,5 +181,15 @@ internal static class MappaInvokeMethodAttributeMappersRunner
             nameof(TargetClassModel),
             sourceClass,
             fieldFromMapperBase.Map(sourceClass));
+
+        report.BeginMapper(nameof(MapEmptyConstructorWithLocalStaticMethodWithSourceClassPropertyAndMappaContextInput));
+        var withMappaContext = new MapEmptyConstructorWithLocalStaticMethodWithSourceClassPropertyAndMappaContextInput();
+        var context = AotSampleData.CustomValueContext;
+        report.RecordInvocation(
+            nameof(MapEmptyConstructorWithLocalStaticMethodWithSourceClassPropertyAndMappaContextInput.Map),
+            "SourceClassModel, MappaContext",
+            nameof(TargetClassModel),
+            sourceClass,
+            withMappaContext.Map(sourceClass, context));
     }
 }

--- a/Mappa.Samples.Tests/MappaInvokeMethodAttributeMappersTests.cs
+++ b/Mappa.Samples.Tests/MappaInvokeMethodAttributeMappersTests.cs
@@ -356,4 +356,24 @@ public sealed class MappaInvokeMethodAttributeMappersTests
         actual.ParamA.Should().Be($"{nameof(MapperDependencyHelper.Map)}/{source.ParamA}/{source.ParamB}/{source.ParamA}");
         actual.ParamB.Should().Be((int)source.ParamB);
     }
+
+    /// <summary>
+    /// Test for <see cref="MapEmptyConstructorWithLocalStaticMethodWithSourceClassPropertyAndMappaContextInput"/>.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void TestMapEmptyConstructorWithLocalStaticMethodWithSourceClassPropertyAndMappaContextInput()
+    {
+        // Arrange
+        var mapper = new MapEmptyConstructorWithLocalStaticMethodWithSourceClassPropertyAndMappaContextInput();
+        var source = new SourceClassModel { ParamA = 10, ParamB = CountingValues.Three };
+        MappaContext context = new Dictionary<string, object> { ["CustomValue"] = "Use the custom value" };
+
+        // Act
+        var actual = mapper.Map(source, context);
+
+        // Assert
+        actual.ParamA.Should().Be($"{nameof(MapEmptyConstructorWithLocalStaticMethodWithSourceClassPropertyAndMappaContextInput)}/static/({nameof(SourceClassModel)},int,{nameof(MappaContext)})/{source.ParamA}/{source.ParamB}/{source.ParamA}/Use the custom value");
+        actual.ParamB.Should().Be((int)source.ParamB);
+    }
 }

--- a/Mappa.Samples/MappaInvokeMethodAttributeMappers.cs
+++ b/Mappa.Samples/MappaInvokeMethodAttributeMappers.cs
@@ -5,6 +5,7 @@
 #pragma warning disable SA1402 // File may only contain a single type
 #pragma warning disable S1118 // Utility classes should not have public constructors
 
+using Mappa;
 using Mappa.Attributes;
 using Mappa.Samples.Models;
 
@@ -604,6 +605,39 @@ public sealed partial class MapEmptyConstructorWithFieldFromMapperBaseClass
     /// <returns>The mapped object.</returns>
     [MappaInvokeMethod(nameof(TargetClassModel.ParamA), nameof(Dependency), nameof(MapperDependencyHelper.Map))]
     public partial TargetClassModel Map(SourceClassModel source);
+}
+
+/// <summary>
+/// Map from <see cref="SourceClassModel"/> to <see cref="TargetClassModel"/>
+/// using:
+/// <list type="table">
+/// <item><term>Mapping mode</term><description>Empty constructor.</description></item>
+/// <item><term>Custom method location</term><description><see cref="MapEmptyConstructorWithLocalStaticMethodWithSourceClassPropertyAndMappaContextInput"/>.</description></item>
+/// <item><term>Custom method is static</term><description><c>true</c>.</description></item>
+/// <item><term>Custom method input(s)</term><description><see cref="SourceClassModel"/>, <see cref="int"/>, and <see cref="MappaContext"/>.</description></item>
+/// </list>
+/// </summary>
+[Mappa]
+public sealed partial class MapEmptyConstructorWithLocalStaticMethodWithSourceClassPropertyAndMappaContextInput
+{
+    /// <summary>
+    /// Map from <see cref="SourceClassModel"/> to <see cref="TargetClassModel"/>
+    /// using a local static method that accepts source, property, and <see cref="MappaContext"/>.
+    /// </summary>
+    /// <param name="source">The source model to map.</param>
+    /// <param name="context">The mapping context.</param>
+    /// <returns>The mapped object.</returns>
+    [MappaInvokeMethod(nameof(TargetClassModel.ParamA), nameof(CustomMap))]
+    public partial TargetClassModel Map(SourceClassModel source, MappaContext context);
+
+    private static string CustomMap(SourceClassModel source, int property, MappaContext mappaContext)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(mappaContext);
+        mappaContext.TryGetValue<string>("CustomValue", out var customValue);
+        customValue ??= string.Empty;
+        return $"{nameof(MapEmptyConstructorWithLocalStaticMethodWithSourceClassPropertyAndMappaContextInput)}/static/({nameof(SourceClassModel)},int,{nameof(MappaContext)})/{source.ParamA}/{source.ParamB}/{property}/{customValue}";
+    }
 }
 
 /// <summary>

--- a/MappaVersion.targets
+++ b/MappaVersion.targets
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <MappaVersion>1.3.0-alpha.38</MappaVersion>
+        <MappaVersion>1.3.0-alpha.39</MappaVersion>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Extend `[MappaInvokeMethod]` method resolution with a 14-tier priority order so invoked helper methods can accept `MappaContext` (always last when combined with source and/or source-property arguments).
- Propagate context through the strategy model and builder, and update `UsesSourceProperty` for context-bearing signatures.
- Add generator integration tests covering happy paths, priority resolution, context fallback, and the negative path when only context-requiring overloads exist.
- Add a sample mapper, sample test, and AOT runner coverage; bump to `1.3.0-alpha.39`.
- Document `MappaContext` support on invoked methods in `Documentation/mappa-attributes.md`.

## Test plan
- [x] `dotnet test Mappa.Generator.Tests` — 849 tests passed (including 11 new MappaContext invoke-method tests)
- [x] `dotnet test Mappa.Samples.Tests` — 578 tests passed
- [x] `.\Scripts\RunTestsAndReportCoverage.ps1` — all tests passed, 96% line coverage
- [x] `Mappa.Samples.Aot` builds successfully