### PR TITLE
#67 Add optional SourcePropertyName to MappaInvokeMethodAttribute

### DIFF
--- a/Documentation/mappa-attributes.md
+++ b/Documentation/mappa-attributes.md
@@ -11,7 +11,7 @@ This is the list of attributes provided:
 - `MappaIgnoreTargetProperty`: When mapping structured types via an empty constructor, excludes a target property from property-initializer mapping; has no effect when mapping uses a constructor with parameters;
 - `MappaAssignFromContext`: When mapping structured types, allows specifying which value from a `MappaContext` to use for a target property or constructor parameter;
 - `MappaAssignToContext`: When mapping structured types via the constructor-map strategy, stores the value of a target property or field in `MappaContext` after the target object has been fully constructed;
-- `MappaInvokeMethodAttribute`: When mapping structured types via the constructor-map strategy, forces a target property or constructor parameter to be mapped by invoking a named method (see [MappaInvokeMethodAttribute](#mappainvokemethodattribute));
+- `MappaInvokeMethodAttribute`: When mapping structured types via the constructor-map strategy, forces a target property or constructor parameter to be mapped by invoking a named method; supports an optional `SourcePropertyName` named parameter (see [MappaInvokeMethodAttribute](#mappainvokemethodattribute));
 - `MappaAssignFromConstant`: When mapping structured types, allows specifying a constant value for a target property or constructor parameter;
 - `MappaTypeMapping`: When mapping structured types or interfaces, allows defining the target type depending on the source type;
 - `MappaTypeMappingDefault`: Describes the default behaviour for polymorphic methods defined via `MappaTypeMapping`.
@@ -61,6 +61,22 @@ Depending on which constructor overload is used, the invoked method is resolved 
 
 When multiple methods with the same name exist in a type hierarchy, methods declared on the most derived type are preferred.
 
+### SourcePropertyName
+
+`SourcePropertyName` is an optional named parameter on any constructor overload. When set, it selects which source property is passed to method overloads that accept a source-property argument for the target member specified by `TargetPropertyName`. It overrides the default name-based source property match for that invoke-method mapping.
+
+Example:
+
+```csharp
+[MappaInvokeMethod(
+    nameof(Target.PropertyA),
+    nameof(CustomMap),
+    SourcePropertyName = nameof(Source.SourceProperty))]
+public partial Target Map(Source input);
+```
+
+When only the invoke-method mapping needs a custom source property, prefer `SourcePropertyName` on `[MappaInvokeMethod]` instead of combining it with `[MappaUseProperty]`. Use `[MappaUseProperty]` when other target members on the same map method also require a non-default source property mapping. If both `[MappaUseProperty]` and `SourcePropertyName` target the same member, the generator emits warning **MP00031** because `[MappaUseProperty]` is ignored for that invoke-method mapping.
+
 ### Candidate requirements
 
 Every candidate method must satisfy all of the following:
@@ -76,7 +92,7 @@ When the root map method accepts a `MappaContext` as its second parameter, invok
 
 ### Overload selection priority
 
-If multiple candidate methods match, the first matching overload in the following list is selected. Tiers that reference a source property apply only when a source property is available for the target member (via name matching or `[MappaUseProperty]`):
+If multiple candidate methods match, the first matching overload in the following list is selected. Tiers that reference a source property apply only when a source property is available for the target member (via name matching, `[MappaUseProperty]`, or `SourcePropertyName` on `[MappaInvokeMethod]`):
 
 1. Three parameters: source type (exact), source property (exact), `MappaContext` — requires the map method to provide `MappaContext`.
 2. Two parameters: source type (exact), source property (exact).

--- a/Documentation/mappa-generator-algorithm.md
+++ b/Documentation/mappa-generator-algorithm.md
@@ -236,7 +236,7 @@ The constructor strategy has three sub-strategies, tried in order:
         - `[MappaIgnoreTargetProperty]` *(empty-constructor path only)*
         - `[MappaAssignFromContext]`
         - `[MappaAssignFromConstant]`
-        - `[MappaInvokeMethod]`
+        - `[MappaInvokeMethod]` — optionally accepts `SourcePropertyName` to select the source property passed to the invoked method
         - `[MappaAssignToContext]` *(post-construction context writes; requires the caller to provide `MappaContext`)*
     - When `MappaSettings.ProtobufOptional` is enabled, optional protobuf members are handled via companion `Has*` properties on the source and target types.
 

--- a/Mappa.Generator.Tests/MappaInvokeMethodAttributeTests.SourcePropertyName.cs
+++ b/Mappa.Generator.Tests/MappaInvokeMethodAttributeTests.SourcePropertyName.cs
@@ -1,0 +1,725 @@
+// <copyright file="MappaInvokeMethodAttributeTests.SourcePropertyName.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using Mappa.Generator.Diagnostics;
+using Mappa.Generator.Tests.Assertions;
+using Mappa.Generator.Tests.Assertions.Extensions;
+
+namespace Mappa.Generator.Tests;
+
+/// <summary>
+/// Integration tests for <see cref="MappaInvokeMethodAttribute.SourcePropertyName"/>.
+/// </summary>
+public sealed partial class MappaInvokeMethodAttributeTests
+{
+    /// <summary>
+    /// Test mapping via empty constructor succeeds when <see cref="MappaInvokeMethodAttribute.SourcePropertyName"/>
+    /// identifies the source property for a local invoke method.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    [IntegrationTest]
+    public async Task CanMapUsingSourcePropertyNameOnEmptyConstructorMapping()
+    {
+        const string sourceCode = """
+                                  #nullable enable
+                                  using Mappa.Attributes;
+
+                                  namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                  public class Source
+                                  {
+                                      public int SourceProperty { get; set; }
+                                      public int PropertyB { get; set; }
+                                  }
+
+                                  public class Target
+                                  {
+                                      public string PropertyA { get; set; }
+                                      public long PropertyB { get; set; }
+                                  }
+
+                                  [Mappa]
+                                  public sealed partial class Mapper
+                                  {
+                                      [MappaInvokeMethodAttribute(
+                                          nameof(Target.PropertyA),
+                                          nameof(CustomMapPropertyA),
+                                          SourcePropertyName = nameof(Source.SourceProperty))]
+                                      public partial Target Map(Source input);
+
+                                      [MappaIgnore]
+                                      public string CustomMapPropertyA(int sourceProperty) => sourceProperty.ToString();
+                                  }
+                                  #nullable restore
+                                  """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .NotHaveDiagnostics()
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                NullableAnnotation.NotAnnotated,
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Source",
+                NullableAnnotation.NotAnnotated,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(5)
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(int).ToString(),
+                                "__mappa_tmp_1",
+                                initializationAssertions => initializationAssertions.BeMemberAccessExpressionSyntax("input.SourceProperty"));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(string).ToString(),
+                                "__mappa_tmp_2",
+                                initializationAssertions => initializationAssertions.BeInvocationExpressionSyntax(
+                                    "this.CustomMapPropertyA",
+                                    firstParameterAssertions => firstParameterAssertions.BeIdentifierNameSyntax("__mappa_tmp_1")));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(int).ToString(),
+                                "__mappa_tmp_3",
+                                initializationAssertions => initializationAssertions.BeMemberAccessExpressionSyntax("input.PropertyB"));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                                "__mappa_tmp_4",
+                                initializationAssertions =>
+                                {
+                                    initializationAssertions.BeObjectCreationExpressionSyntax(
+                                        "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                                        ("PropertyA", initAssertions => initAssertions.BeIdentifierNameSyntax("__mappa_tmp_2")),
+                                        ("PropertyB", initAssertions => initAssertions.BeIdentifierNameSyntax("__mappa_tmp_3")));
+                                });
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeReturnStatement("__mappa_tmp_4");
+                        });
+                });
+    }
+
+    /// <summary>
+    /// Test mapping via parameterized constructor succeeds when <see cref="MappaInvokeMethodAttribute.SourcePropertyName"/>
+    /// identifies the source property for a local invoke method.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    [IntegrationTest]
+    public async Task CanMapUsingSourcePropertyNameForConstructorWithParametersMapping()
+    {
+        const string sourceCode = """
+                                  #nullable enable
+                                  using Mappa.Attributes;
+
+                                  namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                  public record Source(int SourceProperty, int PropertyB);
+                                  public record Target(string PropertyA, long PropertyB);
+
+                                  [Mappa]
+                                  public sealed partial class Mapper
+                                  {
+                                      [MappaInvokeMethodAttribute(
+                                          nameof(Target.PropertyA),
+                                          nameof(CustomMapPropertyA),
+                                          SourcePropertyName = nameof(Source.SourceProperty))]
+                                      public partial Target Map(Source input);
+
+                                      [MappaIgnore]
+                                      public string CustomMapPropertyA(int sourceProperty) => sourceProperty.ToString();
+                                  }
+                                  #nullable restore
+                                  """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .NotHaveDiagnostics()
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                NullableAnnotation.NotAnnotated,
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Source",
+                NullableAnnotation.NotAnnotated,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(5)
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(int).ToString(),
+                                "__mappa_tmp_1",
+                                initializationAssertions => initializationAssertions.BeMemberAccessExpressionSyntax("input.SourceProperty"));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(string).ToString(),
+                                "__mappa_tmp_2",
+                                initializationAssertions => initializationAssertions.BeInvocationExpressionSyntax(
+                                    "this.CustomMapPropertyA",
+                                    firstParameterAssertions => firstParameterAssertions.BeIdentifierNameSyntax("__mappa_tmp_1")));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(int).ToString(),
+                                "__mappa_tmp_3",
+                                initializationAssertions => initializationAssertions.BeMemberAccessExpressionSyntax("input.PropertyB"));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                                "__mappa_tmp_4",
+                                initializationAssertions =>
+                                {
+                                    initializationAssertions.BeObjectCreationExpressionSyntax(
+                                        "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                                        parameterSyntaxAssertions => parameterSyntaxAssertions.BeIdentifierNameSyntax("__mappa_tmp_2"),
+                                        parameterSyntaxAssertions => parameterSyntaxAssertions.BeIdentifierNameSyntax("__mappa_tmp_3"));
+                                });
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeReturnStatement("__mappa_tmp_4");
+                        });
+                });
+    }
+
+    /// <summary>
+    /// Test no MP00032 warning when invoking a <c>static</c> method on an external type that accepts the
+    /// source property defined by <see cref="MappaInvokeMethodAttribute.SourcePropertyName"/>.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    [IntegrationTest]
+    public async Task NoWarningIsEmittedWhenMappaInvokeMethodUsesClassTypeAndSourcePropertyNameDefinesTheSourceProperty()
+    {
+        const string sourceCode = """
+                                  #nullable enable
+                                  using Mappa.Attributes;
+
+                                  namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                  public class Source
+                                  {
+                                      public int SourceProperty { get; set; }
+                                      public int PropertyB { get; set; }
+                                  }
+
+                                  public class Target
+                                  {
+                                      public string PropertyA { get; set; }
+                                      public long PropertyB { get; set; }
+                                  }
+
+                                  public sealed class Helper
+                                  {
+                                      public static string CustomMapPropertyA(int sourceProperty) => sourceProperty.ToString();
+                                  }
+
+                                  [Mappa]
+                                  public sealed partial class Mapper
+                                  {
+                                      [MappaInvokeMethodAttribute(
+                                          nameof(Target.PropertyA),
+                                          typeof(Helper),
+                                          nameof(Helper.CustomMapPropertyA),
+                                          SourcePropertyName = nameof(Source.SourceProperty))]
+                                      public partial Target Map(Source input);
+                                  }
+                                  #nullable restore
+                                  """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .NotHaveDiagnostics()
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                NullableAnnotation.NotAnnotated,
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Source",
+                NullableAnnotation.NotAnnotated,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(5)
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(int).ToString(),
+                                "__mappa_tmp_1",
+                                initializationAssertions => initializationAssertions.BeMemberAccessExpressionSyntax("input.SourceProperty"));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(string).ToString(),
+                                "__mappa_tmp_2",
+                                initializationAssertions => initializationAssertions.BeInvocationExpressionSyntax(
+                                    "Mappa.Generator.Tests.UnitTests.SourceCode.Helper.CustomMapPropertyA",
+                                    firstParameterAssertions => firstParameterAssertions.BeIdentifierNameSyntax("__mappa_tmp_1")));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(int).ToString(),
+                                "__mappa_tmp_3",
+                                initializationAssertions => initializationAssertions.BeMemberAccessExpressionSyntax("input.PropertyB"));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                                "__mappa_tmp_4",
+                                initializationAssertions =>
+                                {
+                                    initializationAssertions.BeObjectCreationExpressionSyntax(
+                                        "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                                        ("PropertyA", initAssertions => initAssertions.BeIdentifierNameSyntax("__mappa_tmp_2")),
+                                        ("PropertyB", initAssertions => initAssertions.BeIdentifierNameSyntax("__mappa_tmp_3")));
+                                });
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeReturnStatement("__mappa_tmp_4");
+                        });
+                });
+    }
+
+    /// <summary>
+    /// Test no MP00032 warning when invoking a non-<c>static</c> method on a field that accepts the
+    /// source property defined by <see cref="MappaInvokeMethodAttribute.SourcePropertyName"/>.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    [IntegrationTest]
+    public async Task NoWarningIsEmittedWhenMappaInvokeMethodUsesFieldNameAndSourcePropertyNameDefinesTheSourceProperty()
+    {
+        const string sourceCode = """
+                                  #nullable enable
+                                  using Mappa.Attributes;
+
+                                  namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                  public class Source
+                                  {
+                                      public int SourceProperty { get; set; }
+                                      public int PropertyB { get; set; }
+                                  }
+
+                                  public class Target
+                                  {
+                                      public string PropertyA { get; set; }
+                                      public long PropertyB { get; set; }
+                                  }
+
+                                  public sealed class Helper
+                                  {
+                                      public string CustomMapPropertyA(int sourceProperty) => sourceProperty.ToString();
+                                  }
+
+                                  [Mappa]
+                                  public sealed partial class Mapper
+                                  {
+                                      private readonly Helper dependency = new();
+
+                                      [MappaInvokeMethodAttribute(
+                                          nameof(Target.PropertyA),
+                                          nameof(dependency),
+                                          nameof(Helper.CustomMapPropertyA),
+                                          SourcePropertyName = nameof(Source.SourceProperty))]
+                                      public partial Target Map(Source input);
+                                  }
+                                  #nullable restore
+                                  """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .NotHaveDiagnostics()
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                NullableAnnotation.NotAnnotated,
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Source",
+                NullableAnnotation.NotAnnotated,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(5)
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(int).ToString(),
+                                "__mappa_tmp_1",
+                                initializationAssertions => initializationAssertions.BeMemberAccessExpressionSyntax("input.SourceProperty"));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(string).ToString(),
+                                "__mappa_tmp_2",
+                                initializationAssertions => initializationAssertions.BeInvocationExpressionSyntax(
+                                    "this.dependency.CustomMapPropertyA",
+                                    firstParameterAssertions => firstParameterAssertions.BeIdentifierNameSyntax("__mappa_tmp_1")));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(int).ToString(),
+                                "__mappa_tmp_3",
+                                initializationAssertions => initializationAssertions.BeMemberAccessExpressionSyntax("input.PropertyB"));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                                "__mappa_tmp_4",
+                                initializationAssertions =>
+                                {
+                                    initializationAssertions.BeObjectCreationExpressionSyntax(
+                                        "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                                        ("PropertyA", initAssertions => initAssertions.BeIdentifierNameSyntax("__mappa_tmp_2")),
+                                        ("PropertyB", initAssertions => initAssertions.BeIdentifierNameSyntax("__mappa_tmp_3")));
+                                });
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeReturnStatement("__mappa_tmp_4");
+                        });
+                });
+    }
+
+    /// <summary>
+    /// Test mapping succeeds when <see cref="MappaInvokeMethodAttribute.SourcePropertyName"/> supplies the source property
+    /// to a local method that also accepts <see cref="MappaContext"/>.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    [IntegrationTest]
+    public async Task CanMapUsingSourcePropertyNameWithMappaContext()
+    {
+        const string sourceCode = """
+                                  #nullable enable
+                                  using Mappa;
+                                  using Mappa.Attributes;
+
+                                  namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                  public class Source
+                                  {
+                                      public int SourceProperty { get; set; }
+                                      public int PropertyB { get; set; }
+                                  }
+
+                                  public class Target
+                                  {
+                                      public string PropertyA { get; set; }
+                                      public long PropertyB { get; set; }
+                                  }
+
+                                  [Mappa]
+                                  public sealed partial class Mapper
+                                  {
+                                      [MappaInvokeMethodAttribute(
+                                          nameof(Target.PropertyA),
+                                          nameof(CustomMapPropertyA),
+                                          SourcePropertyName = nameof(Source.SourceProperty))]
+                                      public partial Target Map(Source input, MappaContext context);
+
+                                      [MappaIgnore]
+                                      public string CustomMapPropertyA(Source source, int sourceProperty, MappaContext mappaContext)
+                                          => $"{sourceProperty}/{mappaContext.Keys.Count}";
+                                  }
+                                  #nullable restore
+                                  """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .NotHaveDiagnostics()
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethodWithContext(
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                NullableAnnotation.NotAnnotated,
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Source",
+                NullableAnnotation.NotAnnotated,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(5)
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(int).ToString(),
+                                "__mappa_tmp_1",
+                                initializationAssertions => initializationAssertions.BeMemberAccessExpressionSyntax("input.SourceProperty"));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(string).ToString(),
+                                "__mappa_tmp_2",
+                                initializationAssertions => initializationAssertions.BeInvocationExpressionSyntax(
+                                    "this.CustomMapPropertyA",
+                                    firstParameterAssertions => firstParameterAssertions.BeIdentifierNameSyntax("input"),
+                                    secondParameterAssertions => secondParameterAssertions.BeIdentifierNameSyntax("__mappa_tmp_1"),
+                                    thirdParameterAssertions => thirdParameterAssertions.BeIdentifierNameSyntax("context")));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                typeof(int).ToString(),
+                                "__mappa_tmp_3",
+                                initializationAssertions => initializationAssertions.BeMemberAccessExpressionSyntax("input.PropertyB"));
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                                "__mappa_tmp_4",
+                                initializationAssertions =>
+                                {
+                                    initializationAssertions.BeObjectCreationExpressionSyntax(
+                                        "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                                        ("PropertyA", initAssertions => initAssertions.BeIdentifierNameSyntax("__mappa_tmp_2")),
+                                        ("PropertyB", initAssertions => initAssertions.BeIdentifierNameSyntax("__mappa_tmp_3")));
+                                });
+                        })
+                        .HasNextSyntaxNode(syntaxNodeAssertions =>
+                        {
+                            syntaxNodeAssertions.BeReturnStatement("__mappa_tmp_4");
+                        });
+                });
+    }
+
+    /// <summary>
+    /// Test MP00031 is emitted when <see cref="MappaInvokeMethodAttribute.SourcePropertyName"/> and
+    /// <see cref="MappaUsePropertyAttribute"/> target the same property.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    [IntegrationTest]
+    public async Task AWarningIsEmittedWhenSourcePropertyNameAndMappaUsePropertyTargetTheSameProperty()
+    {
+        const string sourceCode = """
+                                  #nullable enable
+                                  using Mappa.Attributes;
+
+                                  namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                  public class Source
+                                  {
+                                      public int SourceProperty { get; set; }
+                                  }
+
+                                  public class Target
+                                  {
+                                      public string PropertyA { get; set; }
+                                  }
+
+                                  [Mappa]
+                                  public sealed partial class Mapper
+                                  {
+                                      [MappaInvokeMethodAttribute(
+                                          nameof(Target.PropertyA),
+                                          nameof(GetValue),
+                                          SourcePropertyName = nameof(Source.SourceProperty))]
+                                      [MappaUseProperty(nameof(Target.PropertyA), nameof(Source.SourceProperty))]
+                                      public partial Target Map(Source input);
+
+                                      [MappaIgnore]
+                                      public string GetValue(int sourceProperty) => sourceProperty.ToString();
+                                  }
+                                  #nullable restore
+                                  """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .HaveDiagnostics(1)
+            .HaveDiagnostic(
+                MappaDiagnosticDescriptors.MappaUsePropertySourcePropertyWillNotBeUsed,
+                "Map",
+                "PropertyA",
+                "SourceProperty",
+                nameof(MappaInvokeMethodAttribute));
+    }
+
+    /// <summary>
+    /// Test MP00032 is emitted when <see cref="MappaInvokeMethodAttribute.SourcePropertyName"/> is set but the
+    /// invoked method accepts only <see cref="MappaContext"/>.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    [IntegrationTest]
+    public async Task AWarningIsEmittedWhenSourcePropertyNameIsSetAndMappaInvokeMethodAcceptsOnlyMappaContext()
+    {
+        const string sourceCode = """
+                                  #nullable enable
+                                  using Mappa;
+                                  using Mappa.Attributes;
+
+                                  namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                  public class Source
+                                  {
+                                      public int SourceProperty { get; set; }
+                                  }
+
+                                  public class Target
+                                  {
+                                      public string PropertyA { get; set; }
+                                  }
+
+                                  [Mappa]
+                                  public sealed partial class Mapper
+                                  {
+                                      [MappaInvokeMethodAttribute(
+                                          nameof(Target.PropertyA),
+                                          nameof(GetValue),
+                                          SourcePropertyName = nameof(Source.SourceProperty))]
+                                      public partial Target Map(Source input, MappaContext context);
+
+                                      [MappaIgnore]
+                                      public string GetValue(MappaContext ctx) => "fixed";
+                                  }
+                                  #nullable restore
+                                  """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .HaveDiagnostics(1)
+            .HaveDiagnostic(
+                MappaDiagnosticDescriptors.MappaUsePropertyNotUsedByInvokeMethod,
+                "Map",
+                "PropertyA",
+                "SourceProperty",
+                "GetValue");
+    }
+
+    /// <summary>
+    /// Test mapping fails when <see cref="MappaInvokeMethodAttribute.SourcePropertyName"/> references a
+    /// non-existent source property and the invoked method requires the source property type.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    [IntegrationTest]
+    public async Task MappingFailsWhenSourcePropertyNameReferencesNonExistentProperty()
+    {
+        const string sourceCode = """
+                                  #nullable enable
+                                  using Mappa.Attributes;
+
+                                  namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                  public class Source
+                                  {
+                                      public int SourceProperty { get; set; }
+                                  }
+
+                                  public class Target
+                                  {
+                                      public string PropertyA { get; set; }
+                                  }
+
+                                  [Mappa]
+                                  public sealed partial class Mapper
+                                  {
+                                      [MappaInvokeMethodAttribute(
+                                          nameof(Target.PropertyA),
+                                          nameof(GetValue),
+                                          SourcePropertyName = "MissingProperty")]
+                                      public partial Target Map(Source input);
+
+                                      [MappaIgnore]
+                                      public string GetValue(int sourceProperty) => sourceProperty.ToString();
+                                  }
+                                  #nullable restore
+                                  """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .HaveDiagnostics(1)
+            .HaveDiagnostic(
+                MappaDiagnosticDescriptors.CannotDetectSuitableMethodToInvokeForParameter,
+                "GetValue",
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Mapper",
+                "PropertyA");
+    }
+
+    /// <summary>
+    /// Test no MP00032 warning when the invoke method accepts the source property defined by
+    /// <see cref="MappaInvokeMethodAttribute.SourcePropertyName"/>.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    [IntegrationTest]
+    public async Task NoWarningIsEmittedWhenMappaInvokeMethodUsesTheSourcePropertyDefinedBySourcePropertyName()
+    {
+        const string sourceCode = """
+                                  #nullable enable
+                                  using Mappa.Attributes;
+
+                                  namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                  public class Source
+                                  {
+                                      public int SourceProperty { get; set; }
+                                  }
+
+                                  public class Target
+                                  {
+                                      public string PropertyA { get; set; }
+                                  }
+
+                                  [Mappa]
+                                  public sealed partial class Mapper
+                                  {
+                                      [MappaInvokeMethodAttribute(
+                                          nameof(Target.PropertyA),
+                                          nameof(GetValue),
+                                          SourcePropertyName = nameof(Source.SourceProperty))]
+                                      public partial Target Map(Source input);
+
+                                      [MappaIgnore]
+                                      public string GetValue(Source source, int sourceProperty) => $"{source.SourceProperty}:{sourceProperty}";
+                                  }
+                                  #nullable restore
+                                  """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should().NotHaveDiagnostics();
+    }
+}

