### PR TITLE
#208 Replace FluentAssertions with AwesomeAssertions 9.4.0

### DIFF
--- a/Mappa.Dependency.Bson.DependencyInjection.Tests/DependencyInjectionTests.cs
+++ b/Mappa.Dependency.Bson.DependencyInjection.Tests/DependencyInjectionTests.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Stefano Anelli. All rights reserved.
 // </copyright>
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.DependencyInjection;
 

--- a/Mappa.Dependency.Bson.DependencyInjection.Tests/Mappa.Dependency.Bson.DependencyInjection.Tests.csproj
+++ b/Mappa.Dependency.Bson.DependencyInjection.Tests/Mappa.Dependency.Bson.DependencyInjection.Tests.csproj
@@ -29,7 +29,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="8.8.0" />
+        <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
         <PackageReference Include="Xunit.OpenCategories.V3" Version="2.4.1.19" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
         <PackageReference Include="Comment.Todo.Analyzer" Version="1.2.0">

--- a/Mappa.Dependency.Bson.Tests/Mappa.Dependency.Bson.Tests.csproj
+++ b/Mappa.Dependency.Bson.Tests/Mappa.Dependency.Bson.Tests.csproj
@@ -28,7 +28,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="8.8.0" />
+        <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
         <PackageReference Include="Xunit.OpenCategories.V3" Version="2.4.1.19" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
         <PackageReference Include="Comment.Todo.Analyzer" Version="1.2.0">

--- a/Mappa.Dependency.Bson.Tests/MappaBsonMapperUnitTests.cs
+++ b/Mappa.Dependency.Bson.Tests/MappaBsonMapperUnitTests.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Stefano Anelli. All rights reserved.
 // </copyright>
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using MongoDB.Bson;
 

--- a/Mappa.Dependency.Protobuf.DependencyInjection.Tests/DependencyInjectionTests.cs
+++ b/Mappa.Dependency.Protobuf.DependencyInjection.Tests/DependencyInjectionTests.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Stefano Anelli. All rights reserved.
 // </copyright>
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.DependencyInjection;
 

--- a/Mappa.Dependency.Protobuf.DependencyInjection.Tests/Mappa.Dependency.Protobuf.DependencyInjection.Tests.csproj
+++ b/Mappa.Dependency.Protobuf.DependencyInjection.Tests/Mappa.Dependency.Protobuf.DependencyInjection.Tests.csproj
@@ -29,7 +29,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="8.8.0" />
+        <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
         <PackageReference Include="Xunit.OpenCategories.V3" Version="2.4.1.19" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
         <PackageReference Include="Comment.Todo.Analyzer" Version="1.2.0">

--- a/Mappa.Dependency.Protobuf.Tests/Mappa.Dependency.Protobuf.Tests.csproj
+++ b/Mappa.Dependency.Protobuf.Tests/Mappa.Dependency.Protobuf.Tests.csproj
@@ -28,7 +28,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="8.8.0" />
+        <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
         <PackageReference Include="Xunit.OpenCategories.V3" Version="2.4.1.19" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
         <PackageReference Include="Comment.Todo.Analyzer" Version="1.2.0">

--- a/Mappa.Dependency.Protobuf.Tests/ProtobufDurationUnitTests.cs
+++ b/Mappa.Dependency.Protobuf.Tests/ProtobufDurationUnitTests.cs
@@ -4,7 +4,7 @@
 
 using System.Security.Cryptography;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Google.Protobuf.WellKnownTypes;
 

--- a/Mappa.Dependency.Protobuf.Tests/ProtobufTimestampUnitTests.cs
+++ b/Mappa.Dependency.Protobuf.Tests/ProtobufTimestampUnitTests.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Stefano Anelli. All rights reserved.
 // </copyright>
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Google.Protobuf.WellKnownTypes;
 

--- a/Mappa.Generator.Tests/Assertions/AttributeSyntaxAssertions.cs
+++ b/Mappa.Generator.Tests/Assertions/AttributeSyntaxAssertions.cs
@@ -21,7 +21,7 @@ internal sealed class AttributeSyntaxAssertions
     /// </summary>
     /// <param name="value">The target of the assertions.</param>
     internal AttributeSyntaxAssertions(AttributeSyntax value)
-        : base(value, FluentAssertions.Execution.AssertionChain.GetOrCreate())
+        : base(value, AwesomeAssertions.Execution.AssertionChain.GetOrCreate())
     {
     }
 

