### PR TITLE
#184 Relaxed nullability fallback for map method matching

### DIFF
--- a/.cursor/rules/mappa-development-workflow.mdc
+++ b/.cursor/rules/mappa-development-workflow.mdc
@@ -1,5 +1,5 @@
 ---
-description: Mappa development workflow — planning, code, git, versioning, tests, and samples
+description: Mappa development workflow — planning, code, code coverage, git, versioning, tests, and samples
 alwaysApply: true
 ---
 
@@ -24,7 +24,15 @@ The development environment uses **PowerShell**. All commands run in the termina
 - **Plan frontmatter format:** each TODO entry uses `id: "<n>"` and `content: <n>. <description>` where `<n>` is the same integer as the corresponding `### <n>.` heading in the plan body.
 - Plan steps must follow the **Code** project order below, but only include projects that require changes — do **not** add empty steps for unchanged projects.
 - Step numbers are **sequential** (1, 2, 3, …) across the included projects; they do **not** need to match the fixed project position numbers in the Code list (e.g. if **Mappa** and **Mappa.Tests** need no changes, the first step may be **Mappa.Generator** numbered as step `1`).
+- **Before implementation**, establish the **code coverage baseline** described in **Code Coverage** below.
 - Generated code **must compile** and **all tests must pass** before finishing.
+
+## Code Coverage
+
+- **Before starting work** on a new feature or GitHub issue, run `.\Scripts\RunTestsAndReportCoverage.ps1` and record the baseline from [`.mappa-tests-and-coverage/Summary.xml`](.mappa-tests-and-coverage/Summary.xml): **line**, **branch**, and **method** coverage. Also note coverage for any assembly expected to change (especially **Mappa.Generator**).
+- **Coverage must not decrease** relative to that baseline when the issue is finished. Compare the final run using the same metrics.
+- If coverage decreases — including after adding new production code with uncovered paths — **add or extend tests** until coverage is restored. Prefer targeted unit and integration tests for new branches, edge cases, and negative paths.
+- When analyzing gaps, use [`.mappa-tests-and-coverage/Summary.xml`](.mappa-tests-and-coverage/Summary.xml) and the HTML report under [`.mappa-tests-and-coverage/`](.mappa-tests-and-coverage/) to find uncovered lines and branches.
 
 ## Code
 