--- a/Mappa.Generator/Algorithm/StrategyDetectors/ConstructorMapStrategyDetector.cs
+++ b/Mappa.Generator/Algorithm/StrategyDetectors/ConstructorMapStrategyDetector.cs
@@ -165,6 +165,7 @@ internal sealed class ConstructorMapStrategyDetector
                                         this.context.SourceType,
                                         ref sourceProperty,
                                         StringComparison.OrdinalIgnoreCase,
+                                        isConstructorParameterPath: true,
                                         out var propertyStrategyFromAttribute))
                                 {
                                     propertyStrategyFromAttribute = this.EncapsulateMapStrategyForSourceOptional(sourceProperty, sourceProperties, propertyStrategyFromAttribute);
@@ -446,6 +447,7 @@ internal sealed class ConstructorMapStrategyDetector
                                     this.context.SourceType,
                                     ref sourceProperty,
                                     StringComparison.Ordinal,
+                                    isConstructorParameterPath: false,
                                     out var propertyStrategyFromAttribute))
                             {
                                 if (!targetProperty.IsSetterAccessible(this.compilation, this.context.MapMethod))
@@ -796,6 +798,7 @@ internal sealed class ConstructorMapStrategyDetector
         ITypeSymbol sourceClassType,
         ref IPropertySymbol? sourceProperty,
         StringComparison stringComparison,
+        bool isConstructorParameterPath,
         out MapStrategy strategy)
     {
         strategy = new NoMapStrategy(targetType, null!);
@@ -837,6 +840,19 @@ internal sealed class ConstructorMapStrategyDetector
         switch (attribute)
         {
             case MappaInvokeMethodAttribute mappaInvokeMethodAttribute:
+                if (!string.IsNullOrWhiteSpace(mappaInvokeMethodAttribute.SourcePropertyName))
+                {
+                    this.ReportMappaUsePropertySourcePropertyWillNotBeUsedIfPresent(
+                        targetName,
+                        stringComparison,
+                        nameof(MappaInvokeMethodAttribute));
+                    this.TryResolveSourcePropertyForMappaInvokeMethodAttribute(
+                        mappaInvokeMethodAttribute,
+                        sourceClassType,
+                        isConstructorParameterPath,
+                        ref sourceProperty);
+                }
+
                 this.TryGetStrategyUsingMappaInvokeMethodAttribute(
                     targetName,
                     targetType,
@@ -913,6 +929,32 @@ internal sealed class ConstructorMapStrategyDetector
             targetName,
             usePropertyAttributes[0].SourcePropertyName,
             conflictingAttributeName));
+    }
+
+    private void TryResolveSourcePropertyForMappaInvokeMethodAttribute(
+        MappaInvokeMethodAttribute mappaInvokeMethodAttribute,
+        ITypeSymbol sourceClassType,
+        bool isConstructorParameterPath,
+        ref IPropertySymbol? sourceProperty)
+    {
+        if (mappaInvokeMethodAttribute.SourcePropertyName is not string sourcePropertyName ||
+            string.IsNullOrWhiteSpace(sourcePropertyName))
+        {
+            return;
+        }
+
+        var sourceProperties = sourceClassType.GetTypeProperties()
+            .Where(property => !property.IsIndexer && property.IsGetterAccessible(this.compilation, this.context.GetRootMapMethod()))
+            .ToArray();
+
+        PropertyMapNameMatcher.TryFindSourceProperty(
+            sourceProperties,
+            sourcePropertyName,
+            this.context.MappaUserSettings.ForceCaseInsensitivePropertyMap,
+            this.context.MappaUserSettings.IgnoreUnderscoreForPropertyMap,
+            isConstructorParameterPath,
+            useExactNameFromAttribute: true,
+            out sourceProperty);
     }
 
     private void TryGetStrategyUsingMappaAssignFromContextAttribute(
@@ -1078,7 +1120,17 @@ internal sealed class ConstructorMapStrategyDetector
             .Where(attribute => attribute.TargetPropertyName.Equals(targetName, stringComparison))
             .ToArray();
 
-        if (usePropertyAttributes.Length == 1 &&
+        string? explicitSourcePropertyName = null;
+        if (!string.IsNullOrWhiteSpace(mappaInvokeMethodAttribute.SourcePropertyName))
+        {
+            explicitSourcePropertyName = mappaInvokeMethodAttribute.SourcePropertyName;
+        }
+        else if (usePropertyAttributes.Length == 1)
+        {
+            explicitSourcePropertyName = usePropertyAttributes[0].SourcePropertyName;
+        }
+
+        if (explicitSourcePropertyName is not null &&
             !method.UsesSourceProperty(
                 this.compilation,
                 sourceProperty,
@@ -1089,7 +1141,7 @@ internal sealed class ConstructorMapStrategyDetector
                 mapMethodMethodDeclarationSyntax,
                 this.context.GetRootMapMethod().MethodName,
                 targetName,
-                usePropertyAttributes[0].SourcePropertyName,
+                explicitSourcePropertyName,
                 mappaInvokeMethodAttribute.MethodName));
         }
 

--- a/Mappa.Generator/Extensions/AttributeDataExtensions.cs
+++ b/Mappa.Generator/Extensions/AttributeDataExtensions.cs
@@ -99,42 +99,56 @@ internal static class AttributeDataExtensions
     {
         var mappaInvokeMethodAttributeSymbol = compilation.GetTypeByMetadataName(MappaInvokeMethodAttributeFullName);
         List<MappaInvokeMethodAttribute> results = new();
-        foreach (var constructorArguments in attributes
-                     .Where(attribute => SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, mappaInvokeMethodAttributeSymbol))
-                     .Select(attributeData => attributeData.ConstructorArguments))
+        foreach (var attributeData in attributes
+                     .Where(attribute => SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, mappaInvokeMethodAttributeSymbol)))
         {
-                switch (constructorArguments.Length)
+            MappaInvokeMethodAttribute? attribute = null;
+            var constructorArguments = attributeData.ConstructorArguments;
+            switch (constructorArguments.Length)
+            {
+                case 2: // (targetPropertyName, methodName)
+                    {
+                        if (constructorArguments[0].Value is string targetParameterName &&
+                            constructorArguments[1].Value is string methodName)
+                        {
+                            attribute = new MappaInvokeMethodAttribute(targetParameterName, methodName);
+                        }
+                    }
+
+                    break;
+
+                case 3: // (targetPropertyName, classType, methodName) or (targetPropertyName, fieldName, methodName)
+                    {
+                        if (constructorArguments[0].Value is string targetParameterName &&
+                            constructorArguments[2].Value is string methodName)
+                        {
+                            attribute = constructorArguments[1].Value switch
+                            {
+                                string fieldName => new MappaInvokeMethodAttribute(targetParameterName, fieldName, methodName),
+                                INamedTypeSymbol classType => new MappaInvokeMethodAttribute(targetParameterName, new FakeType(classType.ToDisplayString()), methodName),
+                                _ => null,
+                            };
+                        }
+                    }
+
+                    break;
+            }
+
+            if (attribute is null)
+            {
+                continue;
+            }
+
+            foreach (var namedArgument in attributeData.NamedArguments)
+            {
+                if (namedArgument.Key == nameof(MappaInvokeMethodAttribute.SourcePropertyName) &&
+                    namedArgument.Value.Value is string sourcePropertyName)
                 {
-                    case 2: // (targetPropertyName, methodName)
-                        {
-                            if (constructorArguments[0].Value is string targetParameterName &&
-                                constructorArguments[1].Value is string methodName)
-                            {
-                                results.Add(new MappaInvokeMethodAttribute(targetParameterName, methodName));
-                            }
-                        }
-
-                        break;
-
-                    case 3: // (targetPropertyName, classType, methodName) or (targetPropertyName, fieldName, methodName)
-                        {
-                            if (constructorArguments[0].Value is string targetParameterName &&
-                                constructorArguments[2].Value is string methodName)
-                            {
-                                switch (constructorArguments[1].Value)
-                                {
-                                    case string fieldName:
-                                        results.Add(new MappaInvokeMethodAttribute(targetParameterName, fieldName, methodName));
-                                        break;
-                                    case INamedTypeSymbol classType:
-                                        results.Add(new MappaInvokeMethodAttribute(targetParameterName, new FakeType(classType.ToDisplayString()), methodName));
-                                        break;
-                                }
-                            }
-                        }
-
-                        break;
+                    attribute.SourcePropertyName = sourcePropertyName;
                 }
+            }
+
+            results.Add(attribute);
         }
 
         return [.. results];