--- a/Mappa.Generator.Tests/Assertions/BaseNamespaceDeclarationSyntaxAssertions.cs
+++ b/Mappa.Generator.Tests/Assertions/BaseNamespaceDeclarationSyntaxAssertions.cs
@@ -32,7 +32,7 @@ internal abstract class BaseNamespaceDeclarationSyntaxAssertions<TNamespaceSynta
         TNamespaceSyntax value,
         SemanticModel semanticModel,
         Compilation compilation)
-        : base(value, FluentAssertions.Execution.AssertionChain.GetOrCreate())
+        : base(value, AwesomeAssertions.Execution.AssertionChain.GetOrCreate())
     {
         this.semanticModel = semanticModel;
         this.compilation = compilation;

--- a/Mappa.Generator.Tests/Assertions/BlockSyntaxAssertions.cs
+++ b/Mappa.Generator.Tests/Assertions/BlockSyntaxAssertions.cs
@@ -30,7 +30,7 @@ internal sealed class BlockSyntaxAssertions
         BlockSyntax value,
         SemanticModel semanticModel,
         Compilation compilation)
-        : base(value, FluentAssertions.Execution.AssertionChain.GetOrCreate())
+        : base(value, AwesomeAssertions.Execution.AssertionChain.GetOrCreate())
     {
         this.semanticModel = semanticModel;
         this.compilation = compilation;

--- a/Mappa.Generator.Tests/Assertions/CasePatternSwitchLabelSyntaxAssertions.cs
+++ b/Mappa.Generator.Tests/Assertions/CasePatternSwitchLabelSyntaxAssertions.cs
@@ -24,7 +24,7 @@ internal sealed class CasePatternSwitchLabelSyntaxAssertions
     /// <param name="compilation">The compilation.</param>
     public CasePatternSwitchLabelSyntaxAssertions(
         CasePatternSwitchLabelSyntax value, SemanticModel semanticModel, Compilation compilation)
-        : base(value, FluentAssertions.Execution.AssertionChain.GetOrCreate())
+        : base(value, AwesomeAssertions.Execution.AssertionChain.GetOrCreate())
     {
         this.semanticModel = semanticModel;
         this.compilation = compilation;

--- a/Mappa.Generator.Tests/Assertions/CaseSwitchLabelSyntaxAssertions.cs
+++ b/Mappa.Generator.Tests/Assertions/CaseSwitchLabelSyntaxAssertions.cs
@@ -26,7 +26,7 @@ internal sealed class CaseSwitchLabelSyntaxAssertions
         CaseSwitchLabelSyntax value,
         SemanticModel semanticModel,
         Compilation compilation)
-        : base(value, FluentAssertions.Execution.AssertionChain.GetOrCreate())
+        : base(value, AwesomeAssertions.Execution.AssertionChain.GetOrCreate())
     {
         this.semanticModel = semanticModel;
         this.compilation = compilation;

--- a/Mappa.Generator.Tests/Assertions/ClassDeclarationSyntaxAssertions.cs
+++ b/Mappa.Generator.Tests/Assertions/ClassDeclarationSyntaxAssertions.cs
@@ -30,7 +30,7 @@ internal sealed class ClassDeclarationSyntaxAssertions
         ClassDeclarationSyntax value,
         SemanticModel semanticModel,
         Compilation compilation)
-        : base(value, FluentAssertions.Execution.AssertionChain.GetOrCreate())
+        : base(value, AwesomeAssertions.Execution.AssertionChain.GetOrCreate())
     {
         this.semanticModel = semanticModel;
         this.compilation = compilation;

--- a/Mappa.Generator.Tests/Assertions/CompilationUnitSyntaxAssertions.cs
+++ b/Mappa.Generator.Tests/Assertions/CompilationUnitSyntaxAssertions.cs
@@ -28,7 +28,7 @@ internal sealed class CompilationUnitSyntaxAssertions
         CompilationUnitSyntax value,
         SemanticModel semanticModel,
         Compilation compilation)
-        : base(value, FluentAssertions.Execution.AssertionChain.GetOrCreate())
+        : base(value, AwesomeAssertions.Execution.AssertionChain.GetOrCreate())
     {
         this.semanticModel = semanticModel;
         this.compilation = compilation;

--- a/Mappa.Generator.Tests/Assertions/DefaultSwitchLabelSyntaxAssertions.cs
+++ b/Mappa.Generator.Tests/Assertions/DefaultSwitchLabelSyntaxAssertions.cs
@@ -19,7 +19,7 @@ internal sealed class DefaultSwitchLabelSyntaxAssertions
     /// <param name="value">The target of the assertions.</param>
     internal DefaultSwitchLabelSyntaxAssertions(
         DefaultSwitchLabelSyntax value)
-        : base(value, FluentAssertions.Execution.AssertionChain.GetOrCreate())
+        : base(value, AwesomeAssertions.Execution.AssertionChain.GetOrCreate())
     {
     }
 

--- a/Mappa.Generator.Tests/Assertions/ExpressionSyntaxAssertions.cs
+++ b/Mappa.Generator.Tests/Assertions/ExpressionSyntaxAssertions.cs
@@ -28,7 +28,7 @@ internal sealed class ExpressionSyntaxAssertions
         ExpressionSyntax value,
         SemanticModel semanticModel,
         Compilation compilation)
-        : base(value, FluentAssertions.Execution.AssertionChain.GetOrCreate())
+        : base(value, AwesomeAssertions.Execution.AssertionChain.GetOrCreate())
     {
         this.semanticModel = semanticModel;
         this.compilation = compilation;

--- a/Mappa.Generator.Tests/Assertions/GeneratedResultsAssertions.cs
+++ b/Mappa.Generator.Tests/Assertions/GeneratedResultsAssertions.cs
@@ -24,7 +24,7 @@ internal sealed class GeneratedResultsAssertions
     /// </summary>
     /// <param name="value">The target of the assertions.</param>
     internal GeneratedResultsAssertions(GeneratedResults value)
-        : base(value, FluentAssertions.Execution.AssertionChain.GetOrCreate())
+        : base(value, AwesomeAssertions.Execution.AssertionChain.GetOrCreate())
     {
     }
 

--- a/Mappa.Generator.Tests/Assertions/GeneratorRunResultAssertions.cs
+++ b/Mappa.Generator.Tests/Assertions/GeneratorRunResultAssertions.cs
@@ -19,7 +19,7 @@ internal sealed class GeneratorRunResultAssertions
     /// </summary>
     /// <param name="value">The target of the assertions.</param>
     internal GeneratorRunResultAssertions(GeneratorRunResult value)
-        : base(value, FluentAssertions.Execution.AssertionChain.GetOrCreate())
+        : base(value, AwesomeAssertions.Execution.AssertionChain.GetOrCreate())
     {
     }
 

--- a/Mappa.Generator.Tests/Assertions/MethodDeclarationSyntaxAssertions.cs
+++ b/Mappa.Generator.Tests/Assertions/MethodDeclarationSyntaxAssertions.cs
@@ -29,7 +29,7 @@ internal sealed class MethodDeclarationSyntaxAssertions
         MethodDeclarationSyntax value,
         SemanticModel semanticModel,
         Compilation compilation)
-        : base(value, FluentAssertions.Execution.AssertionChain.GetOrCreate())
+        : base(value, AwesomeAssertions.Execution.AssertionChain.GetOrCreate())
     {
         this.semanticModel = semanticModel;
         this.compilation = compilation;

--- a/Mappa.Generator.Tests/Assertions/PatternSyntaxAssertions.cs
+++ b/Mappa.Generator.Tests/Assertions/PatternSyntaxAssertions.cs
@@ -24,7 +24,7 @@ internal sealed class PatternSyntaxAssertions
     /// <param name="semanticModel">The semantic model.</param>
     /// <param name="compilation">The compilation.</param>
     public PatternSyntaxAssertions(PatternSyntax value, SemanticModel semanticModel, Compilation compilation)
-        : base(value, FluentAssertions.Execution.AssertionChain.GetOrCreate())
+        : base(value, AwesomeAssertions.Execution.AssertionChain.GetOrCreate())
     {
         this.semanticModel = semanticModel;
         this.compilation = compilation;

--- a/Mappa.Generator.Tests/Assertions/StatementSyntaxAssertions.cs
+++ b/Mappa.Generator.Tests/Assertions/StatementSyntaxAssertions.cs
@@ -18,7 +18,7 @@ internal sealed class StatementSyntaxAssertions
     /// </summary>
     /// <param name="value">The target of assertions.</param>
     public StatementSyntaxAssertions(StatementSyntax value)
-        : base(value, FluentAssertions.Execution.AssertionChain.GetOrCreate())
+        : base(value, AwesomeAssertions.Execution.AssertionChain.GetOrCreate())
     {
     }
 

--- a/Mappa.Generator.Tests/Assertions/SyntaxNodeAssertions.cs
+++ b/Mappa.Generator.Tests/Assertions/SyntaxNodeAssertions.cs
@@ -29,7 +29,7 @@ internal sealed class SyntaxNodeAssertions
         SyntaxNode value,
         SemanticModel semanticModel,
         Compilation compilation)
-        : base(value, FluentAssertions.Execution.AssertionChain.GetOrCreate())
+        : base(value, AwesomeAssertions.Execution.AssertionChain.GetOrCreate())
     {
         this.semanticModel = semanticModel;
         this.compilation = compilation;

--- a/Mappa.Generator.Tests/Assertions/VariableDeclarationSyntaxAssertions.cs
+++ b/Mappa.Generator.Tests/Assertions/VariableDeclarationSyntaxAssertions.cs
@@ -25,7 +25,7 @@ internal sealed class VariableDeclarationSyntaxAssertions
     /// <param name="semanticModel">The semantic model.</param>
     /// <param name="compilation">The compilation.</param>
     public VariableDeclarationSyntaxAssertions(VariableDeclarationSyntax value, SemanticModel semanticModel, Compilation compilation)
-        : base(value, FluentAssertions.Execution.AssertionChain.GetOrCreate())
+        : base(value, AwesomeAssertions.Execution.AssertionChain.GetOrCreate())
     {
         this.semanticModel = semanticModel;
         this.compilation = compilation;

--- a/Mappa.Generator.Tests/Mappa.Generator.Tests.csproj
+++ b/Mappa.Generator.Tests/Mappa.Generator.Tests.csproj
@@ -29,7 +29,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="FluentAssertions" Version="8.8.0" />
+		<PackageReference Include="AwesomeAssertions" Version="9.4.0" />
 		<PackageReference Include="Xunit.OpenCategories.V3" Version="2.4.1.19" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
 		<PackageReference Include="PrettyCode.StringBuilder" Version="1.0.0" />

--- a/Mappa.Generator.Tests/Usings.cs
+++ b/Mappa.Generator.Tests/Usings.cs
@@ -5,8 +5,8 @@
 global using System.Reflection;
 global using System.Threading;
 
-global using FluentAssertions;
-global using FluentAssertions.Primitives;
+global using AwesomeAssertions;
+global using AwesomeAssertions.Primitives;
 
 global using Mappa.Attributes;
 global using Mappa.Generator.Algorithm;

--- a/Mappa.Samples.Tests/GlobalUsings.cs
+++ b/Mappa.Samples.Tests/GlobalUsings.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Stefano Anelli. All rights reserved.
 // </copyright>
 
-global using FluentAssertions;
+global using AwesomeAssertions;
 global using Mappa.Samples.Models;
 global using Xunit;
 global using Xunit.OpenCategories.V3;

--- a/Mappa.Samples.Tests/Mappa.Samples.Tests.csproj
+++ b/Mappa.Samples.Tests/Mappa.Samples.Tests.csproj
@@ -22,7 +22,7 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="coverlet.MTP" Version="10.0.1" />
-        <PackageReference Include="FluentAssertions" Version="8.8.0" />
+        <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
         <PackageReference Include="Xunit.OpenCategories.V3" Version="2.4.1.19" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
         <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">

--- a/Mappa.Tests/Mappa.Tests.csproj
+++ b/Mappa.Tests/Mappa.Tests.csproj
@@ -28,7 +28,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="8.8.0" />
+        <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
         <PackageReference Include="Xunit.OpenCategories.V3" Version="2.4.1.19" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
         <PackageReference Include="Comment.Todo.Analyzer" Version="1.2.0">

--- a/Mappa.Tests/MappaContextTests.cs
+++ b/Mappa.Tests/MappaContextTests.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Stefano Anelli. All rights reserved.
 // </copyright>
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Xunit;
 using Xunit.OpenCategories.V3;

--- a/MappaVersion.targets
+++ b/MappaVersion.targets
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <MappaVersion>10.1.0-alpha.1</MappaVersion>
+        <MappaVersion>10.1.0-alpha.2</MappaVersion>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

- Replace FluentAssertions 8.8.0 with AwesomeAssertions 9.4.0 across all seven test projects.
- Update namespaces from \FluentAssertions\ to \AwesomeAssertions\ (including custom \ObjectAssertions\ helpers in Mappa.Generator.Tests).
- Bump \MappaVersion\ to \10.1.0-alpha.2\ and rebuild downstream projects.

## Test plan

- [x] \dotnet test\ each migrated test project in Release
- [x] \.\Scripts\RunTestsAndReportCoverage.ps1\ — 1713 tests passed
- [x] Confirm no remaining \FluentAssertions\ references in the repository

Made with [Cursor](https://cursor.com)