### PR TITLE
#209 Update MappaInvokeMethod attribute docs for MappaContext rules

### DIFF
--- a/Documentation/mappa-attributes.md
+++ b/Documentation/mappa-attributes.md
@@ -10,12 +10,58 @@ This is the list of attributes provided:
 - `MappaIgnoreTargetProperty`: When mapping structured types (`class`, `struct` and `records`) via an empty constructor allows excluding a target property from property-initializer mapping; has no effect when mapping uses a constructor with parameters;
 - `MappaAssignFromContext`:  When mapping structured types (`class`, `struct` and `records`) allows specifying which value from the context of type `MappaContext` use for a target property or constructor parameter;
 - `MappaAssignToContext`: When mapping structured types (`class`, `struct` and `records`) via the constructor-map strategy allows storing the value of a target property or field in the `MappaContext` after the target object has been fully constructed;
-- `MappaInvokeMethodAttribute`: When mapping structured types (`class`, `struct` and `records`) allows specifying that a property or attribute should be mapped by invoking a method; methods may be declared on the mapper **or an accessible base class**, on a type specified in the attribute **or its base classes**, or on a field or property declared on the mapper **or an accessible base class** (methods on the field or property type **and its base classes** are also considered); invoked methods can optionally accept a `MappaContext` parameter (as the last parameter when combined with source and/or source-property arguments) when the map method provides one;
+- `MappaInvokeMethodAttribute`: When mapping structured types (`class`, `struct` and `records`) via the constructor-map strategy, forces a target property or constructor parameter to be mapped by invoking a named method (see [MappaInvokeMethodAttribute](#mappainvokemethodattribute) below);
 - `MappaAssignFromConstant`: When mapping structured types (`class`, `struct` and `records`) allows specifying a constant value for a target property or constructor parameter;
 - `MappaTypeMapping`: When mapping structured types (`class`, `struct` and `records`) or interfaces it allows to define the target type depending on the source type.
 - `MappaTypeMappingDefault`: Describe the default behavior for polymorphic methods defined via `MappaTypeMappingDefault`.
 
 The [Mappa](https://www.nuget.org/packages/Mappa/) package also provides the `MappaContext` class that can be used to pass contextual values to mappers via the `MappaAssignFromContext` attribute, store mapped values via the `MappaAssignToContext` attribute, or supply context to methods invoked via the `MappaInvokeMethodAttribute` attribute.
+
+## MappaInvokeMethodAttribute
+
+When the constructor-map strategy is used, this attribute forces the source generator to map a target property or constructor parameter by invoking a named method. It does not apply when mapping nested inner types.
+
+### Method location
+
+Depending on which constructor overload is used, the invoked method is resolved as follows:
+
+- `(targetPropertyName, methodName)`: a `static` or instance method declared on the mapper class or an accessible base class. When the root map method is `static`, only `static` methods are considered; otherwise both `static` and instance methods are considered.
+- `(targetPropertyName, classType, methodName)`: a `static` method declared on the specified type or one of its base classes.
+- `(targetPropertyName, fieldName, methodName)`: an instance method declared on the type of the field or property (including its base classes). The field or property must be declared on the mapper class or an accessible base class. When the root map method is `static`, the field or property must also be `static`.
+
+When multiple methods with the same name exist in a type hierarchy, methods declared on the most derived type are preferred.
+
+### Candidate requirements
+
+Every candidate method must satisfy all of the following:
+
+- Its name matches the method name specified in the attribute exactly.
+- Its return type is equal to the target property or constructor parameter type, or is implicitly convertible to it.
+- It is accessible from the mapper class.
+- It satisfies the `static` or instance requirement described above for the attribute overload in use.
+
+### MappaContext
+
+When the root map method accepts a `MappaContext` as its second parameter, invoked methods may also accept a `MappaContext` parameter. The `MappaContext` parameter is always the last parameter when combined with source and/or source-property arguments, and its type must be `Mappa.MappaContext`. Overloads that require `MappaContext` are ignored when the map method does not provide one. If only `MappaContext`-requiring overloads exist and the map method has no `MappaContext` parameter, mapping fails.
+
+### Overload selection priority
+
+If multiple candidate methods match, the first matching overload in the following list is selected. Tiers that reference a source property apply only when a source property is available for the target member (via name matching or `[MappaUseProperty]`):
+
+1. Three parameters: source type (exact), source property (exact), `MappaContext` — requires the map method to provide `MappaContext`.
+2. Two parameters: source type (exact), source property (exact).
+3. Three parameters: source type (exact or implicitly convertible), source property (exact or implicitly convertible), `MappaContext` — requires the map method to provide `MappaContext`.
+4. Two parameters: source type (exact or implicitly convertible), source property (exact or implicitly convertible).
+5. Two parameters: source type (exact), `MappaContext` — requires the map method to provide `MappaContext`.
+6. One parameter of the same type as the source type.
+7. Two parameters: source type (exact or implicitly convertible), `MappaContext` — requires the map method to provide `MappaContext`.
+8. One parameter with a type implicitly convertible from the source type.
+9. Two parameters: source property (exact), `MappaContext` — requires the map method to provide `MappaContext`.
+10. One parameter of the same type as the source property.
+11. Two parameters: source property (exact or implicitly convertible), `MappaContext` — requires the map method to provide `MappaContext`.
+12. One parameter with a type implicitly convertible from the source property type.
+13. One parameter of type `MappaContext` — requires the map method to provide `MappaContext`.
+14. No parameters.
 
 Via `MappaSettings` the following settings can be identified:
 - `DateTimeFormat`: the format to use to map `string`s into `System.DateTime` and vice versa;

--- a/Mappa/Attributes/MappaInvokeMethodAttribute.cs
+++ b/Mappa/Attributes/MappaInvokeMethodAttribute.cs
@@ -5,30 +5,46 @@
 namespace Mappa.Attributes;
 
 /// <summary>
-/// When the constructor strategy is used it allows
-/// to force the <see cref="Mappa"/> source generator
-/// to use the method <see cref="MethodName"/>.
-/// The method <see cref="MethodName"/> can be a
-/// <c>static</c> or non-<c>static</c> method in
-/// the same class the method this attribute is applied
-/// is contained or in an accessible base class, or can be a
-/// <c>static</c> method on type <see cref="ClassType"/> or one
-/// of its base classes, or can be a non-<c>static</c>
-/// method available on a field or property in the same class
-/// the method this attribute is applied is contained or in an
-/// accessible base class.<br/>
-/// The method can have the following set of parameters:
+/// When the constructor-map strategy is used, forces the <see cref="Mappa"/> source generator
+/// to map a target property or constructor parameter by invoking <see cref="MethodName"/>.
+/// This attribute does not apply when mapping nested inner types.<br/>
+/// <br/>
+/// The method <see cref="MethodName"/> can be located in one of the following ways,
+/// depending on which constructor overload is used:<br/>
 /// <list type="bullet">
-/// <item><description>Two parameters: the first one of the same type of the source <c>class</c>/<c>struct</c>/<c>record</c>, and the second one of the same type of the source property.</description></item>
-/// <item><description>Two parameters: the first one of the same type of (or implicitly convertible from) the source <c>class</c>/<c>struct</c>/<c>record</c>, and the second one of the same type of (or implicitly convertible from) the source property.</description></item>
-/// <item><description>One parameter of the same type of the source <c>class</c>/<c>struct</c>/<c>record</c>.</description></item>
-/// <item><description>One parameter with type implicitly convertible from the source type.</description></item>
-/// <item><description>One parameter of the same type of the source property.</description></item>
-/// <item><description>One parameter with type implicitly convertible from the source property type.</description></item>
+/// <item><description><c>(targetPropertyName, methodName)</c>: a <c>static</c> or non-<c>static</c> method declared on the mapper class that contains the map method, or on an accessible base class. When the root map method is <c>static</c>, only <c>static</c> methods are considered; otherwise both <c>static</c> and instance methods are considered.</description></item>
+/// <item><description><c>(targetPropertyName, classType, methodName)</c>: a <c>static</c> method declared on <see cref="ClassType"/> or one of its base classes.</description></item>
+/// <item><description><c>(targetPropertyName, fieldName, methodName)</c>: a non-<c>static</c> method declared on the type of the field or property identified by <see cref="FieldName"/> (including its base classes). The field or property must be declared on the mapper class or an accessible base class. When the root map method is <c>static</c>, the field or property must also be <c>static</c>.</description></item>
+/// </list>
+/// When multiple methods with the same name exist in a type hierarchy, methods declared on the most derived type are preferred.<br/>
+/// <br/>
+/// Every candidate method must satisfy all of the following requirements:<br/>
+/// <list type="bullet">
+/// <item><description>Its name matches <see cref="MethodName"/> exactly.</description></item>
+/// <item><description>Its return type is equal to the target property or constructor parameter type, or is implicitly convertible to it.</description></item>
+/// <item><description>It is accessible from the mapper class.</description></item>
+/// <item><description>It satisfies the <c>static</c> or instance requirement described above for the attribute overload in use.</description></item>
+/// </list>
+/// <br/>
+/// When the root map method accepts a <see cref="Mappa.MappaContext"/> as its second parameter, invoked methods may also accept a <see cref="Mappa.MappaContext"/> parameter. The <see cref="Mappa.MappaContext"/> parameter is always the last parameter when combined with source and/or source-property arguments, and its type must be <c>Mappa.MappaContext</c>. Overloads that require <see cref="Mappa.MappaContext"/> are ignored when the map method does not provide one. If only <see cref="Mappa.MappaContext"/>-requiring overloads exist and the map method has no <see cref="Mappa.MappaContext"/> parameter, mapping fails.<br/>
+/// <br/>
+/// If multiple candidate methods match, the method is selected following the priority order below. The first matching overload wins. Tiers that reference a source property apply only when a source property is available for the target member (via name matching or <c>[MappaUseProperty]</c>):<br/>
+/// <list type="number">
+/// <item><description>Three parameters: the source <c>class</c>/<c>struct</c>/<c>record</c> (exact type), the source property (exact type), and <see cref="Mappa.MappaContext"/>. Requires the map method to provide <see cref="Mappa.MappaContext"/>.</description></item>
+/// <item><description>Two parameters: the source <c>class</c>/<c>struct</c>/<c>record</c> (exact type) and the source property (exact type).</description></item>
+/// <item><description>Three parameters: the source <c>class</c>/<c>struct</c>/<c>record</c> (exact or implicitly convertible type), the source property (exact or implicitly convertible type), and <see cref="Mappa.MappaContext"/>. Requires the map method to provide <see cref="Mappa.MappaContext"/>.</description></item>
+/// <item><description>Two parameters: the source <c>class</c>/<c>struct</c>/<c>record</c> (exact or implicitly convertible type) and the source property (exact or implicitly convertible type).</description></item>
+/// <item><description>Two parameters: the source <c>class</c>/<c>struct</c>/<c>record</c> (exact type) and <see cref="Mappa.MappaContext"/>. Requires the map method to provide <see cref="Mappa.MappaContext"/>.</description></item>
+/// <item><description>One parameter of the same type as the source <c>class</c>/<c>struct</c>/<c>record</c>.</description></item>
+/// <item><description>Two parameters: the source <c>class</c>/<c>struct</c>/<c>record</c> (exact or implicitly convertible type) and <see cref="Mappa.MappaContext"/>. Requires the map method to provide <see cref="Mappa.MappaContext"/>.</description></item>
+/// <item><description>One parameter with a type implicitly convertible from the source <c>class</c>/<c>struct</c>/<c>record</c> type.</description></item>
+/// <item><description>Two parameters: the source property (exact type) and <see cref="Mappa.MappaContext"/>. Requires the map method to provide <see cref="Mappa.MappaContext"/>.</description></item>
+/// <item><description>One parameter of the same type as the source property.</description></item>
+/// <item><description>Two parameters: the source property (exact or implicitly convertible type) and <see cref="Mappa.MappaContext"/>. Requires the map method to provide <see cref="Mappa.MappaContext"/>.</description></item>
+/// <item><description>One parameter with a type implicitly convertible from the source property type.</description></item>
+/// <item><description>One parameter of type <see cref="Mappa.MappaContext"/>. Requires the map method to provide <see cref="Mappa.MappaContext"/>.</description></item>
 /// <item><description>No parameters.</description></item>
 /// </list>
-/// If multiple matching methods exist the method is
-/// picked up following the order in the above list.
 /// </summary>
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
 public sealed class MappaInvokeMethodAttribute
@@ -37,8 +53,8 @@ public sealed class MappaInvokeMethodAttribute
     /// <summary>
     /// Initializes a new instance of the <see cref="MappaInvokeMethodAttribute"/> class.
     /// </summary>
-    /// <param name="targetPropertyName">The name of the target property.</param>
-    /// <param name="methodName">The name of the method to execute.</param>
+    /// <param name="targetPropertyName">The name of the target property or constructor parameter.</param>
+    /// <param name="methodName">The name of the method to invoke on the mapper class or an accessible base class.</param>
     public MappaInvokeMethodAttribute(string targetPropertyName, string methodName)
     {
         this.TargetPropertyName = targetPropertyName;
@@ -48,7 +64,7 @@ public sealed class MappaInvokeMethodAttribute
     /// <summary>
     /// Initializes a new instance of the <see cref="MappaInvokeMethodAttribute"/> class.
     /// </summary>
-    /// <param name="targetPropertyName">The name of the target property.</param>
+    /// <param name="targetPropertyName">The name of the target property or constructor parameter.</param>
     /// <param name="classType">The type defining the <c>static</c> method <paramref name="methodName"/> or one of its base classes.</param>
     /// <param name="methodName">The name of the <c>static</c> method to execute.</param>
     public MappaInvokeMethodAttribute(string targetPropertyName, Type classType, string methodName)
@@ -60,8 +76,8 @@ public sealed class MappaInvokeMethodAttribute
     /// <summary>
     /// Initializes a new instance of the <see cref="MappaInvokeMethodAttribute"/> class.
     /// </summary>
-    /// <param name="targetPropertyName">The name of the target property.</param>
-    /// <param name="fieldName">The name of the field or property on the mapper class or an accessible base class exposing the non-<c>static</c> method <paramref name="methodName"/>.</param>
+    /// <param name="targetPropertyName">The name of the target property or constructor parameter.</param>
+    /// <param name="fieldName">The name of the field or property on the mapper class or an accessible base class whose type exposes the non-<c>static</c> method <paramref name="methodName"/>. Must be <c>static</c> when the root map method is <c>static</c>.</param>
     /// <param name="methodName">The name of the non-<c>static</c> method to execute.</param>
     public MappaInvokeMethodAttribute(string targetPropertyName, string fieldName, string methodName)
         : this(targetPropertyName, methodName)
@@ -78,15 +94,12 @@ public sealed class MappaInvokeMethodAttribute
     public string MethodName { get; }
 
     /// <summary>
-    /// Gets the type for which the static method
-    /// <see cref="MethodName"/> should be invoked, including methods declared on its base classes.
-    /// If this property is set then <see cref="MethodName"/> must be <c>static</c>.
+    /// Gets the type for which the <c>static</c> method <see cref="MethodName"/> should be invoked, including methods declared on its base classes. When this property is set, <see cref="MethodName"/> must refer to a <c>static</c> method.
     /// </summary>
     public Type? ClassType { get; }
 
     /// <summary>
-    /// Gets the name of the field or property on the mapper class or an accessible base class
-    /// on which the non-<c>static</c> method <see cref="MethodName"/> should be invoked.
+    /// Gets the name of the field or property on the mapper class or an accessible base class whose type exposes the non-<c>static</c> method <see cref="MethodName"/>. When the root map method is <c>static</c>, the field or property must also be <c>static</c>.
     /// </summary>
     public string? FieldName { get; }
 }

--- a/MappaVersion.targets
+++ b/MappaVersion.targets
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <MappaVersion>1.3.0-alpha.43</MappaVersion>
+        <MappaVersion>1.3.0-alpha.44</MappaVersion>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Expand `MappaInvokeMethodAttribute` XML documentation to describe full compile-time method resolution rules, including `MappaContext` support and the 14-tier overload priority.
- Align `Documentation/mappa-attributes.md` with the updated attribute docs.
- Bump version to `1.3.0-alpha.44`.

## Test plan
- [x] `.\Scripts\RebuildUponVersionChange.ps1` succeeded
- [x] `.\Scripts\RunTestsAndReportCoverage.ps1` — all 1,500 tests passed

Made with [Cursor](https://cursor.com)