--- a/Mappa.Generator/README.md
+++ b/Mappa.Generator/README.md
@@ -237,7 +237,7 @@ The constructor strategy has three sub-strategies, tried in order:
         - `[MappaIgnoreTargetProperty]` *(empty-constructor path only)*
         - `[MappaAssignFromContext]`
         - `[MappaAssignFromConstant]`
-        - `[MappaInvokeMethod]`
+        - `[MappaInvokeMethod]` — optionally accepts `SourcePropertyName` to select the source property passed to the invoked method
         - `[MappaAssignToContext]` *(post-construction context writes; requires the caller to provide `MappaContext`)*
     - When `MappaSettings.ProtobufOptional` is enabled, optional protobuf members are handled via companion `Has*` properties on the source and target types.
 

--- a/Mappa.Samples.Aot/Runners/MappaInvokeMethodAttributeMappersRunner.cs
+++ b/Mappa.Samples.Aot/Runners/MappaInvokeMethodAttributeMappersRunner.cs
@@ -191,5 +191,14 @@ internal static class MappaInvokeMethodAttributeMappersRunner
             nameof(TargetClassModel),
             sourceClass,
             withMappaContext.Map(sourceClass, context));
+
+        report.BeginMapper(nameof(MapEmptyConstructorWithLocalMethodUsingSourcePropertyName));
+        var withSourcePropertyName = new MapEmptyConstructorWithLocalMethodUsingSourcePropertyName();
+        report.RecordInvocation(
+            nameof(MapEmptyConstructorWithLocalMethodUsingSourcePropertyName.Map),
+            nameof(SourceClassModel),
+            nameof(TargetClassModel),
+            sourceClass,
+            withSourcePropertyName.Map(sourceClass));
     }
 }