@@ -94,6 +102,7 @@ A single feature may require **two** bumps (e.g. one after **Mappa**, one after 
 
 - Update tests after changing a project.
 - Cover **happy path and negative paths** where possible.
+- Maintain or improve **code coverage** relative to the baseline recorded at the start of the issue (see **Code Coverage**).
 - For **Mappa.Generator**, test error/warning messages and corner cases.
 - For **Mappa.Generator.Tests** integration tests that assert generated syntax: when `blockSyntaxAssertions` (or nested block assertions) include `HasSyntaxNodesCount(X)`, there must be exactly **X** subsequent `HasNextSyntaxNode` entries chained after it. Tests that only assert diagnostic errors and do not inspect generated syntax are exempt.
 - When adding samples in **Mappa.Samples**, also update **Mappa.Samples.Aot**.
@@ -119,3 +128,5 @@ Always end with:
 ```powershell
 .\Scripts\RunTestsAndReportCoverage.ps1
 ```
+
+Confirm that **line**, **branch**, and **method** coverage in [`.mappa-tests-and-coverage/Summary.xml`](.mappa-tests-and-coverage/Summary.xml) are **greater than or equal to** the baseline recorded before starting the issue. If any metric decreased, add tests and re-run until coverage is restored.

--- a/Documentation/features.md
+++ b/Documentation/features.md
@@ -42,8 +42,9 @@ Before the detector chain, nested mappings may invoke an existing map method on 
 
 | Feature | Sample |
 |---------|--------|
-| Hand-written map methods on the mapper | [MapMethodStrategyMapper.cs](../Mappa.Samples/MapMethodStrategyMapper.cs), [MapMethodStrategyWithUserCustomInstanceMethodMapper.cs](../Mappa.Samples/MapMethodStrategyWithUserCustomInstanceMethodMapper.cs), [MapMethodStrategyWithUserCustomStaticMethodMapper.cs](../Mappa.Samples/MapMethodStrategyWithUserCustomStaticMethodMapper.cs) |
+| Hand-written map methods on the mapper | [MapMethodStrategyMapper.cs](../Mappa.Samples/MapMethodStrategyMapper.cs), [MapMethodStrategyWithUserCustomInstanceMethodMapper.cs](../Mappa.Samples/MapMethodStrategyWithUserCustomInstanceMethodMapper.cs), [MapMethodStrategyWithUserCustomStaticMethodMapper.cs](../Mappa.Samples/MapMethodStrategyWithUserCustomStaticMethodMapper.cs), [RelaxedNullabilityMethodMapMapper.cs](../Mappa.Samples/RelaxedNullabilityMethodMapMapper.cs) |
 | Polymorphic method resolution for nested properties | [PolymorphicMethodMapMapper.cs](../Mappa.Samples/PolymorphicMethodMapMapper.cs) |
+| Relaxed nullability when reusing existing map methods | [Algorithm — existing-method pre-step](./mappa-generator-algorithm.md#existing-method-pre-step-nested-mappings-only), [RelaxedNullabilityMethodMapMapper.cs](../Mappa.Samples/RelaxedNullabilityMethodMapMapper.cs) |
 
 ## Attributes
 

--- a/Documentation/mappa-generator-algorithm.md
+++ b/Documentation/mappa-generator-algorithm.md
@@ -51,7 +51,8 @@ Before the detector chain, `TypeMapIdentifierWithMapMethodAlgorithm` checks whet
     - The existing method is invoked;
 - _Notes_:
     - A nested mapper method that requires `MappaContext` is only invoked when the caller provides context (the root map method has a `MappaContext` parameter);
-    - This pre-step is used when mapping elements of an array, keys or values of dictionaries, elements of tuples, and properties or constructor parameters of class/struct/record types.
+    - This pre-step is used when mapping elements of an array, keys or values of dictionaries, elements of tuples, and properties or constructor parameters of class/struct/record types;
+    - When `#nullable enable` is active, nullability annotations must match exactly first. If no exact match exists, the generator may reuse a method with a relaxed nullability signature on the same underlying types: nested mapping to `TTarget?` may invoke a method returning `TTarget`, and nested mapping from `TSource` may invoke a method accepting `TSource?`.
 
 ### Detector chain order
 

--- a/Documentation/upgrade.md
+++ b/Documentation/upgrade.md
@@ -1,5 +1,17 @@
 # Upgrade guide
 
+## 10.1.0 → 10.2.0
+
+### Breaking changes
+
+- **Relaxed nullability matching for existing map methods (nested mappings)**
+  - When `#nullable enable` is active, nested mappings may now reuse an existing map method on the mapper, a dependency, or a matching polymorphic method even when nullability annotations differ slightly, as long as the underlying types match.
+  - Exact nullability matches are still preferred. A relaxed match is used only when no exact match exists.
+  - Supported relaxations:
+    - Nested mapping needs `TTarget?` → may invoke a method returning `TTarget`.
+    - Nested mapping needs `TSource` → may invoke a method accepting `TSource?`.
+  - Previously, a nullability mismatch caused the generator to skip the existing method and generate inline mapping (or select another strategy) instead. Review nested mappings that relied on the old behaviour.
+
 ## 10.0.0 → 10.1.0
 
 ### Breaking changes

--- a/Mappa.Generator.Tests/MapMethodTests.cs
+++ b/Mappa.Generator.Tests/MapMethodTests.cs
@@ -164,7 +164,104 @@ public sealed class MapMethodTests
         mapMethod.RequireMappaContextWhenInvoked().Should().BeTrue();
     }
 
-    private static MapMethod CreateMapMethodFromSyntax(string source, string methodName)
+    /// <summary>
+    /// Test <see cref="MapMethod.IsRelaxedMapFor"/> matches when nullability can be relaxed on both axes.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void IsRelaxedMapForReturnsTrueForSupportedNullabilityMismatches()
+    {
+        const string source = """
+                              #nullable enable
+                              using Mappa.Attributes;
+
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              public class Source { }
+
+                              public class Target { }
+
+                              [Mappa]
+                              public sealed partial class Mapper
+                              {
+                                  public partial Target? Map(Source? input);
+                              }
+                              """;
+
+        var mapMethod = CreateMapMethodFromSyntax(source, "Map", nullableEnabled: true);
+        var requiredTarget = mapMethod.TargetType.WithNullableAnnotation(NullableAnnotation.NotAnnotated);
+        var requiredSource = mapMethod.SourceType.WithNullableAnnotation(NullableAnnotation.NotAnnotated);
+
+        mapMethod.IsRelaxedMapFor(requiredTarget, requiredSource, includeNullability: true).Should().BeTrue();
+        mapMethod.IsMapFor(requiredTarget, requiredSource, includeNullability: true).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Test <see cref="MapMethod.IsRelaxedMapFor"/> rejects unsupported nullability mismatches.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void IsRelaxedMapForReturnsFalseForUnsupportedNullabilityMismatches()
+    {
+        const string source = """
+                              #nullable enable
+                              using Mappa.Attributes;
+
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              public class Source { }
+
+                              public class Target { }
+
+                              [Mappa]
+                              public sealed partial class Mapper
+                              {
+                                  public Target Map(Source input);
+                              }
+                              """;
+
+        var mapMethod = CreateMapMethodFromSyntax(source, "Map", nullableEnabled: true);
+        var compilation = BuildCompilation(source);
+        var sourceType = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.Source")!
+            .WithNullableAnnotation(NullableAnnotation.Annotated);
+        var targetType = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.Target")!
+            .WithNullableAnnotation(NullableAnnotation.NotAnnotated);
+
+        mapMethod.IsRelaxedMapFor(targetType, sourceType, includeNullability: true).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Test <see cref="MapMethod.IsRelaxedMapFor"/> is disabled when nullability is disabled.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void IsRelaxedMapForReturnsFalseWhenNullabilityIsDisabled()
+    {
+        const string source = """
+                              using Mappa.Attributes;
+
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              public class Source { }
+
+                              public class Target { }
+
+                              [Mappa]
+                              public sealed partial class Mapper
+                              {
+                                  public partial Target Map(Source input);
+                              }
+                              """;
+
+        var mapMethod = CreateMapMethodFromSyntax(source, "Map", nullableEnabled: false);
+        var compilation = BuildCompilation(source);
+        var sourceType = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.Source")!;
+        var targetType = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.Target")!;
+
+        mapMethod.IsRelaxedMapFor(targetType, sourceType, includeNullability: false).Should().BeFalse();
+    }
+
+    private static MapMethod CreateMapMethodFromSyntax(string source, string methodName, bool nullableEnabled = false)
     {
         var compilation = BuildCompilation(source);
         var syntaxTree = compilation.SyntaxTrees[0];
@@ -177,7 +274,7 @@ public sealed class MapMethodTests
         return new MapMethod(
             methodDeclarationSyntax,
             semanticModel,
-            nullableEnabled: false,
+            nullableEnabled,
             CancellationToken.None);
     }
 }

--- a/Mappa.Generator.Tests/MappaClassGeneratorContextTests.cs
+++ b/Mappa.Generator.Tests/MappaClassGeneratorContextTests.cs
@@ -1,0 +1,228 @@
+// <copyright file="MappaClassGeneratorContextTests.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using Mappa.Attributes;
+using Mappa.Generator.Diagnostics.Debug;
+using Mappa.Generator.Models;
+using Mappa.Generator.Tests.Abstractions;
+using Mappa.Generator.Tests.Helpers;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+using Xunit;
+using Xunit.OpenCategories.V3;
+
+namespace Mappa.Generator.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="MappaClassGeneratorContext"/>.
+/// </summary>
+public sealed class MappaClassGeneratorContextTests
+    : MappaGeneratorAbstractUnitTests
+{
+    private const string PolymorphicMapperSource = """
+                                                     #nullable enable
+                                                     using Mappa.Attributes;
+
+                                                     namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                                     public class SourceBase { }
+
+                                                     public class SourceFirst : SourceBase { }
+
+                                                     public class TargetBase { }
+
+                                                     public class TargetFirst : TargetBase { }
+
+                                                     [Mappa]
+                                                     public sealed partial class Mapper
+                                                     {
+                                                         public partial TargetBase MapDependency(SourceBase input);
+                                                     }
+                                                     """;
+
+    /// <summary>
+    /// Test <see cref="MappaClassGeneratorContext.TryGetPolymorphicMethod"/> ignores
+    /// <see cref="MappaTypeMappingAttribute"/> entries whose types cannot be resolved in the compilation.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void TryGetPolymorphicMethodReturnsFalseWhenTypeMappingAttributeTypesAreNotInCompilation()
+    {
+        var context = CreateContext(PolymorphicMapperSource);
+        var mapMethod = CreatePolymorphicMapMethod(
+            [
+                new MappaTypeMappingAttribute(
+                    typeof(MappaClassGeneratorContextTests),
+                    typeof(MappaClassGeneratorContextTests)),
+            ]);
+        context.TryAddMethod(mapMethod);
+
+        var sourceType = context.Compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.SourceFirst")!;
+        var targetType = context.Compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.TargetFirst")!;
+        var userSettings = CreateUserSettingsWithPolymorphicDefaultEnabled(context.ClassDeclarationSyntax.SyntaxTree);
+
+        var found = context.TryGetPolymorphicMethod(
+            targetType,
+            sourceType,
+            nullableEnabled: true,
+            requireStaticContext: false,
+            userSettings,
+            out var resolvedMethod);
+
+        found.Should().BeFalse();
+        resolvedMethod.Should().BeNull();
+    }
+
+    /// <summary>
+    /// Test <see cref="MappaClassGeneratorContext.TryGetPolymorphicMethod"/> ignores
+    /// <see cref="MappaTypeMappingDefaultAttribute"/> when its behavior is not
+    /// <see cref="MappaTypeMappingDefaultBehavior.MapSourceType"/>.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void TryGetPolymorphicMethodReturnsFalseWhenTypeMappingDefaultAttributeHasUnsupportedBehavior()
+    {
+        var context = CreateContext(PolymorphicMapperSource);
+        var mapMethod = CreatePolymorphicMapMethod(
+            [
+                new MappaTypeMappingAttribute(
+                    typeof(MappaClassGeneratorContextTests),
+                    typeof(MappaClassGeneratorContextTests)),
+                new MappaTypeMappingDefaultAttribute(MappaTypeMappingDefaultBehavior.Throw),
+            ]);
+        context.TryAddMethod(mapMethod);
+
+        var sourceType = context.Compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.SourceFirst")!;
+        var targetType = context.Compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.TargetFirst")!;
+        var userSettings = CreateUserSettingsWithPolymorphicDefaultEnabled(context.ClassDeclarationSyntax.SyntaxTree);
+
+        var found = context.TryGetPolymorphicMethod(
+            targetType,
+            sourceType,
+            nullableEnabled: true,
+            requireStaticContext: false,
+            userSettings,
+            out _);
+
+        found.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Test <see cref="MappaClassGeneratorContext.TryGetPolymorphicMethod"/> ignores
+    /// <see cref="MappaTypeMappingDefaultAttribute"/> when
+    /// <see cref="MappaTypeMappingDefaultBehavior.MapSourceType"/> is used without a target type.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void TryGetPolymorphicMethodReturnsFalseWhenTypeMappingDefaultAttributeMapSourceTypeHasNoTargetType()
+    {
+        var context = CreateContext(PolymorphicMapperSource);
+        var mapMethod = CreatePolymorphicMapMethod(
+            [
+                new MappaTypeMappingAttribute(
+                    typeof(MappaClassGeneratorContextTests),
+                    typeof(MappaClassGeneratorContextTests)),
+                new MappaTypeMappingDefaultAttribute(MappaTypeMappingDefaultBehavior.MapSourceType),
+            ]);
+        context.TryAddMethod(mapMethod);
+
+        var sourceType = context.Compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.SourceFirst")!;
+        var targetType = context.Compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.TargetFirst")!;
+        var userSettings = CreateUserSettingsWithPolymorphicDefaultEnabled(context.ClassDeclarationSyntax.SyntaxTree);
+
+        var found = context.TryGetPolymorphicMethod(
+            targetType,
+            sourceType,
+            nullableEnabled: true,
+            requireStaticContext: false,
+            userSettings,
+            out _);
+
+        found.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Test <see cref="MappaClassGeneratorContext.TryGetPolymorphicMethod"/> ignores
+    /// <see cref="MappaTypeMappingDefaultAttribute"/> when its target type cannot be resolved in the compilation.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void TryGetPolymorphicMethodReturnsFalseWhenTypeMappingDefaultAttributeTargetTypeIsNotInCompilation()
+    {
+        var context = CreateContext(PolymorphicMapperSource);
+        var mapMethod = CreatePolymorphicMapMethod(
+            [
+                new MappaTypeMappingAttribute(
+                    typeof(MappaClassGeneratorContextTests),
+                    typeof(MappaClassGeneratorContextTests)),
+                new MappaTypeMappingDefaultAttribute(
+                    MappaTypeMappingDefaultBehavior.MapSourceType,
+                    typeof(MappaClassGeneratorContextTests)),
+            ]);
+        context.TryAddMethod(mapMethod);
+
+        var sourceType = context.Compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.SourceFirst")!;
+        var targetType = context.Compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.TargetFirst")!;
+        var userSettings = CreateUserSettingsWithPolymorphicDefaultEnabled(context.ClassDeclarationSyntax.SyntaxTree);
+
+        var found = context.TryGetPolymorphicMethod(
+            targetType,
+            sourceType,
+            nullableEnabled: true,
+            requireStaticContext: false,
+            userSettings,
+            out _);
+
+        found.Should().BeFalse();
+    }
+
+    private static MappaClassGeneratorContext CreateContext(string source)
+    {
+        var compilation = BuildCompilation(source);
+        var syntaxTree = compilation.SyntaxTrees[0];
+        var classDeclarationSyntax = syntaxTree.GetRoot()
+            .DescendantNodes()
+            .OfType<ClassDeclarationSyntax>()
+            .Single(classSyntax => classSyntax.Identifier.Text == "Mapper");
+        var globalOptions = new MappaGlobalOptions(
+            TestAnalyzerConfigOptionsProvider.FromEditorConfig("root = true"),
+            syntaxTree);
+
+        return new MappaClassGeneratorContext(
+            globalOptions,
+            new MappaDebug(globalOptions, _ => { }),
+            compilation,
+            classDeclarationSyntax);
+    }
+
+    private static MapMethod CreatePolymorphicMapMethod(Attribute[] attributes)
+    {
+        var compilation = BuildCompilation(PolymorphicMapperSource);
+        var mapperType = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.Mapper");
+        if (mapperType is null)
+        {
+            throw new InvalidOperationException("Expected mapper type to be present in the compilation.");
+        }
+
+        var methodSymbol = mapperType.GetMembers("MapDependency").OfType<IMethodSymbol>().Single();
+        return new MapMethod(
+            methodSymbol,
+            "this",
+            nullableEnabled: true,
+            canBeUsedByStaticMethod: false,
+            attributes);
+    }
+
+    private static MappaGlobalOptions CreateUserSettingsWithPolymorphicDefaultEnabled(SyntaxTree syntaxTree)
+    {
+        return new MappaGlobalOptions(
+            TestAnalyzerConfigOptionsProvider.FromEditorConfig("""
+                root = true
+                mappa.polymorphicmapmethodwithmatchingdefaultattribute = enable
+                """),
+            syntaxTree);
+    }
+}

--- a/Mappa.Generator.Tests/MethodMapStrategyIntegrationTests.cs
+++ b/Mappa.Generator.Tests/MethodMapStrategyIntegrationTests.cs
@@ -2521,4 +2521,296 @@ public sealed class MethodMapStrategyIntegrationTests
                         });
                 });
     }
