### PR TITLE
#234 Rename misleading isTargetDateTime local in CanMapStringToNumber

### DIFF
--- a/Mappa.Generator/Algorithm/StrategyDetectors/StringMapStrategyDetector.cs
+++ b/Mappa.Generator/Algorithm/StrategyDetectors/StringMapStrategyDetector.cs
@@ -303,9 +303,9 @@ internal sealed class StringMapStrategyDetector
 
     private bool CanMapStringToNumber()
     {
-        var isTargetDateTime = this.context.TargetType.IsNumeric();
+        var isTargetNumeric = this.context.TargetType.IsNumeric();
         var isSourceString = this.context.SourceType.IsString();
-        return isTargetDateTime && isSourceString;
+        return isTargetNumeric && isSourceString;
     }
 
     private NumberStyles? GetNumericNumberStyleWithSource(ITypeSymbol typeSymbol, out string? propertyName)

--- a/MappaVersion.targets
+++ b/MappaVersion.targets
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <MappaVersion>10.1.0-alpha.15</MappaVersion>
+        <MappaVersion>10.1.0-alpha.16</MappaVersion>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

- Rename the misleading `isTargetDateTime` local in `CanMapStringToNumber` to `isTargetNumeric` so the variable name matches the `IsNumeric()` check.
- Bump version to `10.1.0-alpha.16`.

## Test plan

- [x] `.\Scripts\RunTestsAndReportCoverage.ps1` — 2178 tests passed