--- a/Mappa.Samples.Tests/MappaInvokeMethodAttributeMappersTests.cs
+++ b/Mappa.Samples.Tests/MappaInvokeMethodAttributeMappersTests.cs
@@ -370,4 +370,23 @@ public sealed class MappaInvokeMethodAttributeMappersTests
         actual.ParamA.Should().Be($"{nameof(MapEmptyConstructorWithLocalStaticMethodWithSourceClassPropertyAndMappaContextInput)}/static/({nameof(SourceClassModel)},int,{nameof(MappaContext)})/{source.ParamA}/{source.ParamB}/{source.ParamA}/Use the custom value");
         actual.ParamB.Should().Be((int)source.ParamB);
     }
+
+    /// <summary>
+    /// Test for <see cref="MapEmptyConstructorWithLocalMethodUsingSourcePropertyName"/>.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void TestMapEmptyConstructorWithLocalMethodUsingSourcePropertyName()
+    {
+        // Arrange
+        var mapper = new MapEmptyConstructorWithLocalMethodUsingSourcePropertyName();
+        var source = new SourceClassModel { ParamA = 10, ParamB = CountingValues.Three };
+
+        // Act
+        var actual = mapper.Map(source);
+
+        // Assert
+        actual.ParamA.Should().Be($"{nameof(MapEmptyConstructorWithLocalMethodUsingSourcePropertyName)}/static/({nameof(CountingValues)})/{source.ParamB}");
+        actual.ParamB.Should().Be((int)source.ParamB);
+    }
 }