+
+    /// <summary>
+    /// Test a mapping can reuse an existing method when the nested target type is nullable
+    /// and the method returns the non-nullable type.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    [IntegrationTest]
+    public async Task CanMapUsingExistingMethodWithRelaxedReturnNullability()
+    {
+        const string sourceCode = """
+                                  #nullable enable
+                                  using Mappa.Attributes;
+
+                                  namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                  public class InnerSource { public int A { get; set; } }
+                                  public class InnerTarget { public int A { get; set; } }
+
+                                  public class Source { public InnerSource Property { get; set; } }
+                                  public class Target { public InnerTarget? Property { get; set; } }
+
+                                  [Mappa]
+                                  public sealed partial class Mapper
+                                  {
+                                      public InnerTarget Map(InnerSource input)
+                                      {
+                                          return new InnerTarget { A = input.A };
+                                      }
+
+                                      public partial Target Map(Source input);
+                                  }
+                                  #nullable restore
+                                  """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .NotHaveDiagnostics()
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                NullableAnnotation.NotAnnotated,
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Source",
+                NullableAnnotation.NotAnnotated,
+                NullableSetup.Enable,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(4)
+                        .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                            "Mappa.Generator.Tests.UnitTests.SourceCode.InnerSource",
+                            "__mappa_tmp_1",
+                            initializerAssertions => initializerAssertions.BeMemberAccessExpressionSyntax("input.Property")))
+                        .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                            "Mappa.Generator.Tests.UnitTests.SourceCode.InnerTarget",
+                            "__mappa_tmp_2",
+                            initializerAssertions => initializerAssertions.BeInvocationExpressionSyntax(
+                                "this.Map",
+                                parameterAssertions => parameterAssertions.BeIdentifierNameSyntax("__mappa_tmp_1"))))
+                        .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                            "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                            "__mappa_tmp_3",
+                            initializerAssertions => initializerAssertions.BeObjectCreationExpressionSyntax(
+                                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                                ("Property", expressionAssertions => expressionAssertions.BeIdentifierNameSyntax("__mappa_tmp_2")))))
+                        .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeReturnStatement("__mappa_tmp_3"));
+                });
+    }
+
+    /// <summary>
+    /// Test a mapping can reuse an existing method when the nested source type is non-nullable
+    /// and the method accepts the nullable source type.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    [IntegrationTest]
+    public async Task CanMapUsingExistingMethodWithRelaxedParameterNullability()
+    {
+        const string sourceCode = """
+                                  #nullable enable
+                                  using Mappa.Attributes;
+
+                                  namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                  public class InnerSource { public int A { get; set; } }
+                                  public class InnerTarget { public int A { get; set; } }
+
+                                  public class Source { public InnerSource Property { get; set; } }
+                                  public class Target { public InnerTarget Property { get; set; } }
+
+                                  [Mappa]
+                                  public sealed partial class Mapper
+                                  {
+                                      public InnerTarget Map(InnerSource? input)
+                                      {
+                                          return new InnerTarget { A = input!.A };
+                                      }
+
+                                      public partial Target Map(Source input);
+                                  }
+                                  #nullable restore
+                                  """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .NotHaveDiagnostics()
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                NullableAnnotation.NotAnnotated,
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Source",
+                NullableAnnotation.NotAnnotated,
+                NullableSetup.Enable,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(4)
+                        .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                            "Mappa.Generator.Tests.UnitTests.SourceCode.InnerSource",
+                            "__mappa_tmp_1",
+                            initializerAssertions => initializerAssertions.BeMemberAccessExpressionSyntax("input.Property")))
+                        .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                            "Mappa.Generator.Tests.UnitTests.SourceCode.InnerTarget",
+                            "__mappa_tmp_2",
+                            initializerAssertions => initializerAssertions.BeInvocationExpressionSyntax(
+                                "this.Map",
+                                parameterAssertions => parameterAssertions.BeIdentifierNameSyntax("__mappa_tmp_1"))))
+                        .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                            "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                            "__mappa_tmp_3",
+                            initializerAssertions => initializerAssertions.BeObjectCreationExpressionSyntax(
+                                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                                ("Property", expressionAssertions => expressionAssertions.BeIdentifierNameSyntax("__mappa_tmp_2")))))
+                        .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeReturnStatement("__mappa_tmp_3"));
+                });
+    }
+
+    /// <summary>
+    /// Test a mapping prefers an exact nullability match over a relaxed match when both methods exist.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    [IntegrationTest]
+    public async Task CanMapUsingExactMatchingMethodWhenExactAndRelaxedMatchesExist()
+    {
+        const string sourceCode = """
+                                  #nullable enable
+                                  using Mappa.Attributes;
+
+                                  namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                  public class InnerSource { public int A { get; set; } }
+                                  public class InnerTarget { public int A { get; set; } }
+
+                                  public class Source { public InnerSource Property { get; set; } }
+                                  public class Target { public InnerTarget Property { get; set; } }
+
+                                  [Mappa]
+                                  public sealed partial class Mapper
+                                  {
+                                      public InnerTarget MapExact(InnerSource input)
+                                      {
+                                          return new InnerTarget { A = input.A };
+                                      }
+
+                                      public InnerTarget MapRelaxed(InnerSource? input)
+                                      {
+                                          return new InnerTarget { A = input!.A };
+                                      }
+
+                                      public partial Target Map(Source input);
+                                  }
+                                  #nullable restore
+                                  """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .NotHaveDiagnostics()
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                NullableAnnotation.NotAnnotated,
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Source",
+                NullableAnnotation.NotAnnotated,
+                NullableSetup.Enable,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(4)
+                        .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                            "Mappa.Generator.Tests.UnitTests.SourceCode.InnerSource",
+                            "__mappa_tmp_1",
+                            initializerAssertions => initializerAssertions.BeMemberAccessExpressionSyntax("input.Property")))
+                        .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                            "Mappa.Generator.Tests.UnitTests.SourceCode.InnerTarget",
+                            "__mappa_tmp_2",
+                            initializerAssertions => initializerAssertions.BeInvocationExpressionSyntax(
+                                "this.MapExact",
+                                parameterAssertions => parameterAssertions.BeIdentifierNameSyntax("__mappa_tmp_1"))))
+                        .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                            "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                            "__mappa_tmp_3",
+                            initializerAssertions => initializerAssertions.BeObjectCreationExpressionSyntax(
+                                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                                ("Property", expressionAssertions => expressionAssertions.BeIdentifierNameSyntax("__mappa_tmp_2")))))
+                        .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeReturnStatement("__mappa_tmp_3"));
+                });
+    }
+
+    /// <summary>
+    /// Test a mapping does not reuse an existing method when the nested source type differs.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    [IntegrationTest]
+    public async Task CanMapWithoutUsingExistingMethodWhenRelaxedNullabilityMismatchIsUnsupported()
+    {
+        const string sourceCode = """
+                                  #nullable enable
+                                  using Mappa.Attributes;
+
+                                  namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                  public class InnerSource { public int A { get; set; } }
+                                  public class OtherSource { public int A { get; set; } }
+                                  public class InnerTarget { public int A { get; set; } }
+
+                                  public class Source { public InnerSource Property { get; set; } }
+                                  public class Target { public InnerTarget Property { get; set; } }
+
+                                  [Mappa]
+                                  public sealed partial class Mapper
+                                  {
+                                      public InnerTarget Map(OtherSource input)
+                                      {
+                                          return new InnerTarget { A = input.A };
+                                      }
+
+                                      public partial Target Map(Source input);
+                                  }
+                                  #nullable restore
+                                  """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .NotHaveDiagnostics()
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                NullableAnnotation.NotAnnotated,
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Source",
+                NullableAnnotation.NotAnnotated,
+                NullableSetup.Enable,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(5)
+                        .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                            "Mappa.Generator.Tests.UnitTests.SourceCode.InnerSource",
+                            "__mappa_tmp_1",
+                            initializerAssertions => initializerAssertions.BeMemberAccessExpressionSyntax("input.Property")))
+                        .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                            typeof(int).ToString(),
+                            "__mappa_tmp_2",
+                            initializerAssertions => initializerAssertions.BeMemberAccessExpressionSyntax("__mappa_tmp_1.A")))
+                        .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                            "Mappa.Generator.Tests.UnitTests.SourceCode.InnerTarget",
+                            "__mappa_tmp_3",
+                            initializerAssertions => initializerAssertions.BeObjectCreationExpressionSyntax(
+                                "Mappa.Generator.Tests.UnitTests.SourceCode.InnerTarget",
+                                ("A", expressionAssertions => expressionAssertions.BeIdentifierNameSyntax("__mappa_tmp_2")))))
+                        .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                            "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                            "__mappa_tmp_4",
+                            initializerAssertions => initializerAssertions.BeObjectCreationExpressionSyntax(
+                                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                                ("Property", expressionAssertions => expressionAssertions.BeIdentifierNameSyntax("__mappa_tmp_3")))))
+                        .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeReturnStatement("__mappa_tmp_4"));
+                });
+    }
 }

