### PR TITLE
#230 Escape user-controlled format and culture strings in generated mapping code

### DIFF
--- a/.cursor/rules/mappa-development-workflow.mdc
+++ b/.cursor/rules/mappa-development-workflow.mdc
@@ -50,6 +50,8 @@ The development environment uses **PowerShell**. All commands run in the termina
 - Coding standards are **strict**. Diagnostic IDs prefixed with `SA` come from **StyleCop**; IDs prefixed with `S` come from **Sonar Analyzer**.
 - Fix all StyleCop and Sonar Analyzer violations before finishing.
 - If a violation persists after **two** fix attempts, stop and ask the user for help.
+- **File endings:** the root [`.editorconfig`](.editorconfig) sets `insert_final_newline = false` and `end_of_line = crlf`. Source files must **not** end with a trailing newline after the last line of content. A trailing newline triggers StyleCop **SA1518** (*File may not end with a newline character*). When creating or editing files, ensure the final character is the last character of the closing line (e.g. `}`), not an extra blank line or newline after it.
+- **Nullability:** do **not** use the null-forgiving operator (`!`) to silence nullable reference warnings. Prefer APIs that accept nullable parameters when null is valid, explicit null or whitespace checks with a thrown exception when null is unexpected (e.g. `MappaGeneratorException`, `ArgumentNullException`), or assign to a local variable after validation so the compiler can narrow the type.
 
 ## Git
 