--- a/Mappa.Samples/MappaInvokeMethodAttributeMappers.cs
+++ b/Mappa.Samples/MappaInvokeMethodAttributeMappers.cs
@@ -641,6 +641,40 @@ public sealed partial class MapEmptyConstructorWithLocalStaticMethodWithSourceCl
 }
 
 /// <summary>
+/// Map from <see cref="SourceClassModel"/> to <see cref="TargetClassModel"/>
+/// using:
+/// <list type="table">
+/// <item><term>Mapping mode</term><description>Empty constructor.</description></item>
+/// <item><term>Custom method location</term><description><see cref="MapEmptyConstructorWithLocalMethodUsingSourcePropertyName"/>.</description></item>
+/// <item><term>Custom method is static</term><description><c>true</c>.</description></item>
+/// <item><term>Custom method input(s)</term><description><see cref="CountingValues"/>.</description></item>
+/// <item><term>Source property selection</term><description><see cref="MappaInvokeMethodAttribute.SourcePropertyName"/>.</description></item>
+/// </list>
+/// </summary>
+[Mappa]
+public sealed partial class MapEmptyConstructorWithLocalMethodUsingSourcePropertyName
+{
+    /// <summary>
+    /// Map from <see cref="SourceClassModel"/> to <see cref="TargetClassModel"/>
+    /// using <see cref="MappaInvokeMethodAttribute.SourcePropertyName"/> to supply
+    /// <see cref="SourceClassModel.ParamB"/> to the invoked method for
+    /// <see cref="TargetClassModel.ParamA"/>.
+    /// </summary>
+    /// <param name="source">The source model to map.</param>
+    /// <returns>The mapped object.</returns>
+    [MappaInvokeMethod(
+        nameof(TargetClassModel.ParamA),
+        nameof(CustomMap),
+        SourcePropertyName = nameof(SourceClassModel.ParamB))]
+    public partial TargetClassModel Map(SourceClassModel source);
+
+    private static string CustomMap(CountingValues sourceProperty)
+    {
+        return $"{nameof(MapEmptyConstructorWithLocalMethodUsingSourcePropertyName)}/static/({nameof(CountingValues)})/{sourceProperty}";
+    }
+}
+
+/// <summary>
 /// Mapper helper method that can be invoked by other classes.
 /// </summary>
 public sealed class MapperDependencyHelper