--- a/Mappa.Generator.Tests/PolymorphicMethodMapStrategyIntegrationTests.cs
+++ b/Mappa.Generator.Tests/PolymorphicMethodMapStrategyIntegrationTests.cs
@@ -637,8 +637,7 @@ public sealed class PolymorphicMethodMapStrategyIntegrationTests
     /// method where the types are defined by <see cref="MappaTypeMappingDefaultAttribute"/>
     /// using explicit target mapping and
     /// <see cref="MappaSettingsAttribute.PolymorphicMapMethodWithMatchingDefaultAttribute"/> is
-    /// <see cref="BooleanSetting.Enable"/> but nullability do not match
-    /// and therefore the method is not applied.
+    /// <see cref="BooleanSetting.Enable"/> with relaxed nullability matching on the default target type.
     /// </summary>
     /// <returns>The async task.</returns>
     [Fact]
@@ -695,28 +694,26 @@ public sealed class PolymorphicMethodMapStrategyIntegrationTests
                 blockSyntaxAssertions =>
                 {
                     blockSyntaxAssertions
-                        .HasSyntaxNodesCount(5)
+                        .HasSyntaxNodesCount(4)
                         .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
                             "Mappa.Generator.Tests.UnitTests.SourceCode.SourceBase",
                             "__mappa_tmp_13",
                             initializerAssertions => initializerAssertions.BeMemberAccessExpressionSyntax("input.DependencyProperty")))
                         .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
-                            typeof(int).ToString(),
-                            "__mappa_tmp_14",
-                            initializerAssertions => initializerAssertions.BeMemberAccessExpressionSyntax("__mappa_tmp_13.BaseProperty")))
-                        .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
                             "Mappa.Generator.Tests.UnitTests.SourceCode.TargetDefault",
-                            "__mappa_tmp_15",
-                            initializerAssertions => initializerAssertions.BeObjectCreationExpressionSyntax(
+                            "__mappa_tmp_14",
+                            initializerAssertions => initializerAssertions.BeCastExpressionSyntax(
                                 "Mappa.Generator.Tests.UnitTests.SourceCode.TargetDefault",
-                                ("BaseProperty", propertyInitializerAssertions => propertyInitializerAssertions.BeIdentifierNameSyntax("__mappa_tmp_14")))))
+                                expressionAssertions => expressionAssertions.BeInvocationExpressionSyntax(
+                                    "this.MapDependency",
+                                    parameterAssertions => parameterAssertions.BeIdentifierNameSyntax("__mappa_tmp_13")))))
                         .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
                             "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
-                            "__mappa_tmp_16",
+                            "__mappa_tmp_15",
                             initializerAssertions => initializerAssertions.BeObjectCreationExpressionSyntax(
                                 "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
-                                ("DependencyProperty", expressionAssertions => expressionAssertions.BeIdentifierNameSyntax("__mappa_tmp_15")))))
-                        .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeReturnStatement("__mappa_tmp_16"));
+                                ("DependencyProperty", expressionAssertions => expressionAssertions.BeIdentifierNameSyntax("__mappa_tmp_14")))))
+                        .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeReturnStatement("__mappa_tmp_15"));
                 });
     }
 
@@ -1176,10 +1173,9 @@ public sealed class PolymorphicMethodMapStrategyIntegrationTests
     }
 
     /// <summary>
-    /// Test a mapping exists without using the polymorphic mappa-generated
-    /// method where the types are defined by <see cref="MappaTypeMappingDefaultAttribute"/>
-    /// using explicit target mapping but nullability do not match
-    /// and therefore the method is not applied.
+    /// Test a mapping can use a polymorphic mappa-generated
+    /// method where the types are defined by <see cref="MappaTypeMappingAttribute"/>
+    /// using explicit target mapping with relaxed nullability matching.
     /// </summary>
     /// <returns>The async task.</returns>
     [Fact]
@@ -1234,37 +1230,100 @@ public sealed class PolymorphicMethodMapStrategyIntegrationTests
                 blockSyntaxAssertions =>
                 {
                     blockSyntaxAssertions
-                        .HasSyntaxNodesCount(7)
+                        .HasSyntaxNodesCount(4)
                         .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
                             "Mappa.Generator.Tests.UnitTests.SourceCode.SourceFirst",
                             "__mappa_tmp_9",
                             initializerAssertions => initializerAssertions.BeMemberAccessExpressionSyntax("input.DependencyProperty")))
                         .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
-                            typeof(Guid).ToString(),
-                            "__mappa_tmp_10",
-                            initializerAssertions => initializerAssertions.BeMemberAccessExpressionSyntax("__mappa_tmp_9.FirstProperty")))
-                        .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
-                            typeof(string).ToString(),
-                            "__mappa_tmp_11",
-                            initializerAssertions => initializerAssertions.BeInvocationExpressionSyntax("__mappa_tmp_10.ToString")))
-                        .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
-                            typeof(int).ToString(),
-                            "__mappa_tmp_12",
-                            initializerAssertions => initializerAssertions.BeMemberAccessExpressionSyntax("__mappa_tmp_9.BaseProperty")))
-                        .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
                             "Mappa.Generator.Tests.UnitTests.SourceCode.TargetFirst",
-                            "__mappa_tmp_13",
-                            initializerAssertions => initializerAssertions.BeObjectCreationExpressionSyntax(
+                            "__mappa_tmp_10",
+                            initializerAssertions => initializerAssertions.BeCastExpressionSyntax(
                                 "Mappa.Generator.Tests.UnitTests.SourceCode.TargetFirst",
-                                ("FirstProperty", propertyInitializerAssertions => propertyInitializerAssertions.BeIdentifierNameSyntax("__mappa_tmp_11")),
-                                ("BaseProperty", propertyInitializerAssertions => propertyInitializerAssertions.BeIdentifierNameSyntax("__mappa_tmp_12")))))
+                                expressionAssertions => expressionAssertions.BeInvocationExpressionSyntax(
+                                    "this.MapDependency",
+                                    parameterAssertions => parameterAssertions.BeIdentifierNameSyntax("__mappa_tmp_9")))))
                         .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
                             "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