--- a/Mappa.Generator.Tests/FormatAndCultureLiteralEscapingIntegrationTests.cs
+++ b/Mappa.Generator.Tests/FormatAndCultureLiteralEscapingIntegrationTests.cs
@@ -1,0 +1,501 @@
+// <copyright file="FormatAndCultureLiteralEscapingIntegrationTests.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using System.Text;
+
+using Mappa.Generator.Tests.Abstractions;
+using Mappa.Generator.Tests.Assertions;
+using Mappa.Generator.Tests.Assertions.Extensions;
+
+namespace Mappa.Generator.Tests;
+
+/// <summary>
+/// Integration tests for escaped format and culture literals in generated mapping code.
+/// </summary>
+public sealed class FormatAndCultureLiteralEscapingIntegrationTests
+    : MappaGeneratorAbstractUnitTests
+{
+    /// <summary>
+    /// Gets test data for format strings containing special characters.
+    /// </summary>
+    /// <returns>The test data.</returns>
+    public static TheoryData<string, string> SpecialCharacterFormatTestData()
+    {
+        var data = new TheoryData<string, string>();
+        data.Add("embeddedDoubleQuote", @"yyyy""MM""dd");
+        data.Add("backslash", @"yyyy\\MM");
+        data.Add("newline", "yyyy\nMM".Replace("\\n", "\n", StringComparison.Ordinal));
+        return data;
+    }
+
+    /// <summary>
+    /// Gets test data for editorconfig format values that fit on a single line.
+    /// </summary>
+    /// <returns>The test data.</returns>
+    public static TheoryData<string, string> SpecialCharacterEditorConfigFormatTestData()
+    {
+        var data = new TheoryData<string, string>();
+        data.Add("embeddedDoubleQuote", @"yyyy""MM""dd");
+        data.Add("backslash", @"yyyy\\MM");
+        return data;
+    }
+
+    /// <summary>
+    /// Gets test data for culture names containing special characters.
+    /// </summary>
+    /// <returns>The test data.</returns>
+    public static TheoryData<string, string> SpecialCharacterCultureNameTestData()
+    {
+        var data = new TheoryData<string, string>();
+        data.Add("embeddedDoubleQuote", @"it""IT");
+        data.Add("backslash", @"it\\IT");
+        data.Add("newline", "it\nIT".Replace("\\n", "\n", StringComparison.Ordinal));
+        return data;
+    }
+
+    /// <summary>
+    /// Gets test data for editorconfig culture names that fit on a single line.
+    /// </summary>
+    /// <returns>The test data.</returns>
+    public static TheoryData<string, string> SpecialCharacterEditorConfigCultureNameTestData()
+    {
+        var data = new TheoryData<string, string>();
+        data.Add("embeddedDoubleQuote", @"it""IT");
+        data.Add("backslash", @"it\\IT");
+        return data;
+    }
+
+    /// <summary>
+    /// Test string to <see cref="DateTime"/> mapping escapes special characters in a format defined on the method.
+    /// </summary>
+    /// <param name="scenario">The scenario name.</param>
+    /// <param name="format">The format string.</param>
+    /// <returns>The async task.</returns>
+    [Theory]
+    [MemberData(nameof(SpecialCharacterFormatTestData))]
+    [IntegrationTest]
+    public async Task CanMapStringToDateTimeWithSpecialCharacterFormatDefinedInAttribute(string scenario, string format)
+    {
+        ArgumentNullException.ThrowIfNull(format);
+        _ = scenario;
+
+        const string identifierName = "__mappa_tmp_1";
+        var formatInAttribute = EscapeForCSharpStringAttribute(format);
+
+        var sourceCode = $$"""
+                          #nullable enable
+                          using System;
+                          using Mappa.Attributes;
+
+                          namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                          [Mappa]
+                          public sealed partial class Mapper
+                          {
+                              [MappaSettings(DateTimeFormat = "{{formatInAttribute}}", CultureInfoSetting = CultureInfoSetting.InvariantCulture)]
+                              public partial DateTime Map(string input);
+                          }
+                          """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .NotHaveDiagnostics()
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                typeof(DateTime).ToString(),
+                NullableAnnotation.NotAnnotated,
+                typeof(string).ToString(),
+                NullableAnnotation.NotAnnotated,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(2)
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(DateTime).ToString(),
+                                identifierName,
+                                expressionSyntaxAssertions => expressionSyntaxAssertions.BeInvocationExpressionSyntax(
+                                    "System.DateTime.ParseExact",
+                                    firstParameter => firstParameter.BeIdentifierNameSyntax("input"),
+                                    secondParameter => secondParameter.BeLiteralExpressionSyntax(format),
+                                    thirdParameter => thirdParameter.BeMemberAccessExpressionSyntax("System.Globalization.CultureInfo.InvariantCulture")));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeReturnStatement(assertion => assertion.BeIdentifierNameSyntax(identifierName));
+                        });
+                });
+    }
+
+    /// <summary>
+    /// Test <see cref="int"/> to <see cref="string"/> mapping escapes special characters in a format defined on the method.
+    /// </summary>
+    /// <param name="scenario">The scenario name.</param>
+    /// <param name="format">The format string.</param>
+    /// <returns>The async task.</returns>
+    [Theory]
+    [MemberData(nameof(SpecialCharacterFormatTestData))]
+    [IntegrationTest]
+    public async Task CanMapIntToStringWithSpecialCharacterFormatDefinedInAttribute(string scenario, string format)
+    {
+        ArgumentNullException.ThrowIfNull(format);
+        _ = scenario;
+
+        const string identifierName = "__mappa_tmp_1";
+        var formatInAttribute = EscapeForCSharpStringAttribute(format);
+
+        var sourceCode = $$"""
+                          #nullable enable
+                          using Mappa.Attributes;
+
+                          namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                          [Mappa]
+                          public sealed partial class Mapper
+                          {
+                              [MappaSettings(IntFormat = "{{formatInAttribute}}")]
+                              public partial string Map(int input);
+                          }
+                          """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .NotHaveDiagnostics()
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                typeof(string).ToString(),
+                NullableAnnotation.NotAnnotated,
+                typeof(int).ToString(),
+                NullableAnnotation.NotAnnotated,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(2)
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(string).ToString(),
+                                identifierName,
+                                expressionSyntaxAssertions => expressionSyntaxAssertions.BeInvocationExpressionSyntax(
+                                    "input.ToString",
+                                    firstParameter => firstParameter.BeLiteralExpressionSyntax(format)));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeReturnStatement(assertion => assertion.BeIdentifierNameSyntax(identifierName));
+                        });
+                });
+    }
+
+    /// <summary>
+    /// Test string to <see cref="int"/> mapping escapes special characters in a user-defined culture name on the method.
+    /// </summary>
+    /// <param name="scenario">The scenario name.</param>
+    /// <param name="cultureName">The culture name.</param>
+    /// <returns>The async task.</returns>
+    [Theory]
+    [MemberData(nameof(SpecialCharacterCultureNameTestData))]
+    [IntegrationTest]
+    public async Task CanMapStringToIntWithSpecialCharacterCultureNameDefinedInAttribute(string scenario, string cultureName)
+    {
+        ArgumentNullException.ThrowIfNull(cultureName);
+        _ = scenario;
+
+        const string identifierName = "__mappa_tmp_1";
+        var cultureNameInAttribute = EscapeForCSharpStringAttribute(cultureName);
+
+        var sourceCode = $$"""
+                          #nullable enable
+                          using Mappa;
+                          using Mappa.Attributes;
+
+                          namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                          [Mappa]
+                          public sealed partial class Mapper
+                          {
+                              [MappaSettings(CultureInfoSetting = CultureInfoSetting.UserDefined, CultureName = "{{cultureNameInAttribute}}")]
+                              public partial int Map(string input);
+                          }
+                          """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .NotHaveDiagnostics()
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                typeof(int).ToString(),
+                NullableAnnotation.NotAnnotated,
+                typeof(string).ToString(),
+                NullableAnnotation.NotAnnotated,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(2)
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(int).ToString(),
+                                identifierName,
+                                expressionSyntaxAssertions => expressionSyntaxAssertions.BeInvocationExpressionSyntax(
+                                    "int.Parse",
+                                    firstParameter => firstParameter.BeIdentifierNameSyntax("input"),
+                                    secondParameter => secondParameter.BeInvocationExpressionSyntax(
+                                        "System.Globalization.CultureInfo.GetCultureInfo",
+                                        getCultureInfoParameter => getCultureInfoParameter.BeLiteralExpressionSyntax(cultureName))));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeReturnStatement(assertion => assertion.BeIdentifierNameSyntax(identifierName));
+                        });
+                });
+    }
+
+    /// <summary>
+    /// Test string to <see cref="Guid"/> mapping escapes special characters in a format defined on the method.
+    /// </summary>
+    /// <param name="scenario">The scenario name.</param>
+    /// <param name="format">The format string.</param>
+    /// <returns>The async task.</returns>
+    [Theory]
+    [MemberData(nameof(SpecialCharacterFormatTestData))]
+    [IntegrationTest]
+    public async Task CanMapStringToGuidWithSpecialCharacterFormatDefinedInAttribute(string scenario, string format)
+    {
+        ArgumentNullException.ThrowIfNull(format);
+        _ = scenario;
+
+        const string identifierName = "__mappa_tmp_1";
+        var formatInAttribute = EscapeForCSharpStringAttribute(format);
+
+        var sourceCode = $$"""
+                          #nullable enable
+                          using System;
+                          using Mappa.Attributes;
+
+                          namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                          [Mappa]
+                          public sealed partial class Mapper
+                          {
+                              [MappaSettings(GuidFormat = "{{formatInAttribute}}")]
+                              public partial Guid Map(string input);
+                          }
+                          """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .NotHaveDiagnostics()
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                typeof(Guid).ToString(),
+                NullableAnnotation.NotAnnotated,
+                typeof(string).ToString(),
+                NullableAnnotation.NotAnnotated,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(2)
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(Guid).ToString(),
+                                identifierName,
+                                expressionSyntaxAssertions => expressionSyntaxAssertions.BeInvocationExpressionSyntax(
+                                    "System.Guid.ParseExact",
+                                    firstParameter => firstParameter.BeIdentifierNameSyntax("input"),
+                                    secondParameter => secondParameter.BeLiteralExpressionSyntax(format)));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeReturnStatement(assertion => assertion.BeIdentifierNameSyntax(identifierName));
+                        });
+                });
+    }
+
+    /// <summary>
+    /// Test string to <see cref="DateTime"/> mapping escapes special characters in a format defined in <c>.editorconfig</c>.
+    /// </summary>
+    /// <param name="scenario">The scenario name.</param>
+    /// <param name="format">The format string.</param>
+    /// <returns>The async task.</returns>
+    [Theory]
+    [MemberData(nameof(SpecialCharacterEditorConfigFormatTestData))]
+    [IntegrationTest]
+    public async Task CanMapStringToDateTimeWithSpecialCharacterFormatDefinedInEditorConfig(string scenario, string format)
+    {
+        ArgumentNullException.ThrowIfNull(format);
+        _ = scenario;
+
+        const string identifierName = "__mappa_tmp_1";
+
+        var editorConfig = $$"""
+                             root = true
+
+                             [*.cs]
+                             mappa.datetimeformat = {{format}}
+                             mappa.cultureinfosettings = InvariantCulture
+                             """;
+
+        var sourceCode = """
+                          #nullable enable
+                          using System;
+                          using Mappa.Attributes;
+
+                          namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                          [Mappa]
+                          public sealed partial class Mapper
+                          {
+                              public partial DateTime Map(string input);
+                          }
+                          """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, editorConfig, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .NotHaveDiagnostics()
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                typeof(DateTime).ToString(),
+                NullableAnnotation.NotAnnotated,
+                typeof(string).ToString(),
+                NullableAnnotation.NotAnnotated,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(2)
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(DateTime).ToString(),
+                                identifierName,
+                                expressionSyntaxAssertions => expressionSyntaxAssertions.BeInvocationExpressionSyntax(
+                                    "System.DateTime.ParseExact",
+                                    firstParameter => firstParameter.BeIdentifierNameSyntax("input"),
+                                    secondParameter => secondParameter.BeLiteralExpressionSyntax(format),
+                                    thirdParameter => thirdParameter.BeMemberAccessExpressionSyntax("System.Globalization.CultureInfo.InvariantCulture")));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeReturnStatement(assertion => assertion.BeIdentifierNameSyntax(identifierName));
+                        });
+                });
+    }
+
+    /// <summary>
+    /// Test string to <see cref="int"/> mapping escapes special characters in a culture name defined in <c>.editorconfig</c>.
+    /// </summary>
+    /// <param name="scenario">The scenario name.</param>
+    /// <param name="cultureName">The culture name.</param>
+    /// <returns>The async task.</returns>
+    [Theory]
+    [MemberData(nameof(SpecialCharacterEditorConfigCultureNameTestData))]
+    [IntegrationTest]
+    public async Task CanMapStringToIntWithSpecialCharacterCultureNameDefinedInEditorConfig(string scenario, string cultureName)
+    {
+        ArgumentNullException.ThrowIfNull(cultureName);
+        _ = scenario;
+
+        const string identifierName = "__mappa_tmp_1";
+
+        var editorConfig = $$"""
+                             root = true
+
+                             [*.cs]
+                             mappa.cultureinfosettings = UserDefined
+                             mappa.culturename = {{cultureName}}
+                             """;
+
+        var sourceCode = """
+                          #nullable enable
+                          using Mappa.Attributes;
+
+                          namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                          [Mappa]
+                          public sealed partial class Mapper
+                          {
+                              public partial int Map(string input);
+                          }
+                          """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, editorConfig, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .NotHaveDiagnostics()
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                typeof(int).ToString(),
+                NullableAnnotation.NotAnnotated,
+                typeof(string).ToString(),
+                NullableAnnotation.NotAnnotated,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(2)
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(int).ToString(),
+                                identifierName,
+                                expressionSyntaxAssertions => expressionSyntaxAssertions.BeInvocationExpressionSyntax(
+                                    "int.Parse",
+                                    firstParameter => firstParameter.BeIdentifierNameSyntax("input"),
+                                    secondParameter => secondParameter.BeInvocationExpressionSyntax(
+                                        "System.Globalization.CultureInfo.GetCultureInfo",
+                                        getCultureInfoParameter => getCultureInfoParameter.BeLiteralExpressionSyntax(cultureName))));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeReturnStatement(assertion => assertion.BeIdentifierNameSyntax(identifierName));
+                        });
+                });
+    }
+
+    private static string EscapeForCSharpStringAttribute(string value)
+    {
+        var builder = new StringBuilder(value.Length);
+        foreach (var character in value)
+        {
+            switch (character)
+            {
+                case '\\':
+                    builder.Append("\\\\");
+                    break;
+                case '"':
+                    builder.Append("\\\"");
+                    break;
+                case '\n':
+                    builder.Append("\\n");
+                    break;
+                case '\r':
+                    builder.Append("\\r");
+                    break;
+                default:
+                    builder.Append(character);
+                    break;
+            }
+        }
+
+        return builder.ToString();
+    }
+}