--- a/Mappa.Tests/MappaInvokeMethodAttributeTests.cs
+++ b/Mappa.Tests/MappaInvokeMethodAttributeTests.cs
@@ -1,0 +1,86 @@
+// <copyright file="MappaInvokeMethodAttributeTests.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using AwesomeAssertions;
+
+using Mappa.Attributes;
+
+using Xunit;
+using Xunit.OpenCategories.V3;
+
+namespace Mappa.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="MappaInvokeMethodAttribute"/>.
+/// </summary>
+public sealed class MappaInvokeMethodAttributeTests
+{
+    /// <summary>
+    /// Tests <see cref="MappaInvokeMethodAttribute.SourcePropertyName"/> is <c>null</c> when not set.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void SourcePropertyNameIsNullWhenNotSet()
+    {
+        // Act
+        var attribute = new MappaInvokeMethodAttribute("TargetProperty", "MapMethod");
+
+        // Assert
+        attribute.SourcePropertyName.Should().BeNull();
+    }
+
+    /// <summary>
+    /// Tests <see cref="MappaInvokeMethodAttribute.SourcePropertyName"/> returns the value set via object initializer
+    /// on the <c>(targetPropertyName, methodName)</c> constructor overload.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void SourcePropertyNameReturnsValueSetViaObjectInitializerOnTwoArgumentConstructor()
+    {
+        // Act
+        var attribute = new MappaInvokeMethodAttribute("TargetProperty", "MapMethod")
+        {
+            SourcePropertyName = "SourceProperty",
+        };
+
+        // Assert
+        attribute.SourcePropertyName.Should().Be("SourceProperty");
+    }
+
+    /// <summary>
+    /// Tests <see cref="MappaInvokeMethodAttribute.SourcePropertyName"/> returns the value set via object initializer
+    /// on the <c>(targetPropertyName, classType, methodName)</c> constructor overload.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void SourcePropertyNameReturnsValueSetViaObjectInitializerOnClassTypeConstructor()
+    {
+        // Act
+        var attribute = new MappaInvokeMethodAttribute("TargetProperty", typeof(MappaContext), "MapMethod")
+        {
+            SourcePropertyName = "SourceProperty",
+        };
+
+        // Assert
+        attribute.SourcePropertyName.Should().Be("SourceProperty");
+    }
+
+    /// <summary>
+    /// Tests <see cref="MappaInvokeMethodAttribute.SourcePropertyName"/> returns the value set via object initializer
+    /// on the <c>(targetPropertyName, fieldName, methodName)</c> constructor overload.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void SourcePropertyNameReturnsValueSetViaObjectInitializerOnFieldNameConstructor()
+    {
+        // Act
+        var attribute = new MappaInvokeMethodAttribute("TargetProperty", "dependency", "MapMethod")
+        {
+            SourcePropertyName = "SourceProperty",
+        };
+
+        // Assert
+        attribute.SourcePropertyName.Should().Be("SourceProperty");
+    }
+}