-                            "__mappa_tmp_14",
+                            "__mappa_tmp_11",
                             initializerAssertions => initializerAssertions.BeObjectCreationExpressionSyntax(
                                 "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
-                                ("DependencyProperty", propertyInitializerAssertions => propertyInitializerAssertions.BeIdentifierNameSyntax("__mappa_tmp_13")))))
-                        .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeReturnStatement("__mappa_tmp_14"));
+                                ("DependencyProperty", expressionAssertions => expressionAssertions.BeIdentifierNameSyntax("__mappa_tmp_10")))))
+                        .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeReturnStatement("__mappa_tmp_11"));
+                });
+    }
+
+    /// <summary>
+    /// Test a mapping can use a polymorphic mappa-generated
+    /// method with relaxed nullability on the method return and parameter types.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    [IntegrationTest]
+    public async Task CanMapUsingCustomPolymorphicPartialMethodWithRelaxedNullabilityOnMethodSignature()
+    {
+        const string sourceCode = """
+                                  #nullable enable
+                                  using Mappa.Attributes;
+
+                                  namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                  public class SourceBase { public int BaseProperty { get; set; }  }
+                                  public class SourceFirst : SourceBase { public Guid FirstProperty { get; set; }  }
+                                  
+                                  public class TargetBase { public long BaseProperty { get; set; }  }
+                                  public class TargetFirst : TargetBase { public string FirstProperty { get; set; }  }
+                                  
+                                  public class Source { public SourceBase DependencyProperty { get; set; } }
+                                  public class Target { public TargetBase DependencyProperty { get; set; } }
+
+                                  [Mappa]
+                                  public sealed partial class Mapper
+                                  {
+                                      [MappaTypeMapping(typeof(TargetFirst), typeof(SourceFirst))]
+                                      public partial TargetBase? MapDependency(SourceBase? input);
+                                      
+                                      public partial Target Map(Source input);
+                                  }
+                                  #nullable restore
+                                  """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+
+        generatedResults.Should()
+            .NotHaveDiagnostics()
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                NullableAnnotation.NotAnnotated,
+                "Mappa.Generator.Tests.UnitTests.SourceCode.Source",
+                NullableAnnotation.NotAnnotated,
+                2,
+                NullableSetup.Enable,
+                PragmaWarning.NoBlock,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(4)
+                        .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                            "Mappa.Generator.Tests.UnitTests.SourceCode.SourceBase",
+                            "__mappa_tmp_9",
+                            initializerAssertions => initializerAssertions.BeMemberAccessExpressionSyntax("input.DependencyProperty")))
+                        .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                            "Mappa.Generator.Tests.UnitTests.SourceCode.TargetBase?",
+                            "__mappa_tmp_10",
+                            expressionAssertions => expressionAssertions.BeInvocationExpressionSyntax(
+                                "this.MapDependency",
+                                parameterAssertions => parameterAssertions.BeIdentifierNameSyntax("__mappa_tmp_9"))))
+                        .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeLocalDeclarationStatementSyntax(
+                            "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                            "__mappa_tmp_11",
+                            initializerAssertions => initializerAssertions.BeObjectCreationExpressionSyntax(
+                                "Mappa.Generator.Tests.UnitTests.SourceCode.Target",
+                                ("DependencyProperty", expressionAssertions => expressionAssertions.BeIdentifierNameSyntax("__mappa_tmp_10")))))
+                        .HasNextSyntaxNode(syntaxNodeAssertions => syntaxNodeAssertions.BeReturnStatement("__mappa_tmp_11"));
                 });
     }
 

--- a/Mappa.Generator.Tests/TypeSymbolExtensionsTests.cs
+++ b/Mappa.Generator.Tests/TypeSymbolExtensionsTests.cs
@@ -374,4 +374,88 @@ public sealed class TypeSymbolExtensionsTests
         nullableSample.IsNullabilityMatchOrRelaxed(nonNullableSample, isNullableEnabled: true).Should().BeTrue();
         nonNullableSample.IsNullabilityMatchOrRelaxed(nullableSample, isNullableEnabled: true).Should().BeTrue();
     }
+
+    /// <summary>
+    /// Test <see cref="TypeSymbolExtensions.IsRelaxedNullabilityMatch"/> rejects different underlying types.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void IsRelaxedNullabilityMatchReturnsFalseForDifferentUnderlyingTypes()
+    {
+        const string source = """
+                              #nullable enable
+
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              public sealed class Sample
+                              {
+                              }
+
+                              public sealed class OtherSample
+                              {
+                              }
+                              """;
+
+        var compilation = BuildCompilation(source);
+        var sampleType = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.Sample")!;
+        var otherSampleType = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.OtherSample")!;
+        var nullableSample = sampleType.WithNullableAnnotation(NullableAnnotation.Annotated);
+        var nonNullableOtherSample = otherSampleType.WithNullableAnnotation(NullableAnnotation.NotAnnotated);
+
+        nullableSample.IsRelaxedNullabilityMatch(nonNullableOtherSample, isNullableEnabled: true).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Test <see cref="TypeSymbolExtensions.IsRelaxedNullabilityMatch"/> rejects oblivious nullability annotations.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void IsRelaxedNullabilityMatchReturnsFalseWhenNullableAnnotationIsNone()
+    {
+        const string source = """
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              public sealed class Sample
+                              {
+                              }
+                              """;
+
+        var compilation = BuildCompilation(source);
+        var sampleType = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.Sample")!;
+        var obliviousSample = sampleType.WithNullableAnnotation(NullableAnnotation.None);
+        var nonNullableSample = sampleType.WithNullableAnnotation(NullableAnnotation.NotAnnotated);
+        var nullableSample = sampleType.WithNullableAnnotation(NullableAnnotation.Annotated);
+
+        obliviousSample.IsRelaxedNullabilityMatch(nonNullableSample, isNullableEnabled: true).Should().BeFalse();
+        nonNullableSample.IsRelaxedNullabilityMatch(obliviousSample, isNullableEnabled: true).Should().BeFalse();
+        obliviousSample.IsRelaxedNullabilityMatch(nullableSample, isNullableEnabled: true).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Test <see cref="TypeSymbolExtensions.IsNullabilityMatchOrRelaxed"/> rejects different underlying types.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void IsNullabilityMatchOrRelaxedReturnsFalseForDifferentUnderlyingTypes()
+    {
+        const string source = """
+                              #nullable enable
+
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              public sealed class Sample
+                              {
+                              }
+
+                              public sealed class OtherSample
+                              {
+                              }
+                              """;
+
+        var compilation = BuildCompilation(source);
+        var sampleType = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.Sample")!;
+        var otherSampleType = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.OtherSample")!;
+
+        sampleType.IsNullabilityMatchOrRelaxed(otherSampleType, isNullableEnabled: true).Should().BeFalse();
+    }
 }

--- a/Mappa.Generator.Tests/TypeSymbolExtensionsTests.cs
+++ b/Mappa.Generator.Tests/TypeSymbolExtensionsTests.cs
@@ -270,4 +270,108 @@ public sealed class TypeSymbolExtensionsTests
         oneParameter.IsMethodValidToMapToTargetSymbolForPolymorphism(sourceType, compilation, mustBeStatic: true, nullableEnabled: true, acceptTwoParameters: false).Should().BeTrue();
         twoParameters.IsMethodValidToMapToTargetSymbolForPolymorphism(sourceType, compilation, mustBeStatic: true, nullableEnabled: true, acceptTwoParameters: false).Should().BeFalse();
     }