--- a/Mappa.Generator/Builders/Strategies/InvokeToStringMapStrategyBuilder.cs
+++ b/Mappa.Generator/Builders/Strategies/InvokeToStringMapStrategyBuilder.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Stefano Anelli. All rights reserved.
 // </copyright>
 
+using Mappa.Generator.Helpers;
 using Mappa.Generator.Models;
 using Mappa.Generator.Models.Strategies;
 
@@ -33,7 +34,7 @@ internal sealed class InvokeToStringMapStrategyBuilder
             this.strategy.CultureInfoSetting is not CultureInfoSetting.None &&
             !string.IsNullOrWhiteSpace(this.strategy.Format))
         {
-            parameters = $"\"{this.strategy.Format}\", {GetCulture(this.strategy.CultureInfoSetting, this.strategy.CultureName)}";
+            parameters = $"{CSharpLiteralHelper.ToRequiredStringLiteral(this.strategy.Format)}, {GetCulture(this.strategy.CultureInfoSetting, this.strategy.CultureName)}";
         }
         else if (this.strategy.CultureInfoSetting is not CultureInfoSetting.Undefined &&
                  this.strategy.CultureInfoSetting is not CultureInfoSetting.None)
@@ -42,7 +43,7 @@ internal sealed class InvokeToStringMapStrategyBuilder
         }
         else if (!string.IsNullOrWhiteSpace(this.strategy.Format))
         {
-            parameters = $"\"{this.strategy.Format}\"";
+            parameters = CSharpLiteralHelper.ToRequiredStringLiteral(this.strategy.Format);
         }
         else
         {
@@ -59,7 +60,7 @@ internal sealed class InvokeToStringMapStrategyBuilder
         {
             CultureInfoSetting.CurrentCulture => "System.Globalization.CultureInfo.CurrentCulture",
             CultureInfoSetting.InvariantCulture => "System.Globalization.CultureInfo.InvariantCulture",
-            CultureInfoSetting.UserDefined => $"System.Globalization.CultureInfo.GetCultureInfo(\"{cultureName ?? string.Empty}\")",
+            CultureInfoSetting.UserDefined => $"System.Globalization.CultureInfo.GetCultureInfo({CSharpLiteralHelper.ToStringLiteral(cultureName ?? string.Empty)})",
             _ => throw new ArgumentOutOfRangeException(nameof(cultureInfoSettings), cultureInfoSettings, null),
         };
 }