--- a/Mappa/Attributes/MappaInvokeMethodAttribute.cs
+++ b/Mappa/Attributes/MappaInvokeMethodAttribute.cs
@@ -16,6 +16,7 @@ namespace Mappa.Attributes;
 /// <item><description><c>(targetPropertyName, classType, methodName)</c>: a <c>static</c> method declared on <see cref="ClassType"/> or one of its base classes.</description></item>
 /// <item><description><c>(targetPropertyName, fieldName, methodName)</c>: a non-<c>static</c> method declared on the type of the field or property identified by <see cref="FieldName"/> (including its base classes). The field or property must be declared on the mapper class or an accessible base class. When the root map method is <c>static</c>, the field or property must also be <c>static</c>.</description></item>
 /// </list>
+/// <see cref="SourcePropertyName"/> can be supplied as an optional named parameter on any constructor overload to specify which source property supplies the value for the invoked method. When set, it overrides the default name-based source property match for this target member.<br/>
 /// When multiple methods with the same name exist in a type hierarchy, methods declared on the most derived type are preferred.<br/>
 /// <br/>
 /// Every candidate method must satisfy all of the following requirements:<br/>
@@ -28,7 +29,7 @@ namespace Mappa.Attributes;
 /// <br/>
 /// When the root map method accepts a <see cref="Mappa.MappaContext"/> as its second parameter, invoked methods may also accept a <see cref="Mappa.MappaContext"/> parameter. The <see cref="Mappa.MappaContext"/> parameter is always the last parameter when combined with source and/or source-property arguments, and its type must be <c>Mappa.MappaContext</c>. Overloads that require <see cref="Mappa.MappaContext"/> are ignored when the map method does not provide one. If only <see cref="Mappa.MappaContext"/>-requiring overloads exist and the map method has no <see cref="Mappa.MappaContext"/> parameter, mapping fails.<br/>
 /// <br/>
