### PR TITLE
#229 Fix .editorconfig CurrentCulture mapping in MappaGlobalOptions

### DIFF
--- a/Mappa.Generator.Tests/StringToNumberMapStrategyIntegrationTests.CultureSettings.cs
+++ b/Mappa.Generator.Tests/StringToNumberMapStrategyIntegrationTests.CultureSettings.cs
@@ -154,6 +154,81 @@ public sealed partial class StringToNumberMapStrategyIntegrationTests
     }
 
     /// <summary>
+    /// Test a mapping can be created from a string to a number using current culture defined in <c>.editorconfig</c>.
+    /// </summary>
+    /// <param name="aliasNumericType">The type alias.</param>
+    /// <param name="numericType">The type full name.</param>
+    /// <param name="formatPropertyName">The format property name.</param>
+    /// <param name="editorConfigFormatKey">The editorconfig format key.</param>
+    /// <returns>The async task.</returns>
+    [Theory]
+    [MemberData(nameof(NumericMappaSettingsTestHelper.NumericTypeTestData), MemberType = typeof(NumericMappaSettingsTestHelper))]
+    [IntegrationTest]
+    public async Task CanMapStringToNumberWithCurrentCultureDefinedInEditorConfig(
+        string aliasNumericType,
+        string numericType,
+        string formatPropertyName,
+        string editorConfigFormatKey)
+    {
+        _ = formatPropertyName;
+        _ = editorConfigFormatKey;
+
+        const string identifierName = "__mappa_tmp_1";
+
+        const string editorConfig = """
+                                    root = true
+
+                                    [*.cs]
+                                    mappa.cultureinfosettings = CurrentCulture
+                                    """;
+
+        var sourceCode = $$"""
+                          #nullable enable
+                          using Mappa.Attributes;
+
+                          namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                          [Mappa]
+                          public sealed partial class Mapper
+                          {
+                              public partial {{aliasNumericType}} Map(string input);
+                          }
+                          """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, editorConfig, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .NotHaveDiagnostics()
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                numericType,
+                NullableAnnotation.NotAnnotated,
+                typeof(string).ToString(),
+                NullableAnnotation.NotAnnotated,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(2)
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                numericType,
+                                identifierName,
+                                expressionSyntaxAssertions => expressionSyntaxAssertions.BeInvocationExpressionSyntax(
+                                    $"{aliasNumericType}.Parse",
+                                    firstParameter => firstParameter.BeIdentifierNameSyntax("input"),
+                                    secondParameter => secondParameter.BeMemberAccessExpressionSyntax("System.Globalization.CultureInfo.CurrentCulture")));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeReturnStatement(assertion => assertion.BeIdentifierNameSyntax(identifierName));
+                        });
+                });
+    }
+
+    /// <summary>
     /// Test a mapping can be created from a string to a number using user defined culture.
     /// </summary>
     /// <param name="aliasNumericType">The type alias.</param>

--- a/Mappa.Generator/Models/MappaGlobalOptions.cs
+++ b/Mappa.Generator/Models/MappaGlobalOptions.cs
@@ -390,11 +390,6 @@ internal sealed class MappaGlobalOptions
         {
             if (cultureInfoSettings.Equals(nameof(CultureInfoSetting.CurrentCulture), StringComparison.OrdinalIgnoreCase))
             {
-                return CultureInfoSetting.None;
-            }
-
-            if (cultureInfoSettings.Equals(nameof(CultureInfoSetting.CurrentCulture), StringComparison.OrdinalIgnoreCase))
-            {
                 return CultureInfoSetting.CurrentCulture;
             }
 

--- a/MappaVersion.targets
+++ b/MappaVersion.targets
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <MappaVersion>10.1.0-alpha.9</MappaVersion>
+        <MappaVersion>10.1.0-alpha.10</MappaVersion>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

- Fix `GetCultureInfoSettingsFromString` so `mappa.cultureinfosettings = CurrentCulture` in `.editorconfig` resolves to `CultureInfoSetting.CurrentCulture` instead of `None`.
- Add integration test `CanMapStringToNumberWithCurrentCultureDefinedInEditorConfig` covering editorconfig-only current culture for string-to-number parsing.
- Bump version to `10.1.0-alpha.10`.

## Test plan

- [x] `CanMapStringToNumberWithCurrentCultureDefinedInEditorConfig` passes (11 theory cases)
- [x] Full test suite passes (1996 tests)
- [x] Coverage report generated via `.\Scripts\RunTestsAndReportCoverage.ps1`

Closes #229

Made with [Cursor](https://cursor.com)