+
+    /// <summary>
+    /// Test <see cref="TypeSymbolExtensions.IsRelaxedNullabilityMatch"/> allows the supported nullability mismatches.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void IsRelaxedNullabilityMatchAllowsSupportedMismatches()
+    {
+        const string source = """
+                              #nullable enable
+
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              public sealed class Sample
+                              {
+                              }
+                              """;
+
+        var compilation = BuildCompilation(source);
+        var sampleType = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.Sample")!;
+        var nullableSample = sampleType.WithNullableAnnotation(NullableAnnotation.Annotated);
+        var nonNullableSample = sampleType.WithNullableAnnotation(NullableAnnotation.NotAnnotated);
+
+        nullableSample.IsRelaxedNullabilityMatch(nonNullableSample, isNullableEnabled: true).Should().BeTrue();
+        nonNullableSample.IsRelaxedNullabilityMatch(nullableSample, isNullableEnabled: true).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Test <see cref="TypeSymbolExtensions.IsRelaxedNullabilityMatch"/> rejects unsupported nullability mismatches.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void IsRelaxedNullabilityMatchRejectsUnsupportedMismatches()
+    {
+        const string source = """
+                              #nullable enable
+
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              public sealed class Sample
+                              {
+                              }
+                              """;
+
+        var compilation = BuildCompilation(source);
+        var sampleType = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.Sample")!;
+        var nullableSample = sampleType.WithNullableAnnotation(NullableAnnotation.Annotated);
+        var nonNullableSample = sampleType.WithNullableAnnotation(NullableAnnotation.NotAnnotated);
+
+        nullableSample.IsRelaxedNullabilityMatch(nullableSample, isNullableEnabled: true).Should().BeFalse();
+        nonNullableSample.IsRelaxedNullabilityMatch(nonNullableSample, isNullableEnabled: true).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Test <see cref="TypeSymbolExtensions.IsRelaxedNullabilityMatch"/> is disabled when nullable is disabled.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void IsRelaxedNullabilityMatchReturnsFalseWhenNullableIsDisabled()
+    {
+        const string source = """
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              public sealed class Sample
+                              {
+                              }
+                              """;
+
+        var compilation = BuildCompilation(source);
+        var sampleType = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.Sample")!;
+        var nullableSample = sampleType.WithNullableAnnotation(NullableAnnotation.Annotated);
+        var nonNullableSample = sampleType.WithNullableAnnotation(NullableAnnotation.NotAnnotated);
+
+        nullableSample.IsRelaxedNullabilityMatch(nonNullableSample, isNullableEnabled: false).Should().BeFalse();
+        nonNullableSample.IsRelaxedNullabilityMatch(nullableSample, isNullableEnabled: false).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Test <see cref="TypeSymbolExtensions.IsNullabilityMatchOrRelaxed"/> prefers exact matches and allows relaxed matches.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void IsNullabilityMatchOrRelaxedSupportsExactAndRelaxedMatches()
+    {
+        const string source = """
+                              #nullable enable
+
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              public sealed class Sample
+                              {
+                              }
+                              """;
+
+        var compilation = BuildCompilation(source);
+        var sampleType = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.Sample")!;
+        var nullableSample = sampleType.WithNullableAnnotation(NullableAnnotation.Annotated);
+        var nonNullableSample = sampleType.WithNullableAnnotation(NullableAnnotation.NotAnnotated);
+
+        nonNullableSample.IsNullabilityMatchOrRelaxed(nonNullableSample, isNullableEnabled: true).Should().BeTrue();
+        nullableSample.IsNullabilityMatchOrRelaxed(nullableSample, isNullableEnabled: true).Should().BeTrue();
+        nullableSample.IsNullabilityMatchOrRelaxed(nonNullableSample, isNullableEnabled: true).Should().BeTrue();
+        nonNullableSample.IsNullabilityMatchOrRelaxed(nullableSample, isNullableEnabled: true).Should().BeTrue();
+    }
 }

--- a/Mappa.Generator/Extensions/TypeSymbolExtensions.cs
+++ b/Mappa.Generator/Extensions/TypeSymbolExtensions.cs
@@ -908,6 +908,72 @@ internal static class TypeSymbolExtensions
     }
 
     /// <summary>
+    /// Check if <paramref name="methodType"/> can satisfy a mapping that requires
+    /// <paramref name="requiredType"/> under the relaxed nullability rules.
+    /// </summary>
+    /// <param name="requiredType">The type required by the mapping.</param>
+    /// <param name="methodType">The type from the existing map method.</param>
+    /// <param name="isNullableEnabled"><c>true</c> if nullable is enabled.</param>
+    /// <returns><c>true</c> if the relaxed nullability rule applies.</returns>
+    internal static bool IsRelaxedNullabilityMatch(
+        this ITypeSymbol requiredType,
+        ITypeSymbol methodType,
+        bool isNullableEnabled)
+    {
+        if (!isNullableEnabled)
+        {
+            return false;
+        }
+
+        if (!SymbolEqualityComparer.Default.Equals(requiredType, methodType))
+        {
+            return false;
+        }
+
+        if (requiredType.NullableAnnotation == NullableAnnotation.None
+            || methodType.NullableAnnotation == NullableAnnotation.None)
+        {
+            return false;
+        }
+
+        if (requiredType.NullableAnnotation == NullableAnnotation.Annotated
+            && methodType.NullableAnnotation == NullableAnnotation.NotAnnotated)
+        {
+            return true;
+        }
+
+        if (requiredType.NullableAnnotation == NullableAnnotation.NotAnnotated
+            && methodType.NullableAnnotation == NullableAnnotation.Annotated)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Check if <paramref name="methodType"/> satisfies a mapping that requires
+    /// <paramref name="requiredType"/> with an exact or relaxed nullability match.
+    /// </summary>
+    /// <param name="requiredType">The type required by the mapping.</param>
+    /// <param name="methodType">The type from the existing map method.</param>
+    /// <param name="isNullableEnabled"><c>true</c> if nullable is enabled.</param>
+    /// <returns><c>true</c> if the types match exactly or under relaxed nullability rules.</returns>
+    internal static bool IsNullabilityMatchOrRelaxed(
+        this ITypeSymbol requiredType,
+        ITypeSymbol methodType,
+        bool isNullableEnabled)
+    {
+        if (!SymbolEqualityComparer.Default.Equals(requiredType, methodType))
+        {
+            return false;
+        }
+
+        return requiredType.IsEqualTo(methodType, isNullableEnabled)
+               || requiredType.IsRelaxedNullabilityMatch(methodType, isNullableEnabled);
+    }
+
+    /// <summary>
     /// Check if the type is <c>void</c>.
     /// </summary>
     /// <param name="typeSymbol">The type symbol.</param>

--- a/Mappa.Generator/Models/MapMethod.cs
+++ b/Mappa.Generator/Models/MapMethod.cs
@@ -190,6 +190,26 @@ internal sealed class MapMethod
                && this.SourceType.IsEqualTo(sourceType, includeNullability);
 
     /// <summary>
+    /// Check if the method is map from <paramref name="sourceType"/>
+    /// to <paramref name="targetType"/> using relaxed nullability matching.
+    /// </summary>
+    /// <param name="targetType">The target type.</param>
+    /// <param name="sourceType">The source type.</param>
+    /// <param name="includeNullability"><c>true</c> to include nullability for reference types.</param>
+    /// <returns><c>true</c> if the method is a relaxed map from
+    /// <paramref name="sourceType"/> to <paramref name="targetType"/>.</returns>
+    internal bool IsRelaxedMapFor(ITypeSymbol targetType, ITypeSymbol sourceType, bool includeNullability)
+    {
+        if (!includeNullability)
+        {
+            return false;
+        }
+
+        return targetType.IsNullabilityMatchOrRelaxed(this.TargetType, includeNullability)
+               && sourceType.IsNullabilityMatchOrRelaxed(this.SourceType, includeNullability);
+    }
+
+    /// <summary>
     /// Gets all the attributes of type <typeparamref name="TAttribute"/>
     /// applied to the method.
     /// </summary>

--- a/Mappa.Generator/Models/MappaClassGeneratorContext.cs
+++ b/Mappa.Generator/Models/MappaClassGeneratorContext.cs
@@ -119,6 +119,7 @@ internal sealed class MappaClassGeneratorContext
     /// <param name="nullableEnabled"><c>true</c> if nullable is enabled,<c>false</c> otherwise.</param>
     /// <param name="requireStaticContext"><c>true</c> if the invocation require only method that can invoked in a static context,<c>false</c> otherwise.</param>
     /// <param name="mapMethod">The map method, if it exists.</param>
+    /// <param name="allowRelaxedNullability"><c>true</c> to allow relaxed nullability matching when no exact match exists.</param>
     /// <returns><c>true</c> if the method to map from <paramref name="sourceType"/> to
     /// <paramref name="targetType"/>, <c>false</c> otherwise.</returns>
     internal bool TryGetMethod(
@@ -126,19 +127,26 @@ internal sealed class MappaClassGeneratorContext
         ITypeSymbol sourceType,
         bool nullableEnabled,
         bool requireStaticContext,
-        out MapMethod mapMethod)
+        out MapMethod mapMethod,
+        bool allowRelaxedNullability = true)
     {
-        var foundMethod =
-            this.mapMethods.Find(method =>
-            {
-                // This is to avoid invoking a non-static method in a static context.
-                if (requireStaticContext && !method.CanBeUsedByStaticMethod)
-                {
-                    return false;
-                }
+        var foundMethod = this.FindMatchingMethod(
+            targetType,
+            sourceType,
+            nullableEnabled,
+            requireStaticContext,
+            exactOnly: true);
 
-                return method.IsMapFor(targetType, sourceType, nullableEnabled);
-            });
+        if (foundMethod is null && allowRelaxedNullability)
+        {
+            foundMethod = this.FindMatchingMethod(
+                targetType,
+                sourceType,
+                nullableEnabled,
+                requireStaticContext,
+                exactOnly: false);
+        }
+
         mapMethod = foundMethod!;
         return foundMethod is not null;
     }
@@ -163,70 +171,26 @@ internal sealed class MappaClassGeneratorContext
         IMappaUserSettings mappaUserSettings,
         out MapMethod mapMethod)
     {
-        foreach (var method in this.mapMethods)
+        if (this.TryFindPolymorphicMethod(
+                targetType,
+                sourceType,
+                nullableEnabled,
+                requireStaticContext,
+                mappaUserSettings,
+                exactOnly: true,
+                out mapMethod))
         {
-            // This is to avoid invoking a non-static method in a static context.
-            if (requireStaticContext && !method.CanBeUsedByStaticMethod)
-            {
-                continue;
-            }
-
-            // Only look for methods that have any MappaTypeMappingAttribute.
-            var typeMappingAttributes = method.GetAttributes<MappaTypeMappingAttribute>();
-            if (typeMappingAttributes.Length <= 0)
-            {
-                continue;
-            }
-
-            // Search in the attributes to see if there is a mapping that can be used.
-            foreach (var typeMappingAttribute in typeMappingAttributes)
-            {
-                var attributeSourceType =
-                    this.Compilation.GetTypeByMetadataName(typeMappingAttribute.SourceType.FullName!);
-                var attributeTargetType =
-                    this.Compilation.GetTypeByMetadataName(typeMappingAttribute.TargetType.FullName!);
-
-                var attributeSourceTypeWithNullability = attributeSourceType?.WithNullableAnnotation(method.TargetType.NullableAnnotation);
-                var attributeTargetTypeWithNullability = attributeTargetType?.WithNullableAnnotation(method.TargetType.NullableAnnotation);
-
-                if (attributeSourceTypeWithNullability is not null &&
-                    attributeTargetTypeWithNullability is not null &&
-                    attributeSourceTypeWithNullability.IsEqualTo(sourceType, nullableEnabled) &&
-                    attributeTargetTypeWithNullability.IsEqualTo(targetType, nullableEnabled))
-                {
-                    mapMethod = method;
-                    return true;
-                }
-            }
-
-            // Pick up the MappaTypeMappingDefault only if defined and it specify the behavior MapSourceType.
-            // Not that this will only pick up the setup where the target type is defined.
-            // If the attribute target type is the same as the target type we would not even be here because
-            // the method would be picked up earlier by the non polymorphic version of this.
-            if (mappaUserSettings.PolymorphicMapMethodWithMatchingDefaultAttribute is BooleanSetting.Enable)
-            {
-                var mappaTypeMappingDefaultAttribute = method.GetAttribute<MappaTypeMappingDefaultAttribute>();
-                if (mappaTypeMappingDefaultAttribute is not null &&
-                    mappaTypeMappingDefaultAttribute.Behavior is MappaTypeMappingDefaultBehavior.MapSourceType &&
-                    mappaTypeMappingDefaultAttribute.Type is not null)
-                {
-                    var attributeTargetType =
-                        this.Compilation.GetTypeByMetadataName(mappaTypeMappingDefaultAttribute.Type.FullName!);
-
-                    var attributeTargetTypeWithNullability = attributeTargetType?.WithNullableAnnotation(method.TargetType.NullableAnnotation);
-
-                    if (attributeTargetTypeWithNullability is not null &&
-                        attributeTargetTypeWithNullability.IsEqualTo(targetType, nullableEnabled))
-                    {
-                        mapMethod = method;
-                        return true;
-                    }
-                }
-            }
+            return true;
         }
 
-        mapMethod = null!;
-        return false;
+        return this.TryFindPolymorphicMethod(
+            targetType,
+            sourceType,
+            nullableEnabled,
+            requireStaticContext,
+            mappaUserSettings,
+            exactOnly: false,
+            out mapMethod);
     }
 
     /// <summary>