--- a/Mappa.Generator/Builders/Strategies/StringToGuidMapStrategyBuilder.cs
+++ b/Mappa.Generator/Builders/Strategies/StringToGuidMapStrategyBuilder.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using Mappa.Generator.Exceptions;
+using Mappa.Generator.Helpers;
 using Mappa.Generator.Models;
 using Mappa.Generator.Models.Strategies;
 
@@ -33,7 +34,7 @@ internal sealed class StringToGuidMapStrategyBuilder
         if (!string.IsNullOrWhiteSpace(this.strategy.Format))
         {
             parseMethod = nameof(Guid.ParseExact);
-            parameters = $"{parameters}, \"{this.strategy.Format}\"";
+            parameters = $"{parameters}, {CSharpLiteralHelper.ToRequiredStringLiteral(this.strategy.Format)}";
         }
         else if (this.strategy.CultureInfoSetting is not CultureInfoSetting.Undefined &&
                    this.strategy.CultureInfoSetting is not CultureInfoSetting.None)
@@ -52,7 +53,7 @@ internal sealed class StringToGuidMapStrategyBuilder
                 case CultureInfoSetting.UserDefined:
                     if (!string.IsNullOrWhiteSpace(this.strategy.CultureName))
                     {
-                        parameters = $"{parameters}, System.Globalization.CultureInfo.GetCultureInfo(\"{this.strategy.CultureName}\")";
+                        parameters = $"{parameters}, System.Globalization.CultureInfo.GetCultureInfo({CSharpLiteralHelper.ToRequiredStringLiteral(this.strategy.CultureName)})";
                     }
                     else
                     {

--- a/Mappa.Generator/Helpers/CSharpLiteralHelper.cs
+++ b/Mappa.Generator/Helpers/CSharpLiteralHelper.cs
@@ -1,0 +1,49 @@
+// <copyright file="CSharpLiteralHelper.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using Mappa.Generator.Exceptions;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Mappa.Generator.Helpers;
+
+/// <summary>
+/// Emits properly escaped C# literal expressions for generated source code.
+/// </summary>
+internal static class CSharpLiteralHelper
+{
+    /// <summary>
+    /// Returns a fully escaped C# string literal including surrounding quotes.
+    /// </summary>
+    /// <param name="value">The string value.</param>
+    /// <returns>The escaped string literal.</returns>
+    internal static string ToStringLiteral(string value)
+        => ToStringLiteralCore(value);
+
+    /// <summary>
+    /// Returns a fully escaped C# string literal when <paramref name="value"/> is not null or whitespace.
+    /// </summary>
+    /// <param name="value">The string value.</param>
+    /// <returns>The escaped string literal.</returns>
+    /// <exception cref="MappaGeneratorException">When <paramref name="value"/> is null or whitespace.</exception>
+    internal static string ToRequiredStringLiteral(string? value)
+    {
+        if (value is null)
+        {
+            throw new MappaGeneratorException("Cannot emit a string literal for a null value.");
+        }
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new MappaGeneratorException("Cannot emit a string literal for a whitespace value.");
+        }
+
+        return ToStringLiteral(value);
+    }
+
+    private static string ToStringLiteralCore(string value)
+        => SyntaxFactory.LiteralExpression(
+                SyntaxKind.StringLiteralExpression,
+                SyntaxFactory.Literal(value))
+            .ToFullString();
+}

