### PR TITLE
#259 Suppress MP00039 in EnumToEnumMapper sample via pragma warning disable

### DIFF
--- a/.cursor/rules/mappa-development-workflow.mdc
+++ b/.cursor/rules/mappa-development-workflow.mdc
@@ -102,6 +102,7 @@ A single feature may require **two** bumps (e.g. one after **Mappa**, one after 
 - Add samples in **Mappa.Samples** after **Mappa.Generator** changes that add features or enhance existing behavior.
 - **Do not** add new samples for bug fixes alone.
 - Before adding samples, ensure the **Mappa.Generator** version bump and rebuild described in **Versioning** has already been done.
+- **Warning suppression:** when a sample intentionally triggers a Mappa analyzer warning (e.g. MP00013, MP00016, MP00039), suppress it with `#pragma warning disable` / `#pragma warning restore` at the method or file level, including a short explanatory comment. Do **not** suppress sample warnings via `WarningsNotAsErrors`, `NoWarn`, or global analyzer config in the `.csproj`. Exception: `MP00000` may remain in `WarningsNotAsErrors` (debug diagnostic infrastructure). See [`InvokeParseMapper.cs`](Mappa.Samples/InvokeParseMapper.cs), [`MappaIgnoreMappers.cs`](Mappa.Samples/MappaIgnoreMappers.cs), and [`EnumToEnumMapper.cs`](Mappa.Samples/EnumToEnumMapper.cs) for examples.
 
 ## Documentation
 

--- a/Mappa.Samples.Aot/Mappa.Samples.Aot.csproj
+++ b/Mappa.Samples.Aot/Mappa.Samples.Aot.csproj
@@ -9,7 +9,7 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <AnalysisLevel>latest-all</AnalysisLevel>
-        <WarningsNotAsErrors>MP00000;MP00039</WarningsNotAsErrors>
+        <WarningsNotAsErrors>MP00000</WarningsNotAsErrors>
         <PublishAot>true</PublishAot>
         <PublishReadyToRun>true</PublishReadyToRun>
         <StripSymbols>true</StripSymbols>

--- a/Mappa.Samples/EnumToEnumMapper.cs
+++ b/Mappa.Samples/EnumToEnumMapper.cs
@@ -18,5 +18,7 @@ public sealed partial class EnumToEnumMapper
     /// </summary>
     /// <param name="input">The input enum value.</param>
     /// <returns>The integer mapped from the value.</returns>
+#pragma warning disable MP00039 // Partial enum mapping is intentional; CountingValues.One has no target member
     public partial CountingValuesFromTwo Map(CountingValues input);
+#pragma warning restore MP00039
 }

--- a/Mappa.Samples/Mappa.Samples.csproj
+++ b/Mappa.Samples/Mappa.Samples.csproj
@@ -10,7 +10,7 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <AnalysisLevel>latest-all</AnalysisLevel>
-        <WarningsNotAsErrors>MP00000;MP00039</WarningsNotAsErrors>
+        <WarningsNotAsErrors>MP00000</WarningsNotAsErrors>
         <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     </PropertyGroup>
 

--- a/MappaVersion.targets
+++ b/MappaVersion.targets
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <MappaVersion>10.1.0-alpha.24</MappaVersion>
+        <MappaVersion>10.1.0-alpha.25</MappaVersion>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

- Suppress intentional MP00039 in `EnumToEnumMapper.Map` with `#pragma warning disable/restore` and an explanatory comment (partial enum mapping demonstrates runtime `ArgumentOutOfRangeException` for unmapped `CountingValues.One`).
- Remove project-level `MP00039` from `WarningsNotAsErrors` in `Mappa.Samples` and `Mappa.Samples.Aot` csproj files.
- Document samples warning-suppression policy in `.cursor/rules/mappa-development-workflow.mdc` (use pragma at source, not `NoWarn`/`WarningsNotAsErrors` for sample warnings).
- Bump version to `10.1.0-alpha.25`.

## Test plan

- [x] `dotnet build` for `Mappa.Samples` and `Mappa.Samples.Aot` — no MP00039 warnings
- [x] `.\Scripts\RunTestsAndReportCoverage.ps1` — 2205 tests passed

Made with [Cursor](https://cursor.com)