@@ -242,7 +206,8 @@ internal sealed class MappaClassGeneratorContext
                 mapMethod.SourceType,
                 mapMethod.NullableEnabled,
                 false, // Bypass the require static requirements here since I just want to add it.
-                out _))
+                out _,
+                allowRelaxedNullability: false))
         {
             this.mapMethods.Add(mapMethod);
             return true;
@@ -273,4 +238,154 @@ internal sealed class MappaClassGeneratorContext
     /// <param name="diagnostic">The diagnostic to be added.</param>
     internal void ReportDiagnostic(Diagnostic diagnostic)
         => this.ReportDiagnostics([diagnostic]);
+
+    private static bool TypesMatchForPolymorphicMapping(
+        ITypeSymbol requiredSourceType,
+        ITypeSymbol attributeSourceType,
+        ITypeSymbol requiredTargetType,
+        ITypeSymbol attributeTargetType,
+        bool nullableEnabled,
+        bool exactOnly)
+    {
+        if (exactOnly)
+        {
+            return attributeSourceType.IsEqualTo(requiredSourceType, nullableEnabled)
+                   && attributeTargetType.IsEqualTo(requiredTargetType, nullableEnabled);
+        }
+
+        return requiredSourceType.IsNullabilityMatchOrRelaxed(attributeSourceType, nullableEnabled)
+               && requiredTargetType.IsNullabilityMatchOrRelaxed(attributeTargetType, nullableEnabled);
+    }
+
+    private MapMethod? FindMatchingMethod(
+        ITypeSymbol targetType,
+        ITypeSymbol sourceType,
+        bool nullableEnabled,
+        bool requireStaticContext,
+        bool exactOnly)
+    {
+        return this.mapMethods.Find(method =>
+        {
+            if (requireStaticContext && !method.CanBeUsedByStaticMethod)
+            {
+                return false;
+            }
+
+            return exactOnly
+                ? method.IsMapFor(targetType, sourceType, nullableEnabled)
+                : method.IsRelaxedMapFor(targetType, sourceType, nullableEnabled);
+        });
+    }
+
+    private bool TryFindPolymorphicMethod(
+        ITypeSymbol targetType,
+        ITypeSymbol sourceType,
+        bool nullableEnabled,
+        bool requireStaticContext,
+        IMappaUserSettings mappaUserSettings,
+        bool exactOnly,
+        out MapMethod mapMethod)
+    {
+        foreach (var method in this.mapMethods)
+        {
+            if (requireStaticContext && !method.CanBeUsedByStaticMethod)
+            {
+                continue;
+            }
+
+            var typeMappingAttributes = method.GetAttributes<MappaTypeMappingAttribute>();
+            if (typeMappingAttributes.Length <= 0)
+            {
+                continue;
+            }
+
+            if (typeMappingAttributes.Any(typeMappingAttribute =>
+                    this.TryMatchPolymorphicTypeMappingAttribute(
+                        method,
+                        typeMappingAttribute,
+                        targetType,
+                        sourceType,
+                        nullableEnabled,
+                        exactOnly)))
+            {
+                mapMethod = method;
+                return true;
+            }
+
+            if (mappaUserSettings.PolymorphicMapMethodWithMatchingDefaultAttribute is BooleanSetting.Enable
+                && this.TryMatchPolymorphicTypeMappingDefaultAttribute(
+                    method,
+                    targetType,
+                    nullableEnabled,
+                    exactOnly))
+            {
+                mapMethod = method;
+                return true;
+            }
+        }
+
+        mapMethod = null!;
+        return false;
+    }
+
+    private bool TryMatchPolymorphicTypeMappingAttribute(
+        MapMethod method,
+        MappaTypeMappingAttribute typeMappingAttribute,
+        ITypeSymbol targetType,
+        ITypeSymbol sourceType,
+        bool nullableEnabled,
+        bool exactOnly)
+    {
+        var attributeSourceType =
+            this.Compilation.GetTypeByMetadataName(typeMappingAttribute.SourceType.FullName!);
+        var attributeTargetType =
+            this.Compilation.GetTypeByMetadataName(typeMappingAttribute.TargetType.FullName!);
+
+        var attributeSourceTypeWithNullability =
+            attributeSourceType?.WithNullableAnnotation(method.TargetType.NullableAnnotation);
+        var attributeTargetTypeWithNullability =
+            attributeTargetType?.WithNullableAnnotation(method.TargetType.NullableAnnotation);
+
+        if (attributeSourceTypeWithNullability is null || attributeTargetTypeWithNullability is null)
+        {
+            return false;
+        }
+
+        return TypesMatchForPolymorphicMapping(
+            sourceType,
+            attributeSourceTypeWithNullability,
+            targetType,
+            attributeTargetTypeWithNullability,
+            nullableEnabled,
+            exactOnly);
+    }
+
+    private bool TryMatchPolymorphicTypeMappingDefaultAttribute(
+        MapMethod method,
+        ITypeSymbol targetType,
+        bool nullableEnabled,
+        bool exactOnly)
+    {
+        var mappaTypeMappingDefaultAttribute = method.GetAttribute<MappaTypeMappingDefaultAttribute>();
+        if (mappaTypeMappingDefaultAttribute is null
+            || mappaTypeMappingDefaultAttribute.Behavior is not MappaTypeMappingDefaultBehavior.MapSourceType
+            || mappaTypeMappingDefaultAttribute.Type is null)
+        {
+            return false;
+        }
+
+        var attributeTargetType =
+            this.Compilation.GetTypeByMetadataName(mappaTypeMappingDefaultAttribute.Type.FullName!);
+        var attributeTargetTypeWithNullability =
+            attributeTargetType?.WithNullableAnnotation(method.TargetType.NullableAnnotation);
+
+        if (attributeTargetTypeWithNullability is null)
+        {
+            return false;
+        }
+
+        return exactOnly
+            ? attributeTargetTypeWithNullability.IsEqualTo(targetType, nullableEnabled)
+            : targetType.IsNullabilityMatchOrRelaxed(attributeTargetTypeWithNullability, nullableEnabled);
+    }
 }

--- a/Mappa.Generator/README.md
+++ b/Mappa.Generator/README.md
@@ -52,7 +52,8 @@ Before the detector chain, `TypeMapIdentifierWithMapMethodAlgorithm` checks whet
     - The existing method is invoked;
 - _Notes_:
     - A nested mapper method that requires `MappaContext` is only invoked when the caller provides context (the root map method has a `MappaContext` parameter);
-    - This pre-step is used when mapping elements of an array, keys or values of dictionaries, elements of tuples, and properties or constructor parameters of class/struct/record types.
+    - This pre-step is used when mapping elements of an array, keys or values of dictionaries, elements of tuples, and properties or constructor parameters of class/struct/record types;
+    - When `#nullable enable` is active, nullability annotations must match exactly first. If no exact match exists, the generator may reuse a method with a relaxed nullability signature on the same underlying types: nested mapping to `TTarget?` may invoke a method returning `TTarget`, and nested mapping from `TSource` may invoke a method accepting `TSource?`.
 
 ### Detector chain order
 