--- a/Mappa.Generator/Helpers/ParseDateTimeStylesCodeHelper.cs
+++ b/Mappa.Generator/Helpers/ParseDateTimeStylesCodeHelper.cs
@@ -72,7 +72,7 @@ internal static class ParseDateTimeStylesCodeHelper
                 var cultureParameter = GetCultureParameter(cultureInfoSetting, cultureName);
                 if (hasFormat)
                 {
-                    return ("ParseExact", $"{source}, \"{format}\", {cultureParameter}");
+                    return ("ParseExact", $"{source}, {CSharpLiteralHelper.ToRequiredStringLiteral(format)}, {cultureParameter}");
                 }
 
                 return ("Parse", $"{source}, {cultureParameter}");
@@ -80,7 +80,7 @@ internal static class ParseDateTimeStylesCodeHelper
 
             if (hasFormat)
             {
-                return ("ParseExact", $"{source}, \"{format}\"");
+                return ("ParseExact", $"{source}, {CSharpLiteralHelper.ToRequiredStringLiteral(format)}");
             }
 
             return ("Parse", source);
@@ -91,7 +91,7 @@ internal static class ParseDateTimeStylesCodeHelper
 
         if (hasFormat)
         {
-            return ("ParseExact", $"{source}, \"{format}\", {cultureExpression}, {styleExpression}");
+            return ("ParseExact", $"{source}, {CSharpLiteralHelper.ToRequiredStringLiteral(format)}, {cultureExpression}, {styleExpression}");
         }
 
         return ("Parse", $"{source}, {cultureExpression}, {styleExpression}");