-/// If multiple candidate methods match, the method is selected following the priority order below. The first matching overload wins. Tiers that reference a source property apply only when a source property is available for the target member (via name matching or <c>[MappaUseProperty]</c>):<br/>
+/// If multiple candidate methods match, the method is selected following the priority order below. The first matching overload wins. Tiers that reference a source property apply only when a source property is available for the target member (via name matching, <c>[MappaUseProperty]</c>, or <see cref="SourcePropertyName"/>):<br/>
 /// <list type="number">
 /// <item><description>Three parameters: the source <c>class</c>/<c>struct</c>/<c>record</c> (exact type), the source property (exact type), and <see cref="Mappa.MappaContext"/>. Requires the map method to provide <see cref="Mappa.MappaContext"/>.</description></item>
 /// <item><description>Two parameters: the source <c>class</c>/<c>struct</c>/<c>record</c> (exact type) and the source property (exact type).</description></item>
@@ -102,4 +103,10 @@ public sealed class MappaInvokeMethodAttribute
     /// Gets the name of the field or property on the mapper class or an accessible base class whose type exposes the non-<c>static</c> method <see cref="MethodName"/>. When the root map method is <c>static</c>, the field or property must also be <c>static</c>.
     /// </summary>
     public string? FieldName { get; }
+
+    /// <summary>
+    /// Gets or sets the name of the source property to use when resolving method overloads that accept a source property argument.
+    /// When set, this value overrides the default name-based source property match for the target member specified by <see cref="TargetPropertyName"/>.
+    /// </summary>
+    public string? SourcePropertyName { get; set; }
 }

--- a/Mappa/README.md
+++ b/Mappa/README.md
@@ -10,7 +10,7 @@ This is the list of attributes provided:
 - `MappaIgnoreTargetProperty`: When mapping structured types via an empty constructor, excludes a target property from property-initializer mapping; has no effect when mapping uses a constructor with parameters;
 - `MappaAssignFromContext`: When mapping structured types, allows specifying which value from a `MappaContext` to use for a target property or constructor parameter;
 - `MappaAssignToContext`: When mapping structured types via the constructor-map strategy, stores the value of a target property or field in `MappaContext` after the target object has been fully constructed;
-- `MappaInvokeMethodAttribute`: When mapping structured types via the constructor-map strategy, forces a target property or constructor parameter to be mapped by invoking a named method;
+- `MappaInvokeMethodAttribute`: When mapping structured types via the constructor-map strategy, forces a target property or constructor parameter to be mapped by invoking a named method; supports an optional `SourcePropertyName` named parameter to select the source property passed to the invoked method;
 - `MappaAssignFromConstant`: When mapping structured types, allows specifying a constant value for a target property or constructor parameter;
 - `MappaTypeMapping`: When mapping structured types or interfaces, allows defining the target type depending on the source type;
 - `MappaTypeMappingDefault`: Describes the default behaviour for polymorphic methods defined via `MappaTypeMapping`.

--- a/MappaVersion.targets
+++ b/MappaVersion.targets
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <MappaVersion>10.1.0-alpha.17</MappaVersion>
+        <MappaVersion>10.1.0-alpha.18</MappaVersion>
     </PropertyGroup>
 </Project>

--- a/MappaVersion.targets
+++ b/MappaVersion.targets
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <MappaVersion>10.1.0-alpha.16</MappaVersion>
+        <MappaVersion>10.1.0-alpha.17</MappaVersion>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

- Add optional `SourcePropertyName` named parameter to `MappaInvokeMethodAttribute` so invoke-method mappings can specify a custom source property without a separate `[MappaUseProperty]`.
- Wire the property through the generator constructor-map strategy, including MP00031/MP00032 warning behavior when it conflicts with or is unused by the selected invoked method overload.
- Add unit and integration tests, a sample mapper, documentation updates, and version bumps to `10.1.0-alpha.18`.

## Test plan

- [x] `Mappa.Tests` attribute surface tests for `SourcePropertyName`
- [x] `Mappa.Generator.Tests` integration tests for happy paths, MP00031, MP00032, and missing source property failures
- [x] `Mappa.Samples.Tests` runtime sample test
- [x] `.\Scripts\RunTestsAndReportCoverage.ps1` (2192 tests passed; 97.8% line coverage)

Made with [Cursor](https://cursor.com)