--- a/Mappa.Samples.Aot/Program.cs
+++ b/Mappa.Samples.Aot/Program.cs
@@ -67,6 +67,7 @@ internal static class Program
         ProtobufOptionalMapperRunner.Run(report);
         ReadOnlyTargetCollectionMapperRunner.Run(report);
         ReferenceNullableToReferenceNullableMapperRunner.Run(report);
+        RelaxedNullabilityMethodMapMapperRunner.Run(report);
         ReferenceToReferenceWithNullableDisabledMapperRunner.Run(report);
         StringToEnumMapperRunner.Run(report);
         StringToSystemEntitiesMapperRunner.Run(report);

--- a/Mappa.Samples.Aot/Runners/RelaxedNullabilityMethodMapMapperRunner.cs
+++ b/Mappa.Samples.Aot/Runners/RelaxedNullabilityMethodMapMapperRunner.cs
@@ -1,0 +1,46 @@
+// <copyright file="RelaxedNullabilityMethodMapMapperRunner.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using Mappa.Samples;
+
+namespace Mappa.Samples.Aot.Runners;
+
+/// <summary>
+/// AOT runner for relaxed nullability method map sample classes.
+/// </summary>
+internal static class RelaxedNullabilityMethodMapMapperRunner
+{
+    /// <summary>
+    /// Runs all map methods on the relaxed nullability method map sample classes.
+    /// </summary>
+    /// <param name="report">The AOT report.</param>
+    public static void Run(AotReport report)
+    {
+        var source = new RelaxedNullabilitySource
+        {
+            Inner = new RelaxedNullabilityInnerSource
+            {
+                Value = 42,
+            },
+        };
+
+        report.BeginMapper(nameof(RelaxedNullabilityMethodMapMapper));
+        var returnRelaxationMapper = new RelaxedNullabilityMethodMapMapper();
+        report.RecordInvocation(
+            nameof(RelaxedNullabilityMethodMapMapper.Map),
+            nameof(RelaxedNullabilitySource),
+            nameof(RelaxedNullabilityTarget),
+            source,
+            returnRelaxationMapper.Map(source));
+
+        report.BeginMapper(nameof(RelaxedNullabilityMethodMapWithNullableParameterMapper));
+        var parameterRelaxationMapper = new RelaxedNullabilityMethodMapWithNullableParameterMapper();
+        report.RecordInvocation(
+            nameof(RelaxedNullabilityMethodMapWithNullableParameterMapper.Map),
+            nameof(RelaxedNullabilitySource),
+            nameof(RelaxedNullabilityTargetWithRequiredInner),
+            source,
+            parameterRelaxationMapper.Map(source));
+    }
+}

--- a/Mappa.Samples/RelaxedNullabilityMethodMapMapper.cs
+++ b/Mappa.Samples/RelaxedNullabilityMethodMapMapper.cs
@@ -1,0 +1,144 @@
+// <copyright file="RelaxedNullabilityMethodMapMapper.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using Mappa.Attributes;
+
+namespace Mappa.Samples;
+
+#pragma warning disable SA1402
+
+/// <summary>
+/// Mapper that reuses an existing non-nullable map method when the nested mapping requires a nullable target type.
+/// </summary>
+[Mappa]
+public sealed partial class RelaxedNullabilityMethodMapMapper
+{
+    private readonly int valueOffset;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RelaxedNullabilityMethodMapMapper"/> class.
+    /// </summary>
+    /// <param name="valueOffset">An optional offset applied to mapped values.</param>
+    public RelaxedNullabilityMethodMapMapper(int valueOffset = 0)
+    {
+        this.valueOffset = valueOffset;
+    }
+
+    /// <summary>
+    /// Map from <see cref="RelaxedNullabilityInnerSource"/> to <see cref="RelaxedNullabilityInnerTarget"/>.
+    /// </summary>
+    /// <param name="input">The source inner model.</param>
+    /// <returns>The mapped inner target.</returns>
+    public RelaxedNullabilityInnerTarget Map(RelaxedNullabilityInnerSource input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+
+        return new RelaxedNullabilityInnerTarget
+        {
+            Value = input.Value + this.valueOffset,
+        };
+    }
+
+    /// <summary>
+    /// Map from <see cref="RelaxedNullabilitySource"/> to <see cref="RelaxedNullabilityTarget"/>.
+    /// </summary>
+    /// <param name="input">The source model.</param>
+    /// <returns>The target model.</returns>
+    public partial RelaxedNullabilityTarget Map(RelaxedNullabilitySource input);
+}
+
+/// <summary>
+/// Mapper that reuses an existing method accepting a nullable source parameter when the nested mapping uses a non-nullable source type.
+/// </summary>
+[Mappa]
+public sealed partial class RelaxedNullabilityMethodMapWithNullableParameterMapper
+{
+    private readonly int valueOffset;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RelaxedNullabilityMethodMapWithNullableParameterMapper"/> class.
+    /// </summary>
+    /// <param name="valueOffset">An optional offset applied to mapped values.</param>
+    public RelaxedNullabilityMethodMapWithNullableParameterMapper(int valueOffset = 0)
+    {
+        this.valueOffset = valueOffset;
+    }
+
+    /// <summary>
+    /// Map from <see cref="RelaxedNullabilityInnerSource"/> to <see cref="RelaxedNullabilityInnerTarget"/>.
+    /// </summary>
+    /// <param name="input">The source inner model.</param>
+    /// <returns>The mapped inner target.</returns>
+    public RelaxedNullabilityInnerTarget Map(RelaxedNullabilityInnerSource? input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+
+        return new RelaxedNullabilityInnerTarget
+        {
+            Value = input.Value + this.valueOffset,
+        };
+    }
+
+    /// <summary>
+    /// Map from <see cref="RelaxedNullabilitySource"/> to <see cref="RelaxedNullabilityTargetWithRequiredInner"/>.
+    /// </summary>
+    /// <param name="input">The source model.</param>
+    /// <returns>The target model.</returns>
+    public partial RelaxedNullabilityTargetWithRequiredInner Map(RelaxedNullabilitySource input);
+}
+
+/// <summary>
+/// Inner source model for <see cref="RelaxedNullabilityMethodMapMapper"/>.
+/// </summary>
+public sealed class RelaxedNullabilityInnerSource
+{
+    /// <summary>
+    /// Gets or sets the value.
+    /// </summary>
+    public int Value { get; set; }
+}
+
+/// <summary>
+/// Inner target model for <see cref="RelaxedNullabilityMethodMapMapper"/>.
+/// </summary>
+public sealed class RelaxedNullabilityInnerTarget
+{
+    /// <summary>
+    /// Gets or sets the value.
+    /// </summary>
+    public int Value { get; set; }
+}
+
+/// <summary>
+/// Source model with a non-nullable inner property.
+/// </summary>
+public sealed class RelaxedNullabilitySource
+{
+    /// <summary>
+    /// Gets or sets the inner model.
+    /// </summary>
+    public RelaxedNullabilityInnerSource Inner { get; set; } = new();
+}
+
+/// <summary>
+/// Target model with a nullable inner property.
+/// </summary>
+public sealed class RelaxedNullabilityTarget
+{
+    /// <summary>
+    /// Gets or sets the inner model.
+    /// </summary>
+    public RelaxedNullabilityInnerTarget? Inner { get; set; }
+}
+
+/// <summary>
+/// Target model with a non-nullable inner property.
+/// </summary>
+public sealed class RelaxedNullabilityTargetWithRequiredInner
+{
+    /// <summary>
+    /// Gets or sets the inner model.
+    /// </summary>
+    public required RelaxedNullabilityInnerTarget Inner { get; set; }
+}

--- a/MappaVersion.targets
+++ b/MappaVersion.targets
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <MappaVersion>10.1.0</MappaVersion>
+        <MappaVersion>10.2.0-alpha.1</MappaVersion>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

- Add a two-pass exact-then-relaxed nullability match when resolving existing map methods and polymorphic partial methods, so mappings requiring `T?` can use methods returning `T` and mappings requiring `T` can use methods accepting `T?`.
- Add unit and integration tests, including coverage for edge cases (different types, oblivious annotations, unresolvable polymorphic attribute types).
- Add sample, AOT runner, and documentation; bump version to `10.2.0-alpha.1`.
- Update the development workflow rule to require a coverage baseline before starting work and to prevent coverage regressions.

## Test plan

- [x] `.\Scripts\RunTestsAndReportCoverage.ps1` passes (2305 tests)
- [x] Relaxed return and parameter nullability matching for standard map methods
- [x] Exact match preferred over relaxed match when both exist
- [x] Polymorphic partial methods with relaxed nullability on method signature and default-attribute matching
- [x] Coverage edge-case unit tests for `IsRelaxedNullabilityMatch` and `MappaClassGeneratorContext`

Made with [Cursor](https://cursor.com)