@@ -124,7 +124,7 @@ internal static class ParseDateTimeStylesCodeHelper
                 var cultureParameter = GetCultureParameter(cultureInfoSetting, cultureName);
                 if (hasFormat)
                 {
-                    return ("ParseExact", $"{source}, \"{format}\", {cultureParameter}");
+                    return ("ParseExact", $"{source}, {CSharpLiteralHelper.ToRequiredStringLiteral(format)}, {cultureParameter}");
                 }
 
                 return ("Parse", $"{source}, {cultureParameter}");
@@ -138,7 +138,7 @@ internal static class ParseDateTimeStylesCodeHelper
 
         if (hasFormat)
         {
-            return ("ParseExact", $"{source}, \"{format}\", {cultureExpression}, {styleExpression}");
+            return ("ParseExact", $"{source}, {CSharpLiteralHelper.ToRequiredStringLiteral(format)}, {cultureExpression}, {styleExpression}");
         }
 
         return ("Parse", $"{source}, {cultureExpression}, {styleExpression}");
@@ -158,7 +158,7 @@ internal static class ParseDateTimeStylesCodeHelper
             case CultureInfoSetting.UserDefined:
                 if (!string.IsNullOrWhiteSpace(cultureName))
                 {
-                    return $"System.Globalization.CultureInfo.GetCultureInfo(\"{cultureName}\")";
+                    return $"System.Globalization.CultureInfo.GetCultureInfo({CSharpLiteralHelper.ToRequiredStringLiteral(cultureName)})";
                 }
 
                 throw new MappaGeneratorException("Unexpected scenario when building GeyCultureInfo without culture name");

--- a/Mappa.Generator/Helpers/ParseNumberStylesCodeHelper.cs
+++ b/Mappa.Generator/Helpers/ParseNumberStylesCodeHelper.cs
@@ -96,7 +96,7 @@ internal static class ParseNumberStylesCodeHelper
             case CultureInfoSetting.UserDefined:
                 if (!string.IsNullOrWhiteSpace(cultureName))
                 {
-                    return $"System.Globalization.CultureInfo.GetCultureInfo(\"{cultureName}\")";
+                    return $"System.Globalization.CultureInfo.GetCultureInfo({CSharpLiteralHelper.ToRequiredStringLiteral(cultureName)})";
                 }
 
                 throw new MappaGeneratorException("Unexpected scenario when building GeyCultureInfo without culture name");

--- a/MappaVersion.targets
+++ b/MappaVersion.targets
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <MappaVersion>10.1.0-alpha.10</MappaVersion>
+        <MappaVersion>10.1.0-alpha.11</MappaVersion>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Add `CSharpLiteralHelper` using Roslyn `SyntaxFactory` to emit properly escaped C# string literals for user-controlled format and culture values.
- Route format/culture embedding through the helper in parse, ToString, and Guid builders/helpers.
- Add 16 integration tests covering quotes, backslashes, and newlines via `[MappaSettings]` and `.editorconfig`.
- Document file-ending and nullability coding standards in the development workflow rules.
- Bump version to `10.1.0-alpha.11`.

## Test plan
- [x] `.\Scripts\RunTestsAndReportCoverage.ps1` (2012 tests passed)
- [x] `FormatAndCultureLiteralEscapingIntegrationTests` (16 tests)
- [x] No new samples (bug fix only)

Made with [Cursor](https://cursor.com)