### PR TITLE
#275 Flattening/unflattening follow-up

### DIFF
--- a/.cursor/rules/mappa-development-workflow.mdc
+++ b/.cursor/rules/mappa-development-workflow.mdc
@@ -1,5 +1,5 @@
 ---
-description: Mappa development workflow — planning, code, code coverage, git, versioning, tests, and samples
+description: Mappa development workflow — planning, code, code coverage, git, pull requests, versioning, tests, and samples
 alwaysApply: true
 ---
 
@@ -72,6 +72,13 @@ The development environment uses **PowerShell**. All commands run in the termina
 - When committing, do **not** use `cat` or heredoc syntax (PowerShell does not support bash heredocs). Use `git commit -m` for the subject and body, and `--trailer` for any trailers (e.g. `git commit -m "#123 Subject." -m "Body paragraph." --trailer "Co-authored-by: Name <email@example.com>"`).
 - Do not query GitHub to read the issue provided, unless instructed.
 - Before finishing work for a GitHub issue, remove any TODOs related to that issue. If no GitHub issue was provided, ask the user for one.
+
+## Pull Requests
+
+- When creating a pull request for a GitHub issue, **also upload the plan** used for that work to the **original GitHub issue** (not only the PR description).
+- Post the plan as an issue comment with `gh issue comment <number>` after the PR exists (so the comment can include the PR URL).
+- Include: a short heading (e.g. `## Implementation plan`), a link to the PR, and the full contents of the plan file under `.cursor/plans/` (e.g. `issue_<number>_*.plan.md`). Prefer `--body-file` with a temporary markdown file built in PowerShell rather than bash heredocs.
+- If no issue number is known when creating the PR, ask the user for one before posting the plan.
 
 ## Versioning
 

--- a/Documentation/mappa-attributes.md
+++ b/Documentation/mappa-attributes.md
@@ -50,7 +50,13 @@ Attributes that accept `TargetPropertyName` and/or `SourcePropertyName` support 
 
 - May be longer than the target path, but must not be shorter (segment count). A shorter source path reports error **MP00043**.
 - Every source segment must exist on the resolved source type. A missing segment reports error **MP00044**.
-- At the leaf target member, the generator emits a chained source read. With `#nullable disable`, reference types and `Nullable<T>` use `?.`. With `#nullable enable`, only annotated nullable references and `Nullable<T>` use `?.`; otherwise `.` is used. When the target member cannot be null, the chain may append `?? throw new System.NullReferenceException("...")` with the full dotted path.
+- At the leaf target member, the generator emits a chained source read from the current nested source receiver (reusing intermediate temps when present).
+- Conditional access (`?.` vs `.`) is chosen from the **receiver** type at each step: with `#nullable disable`, reference types and `Nullable<T>` use `?.`; with `#nullable enable`, only annotated nullable references and `Nullable<T>` use `?.`; otherwise `.` is used.
+- The chain appends `?? throw new System.NullReferenceException("...")` (with the original attribute source path) only when the access expression can be null (any `?.` was used, or the leaf type is nullable-capable) **and** the target member cannot be null. Plain non-nullable value-type leaves (for example `int`) never get `?? throw`.
+
+**Combining attributes under the same root**
+
+- Nested `[MappaIgnoreTargetProperty]` under a shared root with `[MappaUseProperty]` (or other nested attributes) is honoured: ignored sibling members are omitted from the nested object initializer.
 
 See also: [Mappa generator algorithm — nested property paths](./mappa-generator-algorithm.md#nested-property-paths), [tutorial](./tutorial.md#nested-property-paths), and [NestedPropertyPathAttributeMapper.cs](../Mappa.Samples/NestedPropertyPathAttributeMapper.cs).
 
@@ -60,7 +66,7 @@ When mapping structured types, Mappa pairs source and target members by name. `[
 
 ## MappaIgnoreTargetProperty
 
-When mapping via an empty constructor, Mappa assigns each target property with an accessible setter from the corresponding source property. `[MappaIgnoreTargetProperty]` excludes a target property from this mapping. It has no effect when the target is constructed via a constructor with parameters. `TargetPropertyName` supports [nested property paths](#nested-property-paths).
+When mapping via an empty constructor, Mappa assigns each target property with an accessible setter from the corresponding source property. `[MappaIgnoreTargetProperty]` excludes a target property from this mapping. It has no effect when the target is constructed via a constructor with parameters. `TargetPropertyName` supports [nested property paths](#nested-property-paths). A nested ignore under the same root as a nested `[MappaUseProperty]` (for example ignore `Address.ZipCode` while mapping `Address.City`) is applied to that sibling member.
 
 ## MappaAssignFromConstant
 
@@ -72,7 +78,7 @@ When mapping via an empty constructor, Mappa assigns each target property with a
 
 ## MappaAssignToContext
 
-`[MappaAssignToContext]` stores the mapped value of a target property or field into `MappaContext` after the target object has been fully constructed. The map method must accept `MappaContext` as its second parameter. Each context key must be unique within a method. `TargetPropertyName` supports [nested property paths](#nested-property-paths).
+`[MappaAssignToContext]` stores the mapped value of a target property or field into `MappaContext` after the target object has been fully constructed. The map method must accept `MappaContext` as its second parameter. Each context key must be unique within a method. `TargetPropertyName` supports [nested property paths](#nested-property-paths). For a nested path such as `"Address.City"`, the generator still maps the parent `Address` as part of building the result, then writes the leaf from the constructed object (for example `context[key] = result.Address.City`).
 
 ## MappaInvokeMethodAttribute
 

--- a/Documentation/mappa-generator-algorithm.md
+++ b/Documentation/mappa-generator-algorithm.md
@@ -280,7 +280,10 @@ flowchart TD
 
 - A `PropertyPathContext` carries the remaining target and source segments while nested constructor mapping runs with attributes still enabled for path-filtered matching.
 - Multi-segment target paths apply at the first segment; remaining segments are resolved on the nested type.
-- At the leaf target member, remaining source segments become a chained read (`?.` / `.` per nullability rules). When the target cannot be null, the generator may append `?? throw new System.NullReferenceException("...")`.
+- When multiple nested attributes share the same outer target member (for example `[MappaUseProperty("Address.City", ...)]` with `[MappaIgnoreTargetProperty("Address.ZipCode")]`), mapping uses a nested attribute scope so sibling ignore/constant/context attributes apply correctly.
+- At the leaf target member, remaining source segments are read from the **current nested source receiver** (reusing intermediate temps) as a chained access. Conditional access (`?.` vs `.`) is chosen from the **receiver** type at each step (`#nullable disable`: references and `Nullable<T>` use `?.`; `#nullable enable`: only annotated nullable references and `Nullable<T>`).
+- `?? throw new System.NullReferenceException("...")` is appended only when the access expression can be null (any `?.` was used, or the leaf type is nullable-capable) **and** the target cannot be null. Non-nullable value-type leaves such as `int` never receive `?? throw`.
+- `[MappaAssignToContext]` with a nested target path writes the leaf from the fully constructed result (for example `context[key] = result.Address.City`) after the parent object graph has been mapped.
 - Invalid target paths report **MP00033**. A source path shorter than the target path reports **MP00043**. A missing source segment reports **MP00044**.
 
 ## Limitations

--- a/Documentation/tutorial.md
+++ b/Documentation/tutorial.md
@@ -430,7 +430,7 @@ public sealed partial class Mapper
 }
 ```
 
-The same path syntax works on `[MappaInvokeMethod]`, `[MappaAssignFromConstant]`, `[MappaAssignFromContext]`, `[MappaAssignToContext]`, and `[MappaIgnoreTargetProperty]`. The generator trims paths while mapping nested types and emits chained source reads with `?.` / `.` according to nullability rules.
+The same path syntax works on `[MappaInvokeMethod]`, `[MappaAssignFromConstant]`, `[MappaAssignFromContext]`, `[MappaAssignToContext]`, and `[MappaIgnoreTargetProperty]`. The generator trims paths while mapping nested types, reuses nested source receivers for leaf chains, and emits `?.` / `.` from each receiver's nullability. `?? throw` is added only when the chain can be null and the target cannot. Nested `[MappaAssignToContext]` stores the leaf from the constructed result (for example `result.Address.City`).
 
 See also: [Mappa attributes — Nested property paths](./mappa-attributes.md#nested-property-paths), [algorithm](./mappa-generator-algorithm.md#nested-property-paths), and [NestedPropertyPathAttributeMapper.cs](../Mappa.Samples/NestedPropertyPathAttributeMapper.cs).
 

--- a/Mappa.Generator.Tests/NestedPropertyPathAttributeIntegrationTests.Diagnostics.cs
+++ b/Mappa.Generator.Tests/NestedPropertyPathAttributeIntegrationTests.Diagnostics.cs
@@ -317,5 +317,7 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
             .NotHaveDiagnostics()
             .HaveGeneratedSourceCode();
         generatedSource.Should().Contain(".City");
+        generatedSource.Should().NotContain(".ZipCode");
+        generatedSource.Should().NotContain("ZipCode =");
     }
 }

--- a/Mappa.Generator.Tests/NestedPropertyPathAttributeIntegrationTests.MappaUseProperty.cs
+++ b/Mappa.Generator.Tests/NestedPropertyPathAttributeIntegrationTests.MappaUseProperty.cs
@@ -106,8 +106,8 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
         generatedResults.Should()
             .NotHaveDiagnostics()
             .HaveGeneratedSourceCode();
-        generatedSource.Should().Contain("input.Location?.Address");
-        generatedSource.Should().Contain(".City");
+        generatedSource.Should().Contain("input.Location");
+        generatedSource.Should().Contain(".Address?.City");
         generatedSource.Should().Contain("throw new System.NullReferenceException");
     }
 

--- a/Mappa.Generator.Tests/NestedPropertyPathAttributeIntegrationTests.Nullability.cs
+++ b/Mappa.Generator.Tests/NestedPropertyPathAttributeIntegrationTests.Nullability.cs
@@ -322,4 +322,53 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
         generatedSource.Should().Contain(".Metrics.Score");
         generatedSource.Should().NotContain("?? throw");
     }
+
+    /// <summary>
+    /// Test a non-nullable reference chain ending in <see cref="Nullable{T}"/> appends <c>?? throw</c> for a non-nullable target.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    [IntegrationTest]
+    public async Task CanMapChainedSourcePathWithNullableValueTypeLeafOntoNonNullableTarget()
+    {
+        const string sourceCode = """
+                                  #nullable enable
+                                  using Mappa.Attributes;
+
+                                  namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                  public class Outer
+                                  {
+                                      public int? Code { get; set; }
+                                  }
+
+                                  public class Source
+                                  {
+                                      public Outer Outer { get; set; } = null!;
+                                  }
+
+                                  public class Target
+                                  {
+                                      public int Code { get; set; }
+                                  }
+
+                                  [Mappa]
+                                  public sealed partial class Mapper
+                                  {
+                                      [MappaUseProperty(nameof(Target.Code), "Outer.Code")]
+                                      public partial Target Map(Source input);
+                                  }
+                                  #nullable restore
+                                  """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+        var generatedSource = GetGeneratedMapperSource(generatedResults);
+
+        generatedResults.Should()
+            .NotHaveDiagnostics()
+            .HaveGeneratedSourceCode();
+        generatedSource.Should().Contain("input.Outer.Code");
+        generatedSource.Should().Contain("?? throw");
+        generatedSource.Should().NotContain("?.Code");
+    }
 }

--- a/Mappa.Generator.Tests/NestedPropertyPathAttributeIntegrationTests.Nullability.cs
+++ b/Mappa.Generator.Tests/NestedPropertyPathAttributeIntegrationTests.Nullability.cs
@@ -60,7 +60,8 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
         generatedResults.Should()
             .NotHaveDiagnostics()
             .HaveGeneratedSourceCode();
-        generatedSource.Should().Contain("input.Location?.Address?.City");
+        generatedSource.Should().Contain("input.Location");
+        generatedSource.Should().Contain(".Address?.City");
     }
 
     /// <summary>
@@ -69,7 +70,7 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
     /// <returns>The async task.</returns>
     [Fact]
     [IntegrationTest]
-    public async Task CanMapChainedSourcePathWithNullableDisableUsingDotAccess()
+    public async Task CanMapChainedSourcePathWithNullableDisableUsingConditionalAccess()
     {
         const string sourceCode = """
                                   #nullable disable
@@ -112,7 +113,8 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
         generatedResults.Should()
             .NotHaveDiagnostics()
             .HaveGeneratedSourceCode();
-        generatedSource.Should().Contain("input.Location?.Address?.City");
+        generatedSource.Should().Contain(".Location");
+        generatedSource.Should().Contain("?.Address?.City");
     }
 
     /// <summary>
@@ -136,18 +138,18 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
 
                                   public class Source
                                   {
-                                      public Outer Outer { get; set; } = null!;
+                                      public Outer? Outer { get; set; }
                                   }
 
                                   public class Target
                                   {
-                                      public Outer Outer { get; set; } = null!;
+                                      public int? Code { get; set; }
                                   }
 
                                   [Mappa]
                                   public sealed partial class Mapper
                                   {
-                                      [MappaUseProperty("Outer.Code", "Outer.Code")]
+                                      [MappaUseProperty(nameof(Target.Code), "Outer.Code")]
                                       public partial Target Map(Source input);
                                   }
                                   #nullable restore
@@ -160,6 +162,7 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
             .NotHaveDiagnostics()
             .HaveGeneratedSourceCode();
         generatedSource.Should().Contain("input.Outer?.Code");
+        generatedSource.Should().NotContain("?? throw");
     }
 
     /// <summary>
@@ -206,7 +209,117 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
         generatedResults.Should()
             .NotHaveDiagnostics()
             .HaveGeneratedSourceCode();
-        generatedSource.Should().Contain("input.Outer.Code");
-        generatedSource.Should().NotContain("input.Outer?.Code");
+        generatedSource.Should().Contain(".Code");
+        generatedSource.Should().NotContain("?.Code");
+        generatedSource.Should().NotContain("?? throw");
+    }
+
+    /// <summary>
+    /// Test mixed nullable and non-nullable reference segments under <c>#nullable enable</c>.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    [IntegrationTest]
+    public async Task CanMapChainedSourcePathWithMixedNullableAndNonNullableReferences()
+    {
+        const string sourceCode = """
+                                  #nullable enable
+                                  using Mappa.Attributes;
+
+                                  namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                  public class AddressDto
+                                  {
+                                      public string City { get; set; } = null!;
+                                  }
+
+                                  public class LocationDto
+                                  {
+                                      public AddressDto? Address { get; set; }
+                                  }
+
+                                  public class Source
+                                  {
+                                      public LocationDto Location { get; set; } = null!;
+                                  }
+
+                                  public class Target
+                                  {
+                                      public AddressDto Address { get; set; } = null!;
+                                  }
+
+                                  [Mappa]
+                                  public sealed partial class Mapper
+                                  {
+                                      [MappaUseProperty("Address.City", "Location.Address.City")]
+                                      public partial Target Map(Source input);
+                                  }
+                                  #nullable restore
+                                  """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+        var generatedSource = GetGeneratedMapperSource(generatedResults);
+
+        generatedResults.Should()
+            .NotHaveDiagnostics()
+            .HaveGeneratedSourceCode();
+        generatedSource.Should().Contain("input.Location");
+        generatedSource.Should().Contain(".Address?.City");
+        generatedSource.Should().Contain("?? throw");
+        generatedSource.Should().NotContain("Location?.Address");
+    }
+
+    /// <summary>
+    /// Test mixed reference, value type, and <see cref="Nullable{T}"/> segments under <c>#nullable enable</c>.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    [IntegrationTest]
+    public async Task CanMapChainedSourcePathWithMixedReferencesValueTypesAndNullableValueTypes()
+    {
+        const string sourceCode = """
+                                  #nullable enable
+                                  using Mappa.Attributes;
+
+                                  namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                  public struct Metrics
+                                  {
+                                      public int? Score { get; set; }
+                                  }
+
+                                  public class Container
+                                  {
+                                      public Metrics Metrics { get; set; }
+                                  }
+
+                                  public class Source
+                                  {
+                                      public Container? Container { get; set; }
+                                  }
+
+                                  public class Target
+                                  {
+                                      public Metrics Metrics { get; set; }
+                                  }
+
+                                  [Mappa]
+                                  public sealed partial class Mapper
+                                  {
+                                      [MappaUseProperty("Metrics.Score", "Container.Metrics.Score")]
+                                      public partial Target Map(Source input);
+                                  }
+                                  #nullable restore
+                                  """;
+
+        var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+        var generatedSource = GetGeneratedMapperSource(generatedResults);
+
+        generatedResults.Should()
+            .NotHaveDiagnostics()
+            .HaveGeneratedSourceCode();
+        generatedSource.Should().Contain("input.Container");
+        generatedSource.Should().Contain(".Metrics.Score");
+        generatedSource.Should().NotContain("?? throw");
     }
 }

--- a/Mappa.Generator.Tests/NestedPropertyPathAttributeIntegrationTests.OtherAttributes.cs
+++ b/Mappa.Generator.Tests/NestedPropertyPathAttributeIntegrationTests.OtherAttributes.cs
@@ -109,8 +109,8 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
         generatedResults.Should()
             .NotHaveDiagnostics()
             .HaveGeneratedSourceCode();
-        generatedSource.Should().Contain("input?.Location?.Address");
-        generatedSource.Should().Contain(".City");
+        generatedSource.Should().Contain("input.Location?.Address?.City");
+        generatedSource.Should().Contain("throw new System.NullReferenceException");
     }
 
     /// <summary>
@@ -146,17 +146,20 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
                                   [Mappa]
                                   public sealed partial class Mapper
                                   {
-                                      [MappaAssignFromConstant("Address.City", "\"London\"")]
+                                      [MappaAssignFromConstant("Address.City", "London")]
                                       public partial Target Map(Source input, MappaContext context);
                                   }
                                   #nullable restore
                                   """;
 
         var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+        var generatedSource = GetGeneratedMapperSource(generatedResults);
 
         generatedResults.Should()
             .NotHaveDiagnostics()
             .HaveGeneratedSourceCode();
+        generatedSource.Should().Contain("= \"London\"");
+        generatedSource.Should().NotContain("\\\"London\\\"");
     }
 
     /// <summary>
@@ -199,10 +202,13 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
                                   """;
 
         var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+        var generatedSource = GetGeneratedMapperSource(generatedResults);
 
         generatedResults.Should()
             .NotHaveDiagnostics()
             .HaveGeneratedSourceCode();
+        generatedSource.Should().Contain("context[\"city\"]");
+        generatedSource.Should().NotContain(".City;");
     }
 
     /// <summary>

--- a/Mappa.Generator.Tests/PropertyPathSymbolResolverAndExpressionBuilderTests.cs
+++ b/Mappa.Generator.Tests/PropertyPathSymbolResolverAndExpressionBuilderTests.cs
@@ -179,6 +179,62 @@ public sealed class PropertyPathSymbolResolverAndExpressionBuilderTests
         resolvedValueType.Should().HaveCount(2);
         valueTypeAccess.Should().Contain(".Code");
         valueTypeAccess.Should().NotContain("?.Code");
+        valueTypeAccess.Should().NotContain("?? throw");
+    }
+
+    /// <summary>
+    /// Test <see cref="PropertyPathExpressionBuilder.BuildChainedAccessExpression"/> appends
+    /// <c>?? throw</c> only when conditional access makes the expression nullable-capable.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void BuildChainedAccessExpressionAppendsNullForgivingThrowOnlyWhenExpressionCanBeNull()
+    {
+        var compilation = BuildCompilation("""
+                                           #nullable enable
+                                           namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                           public class Address
+                                           {
+                                               public string City { get; set; } = null!;
+                                           }
+
+                                           public class Location
+                                           {
+                                               public Address? Address { get; set; }
+                                           }
+
+                                           public class Source
+                                           {
+                                               public Location Location { get; set; } = null!;
+                                           }
+                                           """);
+        var sourceType = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.Source")!;
+        var addressType = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.Address")!;
+        var cityProperty = addressType.GetMembers("City").OfType<IPropertySymbol>().Single();
+        var locationType = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.Location")!;
+
+        var nullableIntermediate = PropertyPathExpressionBuilder.BuildChainedAccessExpression(
+            "input",
+            "input",
+            ["Location", "Address", "City"],
+            sourceType,
+            nullableEnabled: true,
+            cityProperty.Type,
+            out _);
+        nullableIntermediate.Should().Contain("Location.Address?.City");
+        nullableIntermediate.Should().Contain("?? throw");
+
+        var nonNullableChain = PropertyPathExpressionBuilder.BuildChainedAccessExpression(
+            "input",
+            "input",
+            ["Location"],
+            sourceType,
+            nullableEnabled: true,
+            locationType,
+            out _);
+        nonNullableChain.Should().Be("input.Location");
+        nonNullableChain.Should().NotContain("?? throw");
     }
 
     /// <summary>

--- a/Mappa.Generator.Tests/PropertyPathSymbolResolverAndExpressionBuilderTests.cs
+++ b/Mappa.Generator.Tests/PropertyPathSymbolResolverAndExpressionBuilderTests.cs
@@ -238,6 +238,45 @@ public sealed class PropertyPathSymbolResolverAndExpressionBuilderTests
     }
 
     /// <summary>
+    /// Test <see cref="PropertyPathExpressionBuilder.BuildChainedAccessExpression"/> treats
+    /// <see cref="Nullable{T}"/> leaves as nullable-capable without prior conditional access.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void BuildChainedAccessExpressionTreatsNullableValueTypeLeafAsNullableCapable()
+    {
+        var compilation = BuildCompilation("""
+                                           #nullable enable
+                                           namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                           public class Outer
+                                           {
+                                               public int? Code { get; set; }
+                                           }
+
+                                           public class Source
+                                           {
+                                               public Outer Outer { get; set; } = null!;
+                                           }
+                                           """);
+        var sourceType = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.Source")!;
+        var intType = compilation.GetSpecialType(SpecialType.System_Int32);
+
+        var nullableValueLeaf = PropertyPathExpressionBuilder.BuildChainedAccessExpression(
+            "input",
+            "input",
+            ["Outer", "Code"],
+            sourceType,
+            nullableEnabled: true,
+            intType,
+            out var resolved);
+        resolved.Should().HaveCount(2);
+        nullableValueLeaf.Should().Contain("input.Outer.Code");
+        nullableValueLeaf.Should().NotContain("?.Code");
+        nullableValueLeaf.Should().Contain("?? throw");
+    }
+
+    /// <summary>
     /// Test <see cref="PropertyPathExpressionBuilder.BuildTargetMemberAccessExpression"/> for flat and nested paths.
     /// </summary>
     [Fact]

--- a/Mappa.Generator/Algorithm/StrategyDetectors/ConstructorMapStrategyDetector.PropertyPaths.cs
+++ b/Mappa.Generator/Algorithm/StrategyDetectors/ConstructorMapStrategyDetector.PropertyPaths.cs
@@ -193,52 +193,33 @@ internal sealed partial class ConstructorMapStrategyDetector
             return false;
         }
 
-        if (isLeafTargetMapping && (sourcePath.IsNested || activePropertyPathContext is not null))
+        if (isLeafTargetMapping
+            && (sourcePath.IsNested || activePropertyPathContext is not null)
+            && this.context.PropertyPathContext is not null)
         {
             // Prefer reading remaining segments from the current nested source receiver
             // so intermediate temps are reused instead of rebuilding the chain from the root.
-            if (this.context.PropertyPathContext is not null)
+            string[] remainingSourceSegments;
+            if (this.context.PropertyPathContext.IsNestedAttributeScope)
             {
-                string[] remainingSourceSegments;
-                if (this.context.PropertyPathContext.IsNestedAttributeScope)
-                {
-                    remainingSourceSegments = activePropertyPathContext?.RemainingSourceSegments ?? sourcePath.Segments;
-                }
-                else
-                {
-                    remainingSourceSegments = this.context.PropertyPathContext.RemainingSourceSegments.Length > 0
-                        ? this.context.PropertyPathContext.RemainingSourceSegments
-                        : sourcePath.Segments;
-                }
-
-                if (remainingSourceSegments.Length > 0)
-                {
-                    chainedSourcePropertyPath = new ChainedSourcePropertyPathInfo(
-                        usePropertyAttribute.SourcePropertyName,
-                        remainingSourceSegments,
-                        this.context.SourceType,
-                        string.Empty);
-                    return false;
-                }
+                remainingSourceSegments = activePropertyPathContext?.RemainingSourceSegments ?? sourcePath.Segments;
+            }
+            else
+            {
+                remainingSourceSegments = this.context.PropertyPathContext.RemainingSourceSegments.Length > 0
+                    ? this.context.PropertyPathContext.RemainingSourceSegments
+                    : sourcePath.Segments;
             }
 
-            var receiverPrefix = this.context.GetRootMapMethod().MethodSymbol.Parameters[0].Name;
-            if (activePropertyPathContext is not null
-                && sourcePath.Segments.Length > activePropertyPathContext.RemainingSourceSegments.Length)
+            if (remainingSourceSegments.Length > 0)
             {
-                var consumedCount = sourcePath.Segments.Length - activePropertyPathContext.RemainingSourceSegments.Length;
-                receiverPrefix = string.Join(
-                    ".",
-                    new[] { this.context.GetRootMapMethod().MethodSymbol.Parameters[0].Name }
-                        .Concat(sourcePath.Segments.Take(consumedCount)));
+                chainedSourcePropertyPath = new ChainedSourcePropertyPathInfo(
+                    usePropertyAttribute.SourcePropertyName,
+                    remainingSourceSegments,
+                    this.context.SourceType,
+                    string.Empty);
+                return false;
             }
-
-            chainedSourcePropertyPath = new ChainedSourcePropertyPathInfo(
-                usePropertyAttribute.SourcePropertyName,
-                activePropertyPathContext?.RemainingSourceSegments ?? sourcePath.Segments,
-                this.context.GetRootSourceType(),
-                receiverPrefix);
-            return false;
         }
 
         var expectedSegment = PropertyPathAttributeMatching.GetExpectedSourcePropertyNameForCurrentLevel(

--- a/Mappa.Generator/Algorithm/StrategyDetectors/ConstructorMapStrategyDetector.PropertyPaths.cs
+++ b/Mappa.Generator/Algorithm/StrategyDetectors/ConstructorMapStrategyDetector.PropertyPaths.cs
@@ -123,6 +123,16 @@ internal sealed partial class ConstructorMapStrategyDetector
                 null,
                 stringComparison));
 
+        // MappaUsePropertyAttribute does not implement IMappaTargetPropertyNameAttribute.
+        var nestedUsePropertyAttributeCount = mapMethod
+            .GetAttributes<MappaUsePropertyAttribute>()
+            .Where(attribute => PropertyPath.Parse(attribute.TargetPropertyName).IsNested)
+            .Count(attribute => PropertyPathAttributeMatching.MatchesTargetMember(
+                attribute.TargetPropertyName,
+                targetMemberName,
+                null,
+                stringComparison));
+
         // Ignore does not implement IMappaTargetPropertyNameAttribute.
         var nestedIgnoreAttributeCount = mapMethod
             .GetAttributes<MappaIgnoreTargetPropertyAttribute>()
@@ -133,7 +143,7 @@ internal sealed partial class ConstructorMapStrategyDetector
                 null,
                 stringComparison));
 
-        return nestedTargetNameAttributeCount + nestedIgnoreAttributeCount;
+        return nestedTargetNameAttributeCount + nestedUsePropertyAttributeCount + nestedIgnoreAttributeCount;
     }
 
     private MappaUsePropertyAttribute[] GetMatchingUsePropertyAttributes(
@@ -185,6 +195,33 @@ internal sealed partial class ConstructorMapStrategyDetector
 
         if (isLeafTargetMapping && (sourcePath.IsNested || activePropertyPathContext is not null))
         {
+            // Prefer reading remaining segments from the current nested source receiver
+            // so intermediate temps are reused instead of rebuilding the chain from the root.
+            if (this.context.PropertyPathContext is not null)
+            {
+                string[] remainingSourceSegments;
+                if (this.context.PropertyPathContext.IsNestedAttributeScope)
+                {
+                    remainingSourceSegments = activePropertyPathContext?.RemainingSourceSegments ?? sourcePath.Segments;
+                }
+                else
+                {
+                    remainingSourceSegments = this.context.PropertyPathContext.RemainingSourceSegments.Length > 0
+                        ? this.context.PropertyPathContext.RemainingSourceSegments
+                        : sourcePath.Segments;
+                }
+
+                if (remainingSourceSegments.Length > 0)
+                {
+                    chainedSourcePropertyPath = new ChainedSourcePropertyPathInfo(
+                        usePropertyAttribute.SourcePropertyName,
+                        remainingSourceSegments,
+                        this.context.SourceType,
+                        string.Empty);
+                    return false;
+                }
+            }
+
             var receiverPrefix = this.context.GetRootMapMethod().MethodSymbol.Parameters[0].Name;
             if (activePropertyPathContext is not null
                 && sourcePath.Segments.Length > activePropertyPathContext.RemainingSourceSegments.Length)
@@ -294,15 +331,23 @@ internal sealed partial class ConstructorMapStrategyDetector
         resolvedProperties = [];
         firstProperty = null;
 
-        var rootSourceType = this.context.GetRootSourceType();
-        var rootReceiverExpression = this.context.GetRootMapMethod().MethodSymbol.Parameters[0].Name;
-        if (!PropertyPathSymbolResolver.TryGetReceiverTypeForPathPrefix(
-                rootSourceType,
-                rootReceiverExpression,
-                chainedSourcePropertyPath.ReceiverPathPrefix,
-                out var chainReceiverType))
+        ITypeSymbol chainReceiverType;
+        if (string.IsNullOrWhiteSpace(chainedSourcePropertyPath.ReceiverPathPrefix))
         {
             chainReceiverType = chainedSourcePropertyPath.StartingSourceType;
+        }
+        else
+        {
+            var rootSourceType = this.context.GetRootSourceType();
+            var rootReceiverExpression = this.context.GetRootMapMethod().MethodSymbol.Parameters[0].Name;
+            if (!PropertyPathSymbolResolver.TryGetReceiverTypeForPathPrefix(
+                    rootSourceType,
+                    rootReceiverExpression,
+                    chainedSourcePropertyPath.ReceiverPathPrefix,
+                    out chainReceiverType))
+            {
+                chainReceiverType = chainedSourcePropertyPath.StartingSourceType;
+            }
         }
 
         if (!PropertyPathSymbolResolver.TryResolvePropertyPath(

--- a/Mappa.Generator/Algorithm/StrategyDetectors/ConstructorMapStrategyDetector.cs
+++ b/Mappa.Generator/Algorithm/StrategyDetectors/ConstructorMapStrategyDetector.cs
@@ -980,6 +980,7 @@ internal sealed partial class ConstructorMapStrategyDetector
                     out strategy);
                 if (strategy is not NoMapStrategy)
                 {
+                    sourceProperty = null; // Ignore any input property.
                     this.ReportMappaUsePropertySourcePropertyWillNotBeUsedIfPresent(
                         targetName,
                         stringComparison,

--- a/Mappa.Generator/Builders/Strategies/PropertyMapStrategyBuilder.cs
+++ b/Mappa.Generator/Builders/Strategies/PropertyMapStrategyBuilder.cs
@@ -38,21 +38,26 @@ internal sealed class PropertyMapStrategyBuilder
             var chainedSourcePropertyPath = this.strategy.ChainedSourcePropertyPath;
             var chainSource = source;
             var rootParameterName = context.GetMapMethod().MethodSymbol.Parameters[0].Name;
-            if (!string.IsNullOrWhiteSpace(chainedSourcePropertyPath.ReceiverPathPrefix)
-                && (chainedSourcePropertyPath.ReceiverPathPrefix.Equals(rootParameterName, StringComparison.Ordinal)
-                    || chainedSourcePropertyPath.ReceiverPathPrefix.StartsWith($"{rootParameterName}.", StringComparison.Ordinal)))
+            var receiverPathPrefix = chainedSourcePropertyPath.ReceiverPathPrefix;
+
+            // Only rewrite to the root parameter when the chain is intentionally rooted there.
+            // Empty prefix means read remaining segments from the current nested source receiver.
+            if (!string.IsNullOrWhiteSpace(receiverPathPrefix)
+                && (receiverPathPrefix.Equals(rootParameterName, StringComparison.Ordinal)
+                    || receiverPathPrefix.StartsWith($"{rootParameterName}.", StringComparison.Ordinal)))
             {
                 chainSource = rootParameterName;
             }
 
             var accessExpression = PropertyPathExpressionBuilder.BuildChainedAccessExpression(
                 chainSource,
-                chainedSourcePropertyPath.ReceiverPathPrefix,
+                receiverPathPrefix,
                 chainedSourcePropertyPath.RemainingSourceSegments,
                 chainedSourcePropertyPath.StartingSourceType,
                 context.GetMapMethod().NullableEnabled,
                 this.strategy.TargetProperty.Type,
-                out var resolvedProperties);
+                out var resolvedProperties,
+                chainedSourcePropertyPath.OriginalSourcePath);
 
             ITypeSymbol innermostSourceType;
             if (resolvedProperties.Length > 0)
@@ -62,7 +67,7 @@ internal sealed class PropertyMapStrategyBuilder
             else if (PropertyPathSymbolResolver.TryGetReceiverTypeForPathPrefix(
                          chainedSourcePropertyPath.StartingSourceType,
                          chainSource,
-                         chainedSourcePropertyPath.ReceiverPathPrefix,
+                         string.IsNullOrWhiteSpace(receiverPathPrefix) ? chainSource : receiverPathPrefix,
                          out var receiverType))
             {
                 innermostSourceType = receiverType;

--- a/Mappa.Generator/Helpers/PropertyPathExpressionBuilder.cs
+++ b/Mappa.Generator/Helpers/PropertyPathExpressionBuilder.cs
@@ -23,6 +23,9 @@ internal static class PropertyPathExpressionBuilder
     /// <param name="nullableEnabled">Whether nullable reference types are enabled.</param>
     /// <param name="targetType">The final target member type.</param>
     /// <param name="resolvedProperties">The resolved properties for each segment.</param>
+    /// <param name="diagnosticPathOverride">
+    /// Optional full path used in null-reference diagnostics (for example the original attribute source path).
+    /// </param>
     /// <returns>The chained access expression.</returns>
     internal static string BuildChainedAccessExpression(
         string receiverExpression,
@@ -31,7 +34,8 @@ internal static class PropertyPathExpressionBuilder
         ITypeSymbol startingType,
         bool nullableEnabled,
         ITypeSymbol targetType,
-        out IPropertySymbol[] resolvedProperties)
+        out IPropertySymbol[] resolvedProperties,
+        string? diagnosticPathOverride = null)
     {
         var path = PropertyPath.FromRemainingSegments(pathSegments);
         var chainExpression = string.IsNullOrWhiteSpace(receiverPathPrefix)
@@ -55,21 +59,31 @@ internal static class PropertyPathExpressionBuilder
 
         var expression = chainExpression;
         var diagnosticPath = chainExpression;
+        var usedConditionalAccess = false;
+        var receiverTypeForAccess = pathStartingType;
 
         for (var index = 0; index < pathSegments.Length; index++)
         {
             var segment = pathSegments[index];
-            var segmentType = resolvedProperties[index].Type;
-            var accessOperator = ShouldUseConditionalAccess(segmentType, nullableEnabled) ? "?." : ".";
+            var useConditionalAccess = ShouldUseConditionalAccess(receiverTypeForAccess, nullableEnabled);
+            usedConditionalAccess = usedConditionalAccess || useConditionalAccess;
+            var accessOperator = useConditionalAccess ? "?." : ".";
             expression = $"{expression}{accessOperator}{segment}";
             diagnosticPath = string.IsNullOrWhiteSpace(diagnosticPath)
                 ? segment
                 : $"{diagnosticPath}.{segment}";
+            receiverTypeForAccess = resolvedProperties[index].Type;
         }
 
-        if (!targetType.IsNullable())
+        // Append ?? throw only when the access expression can be null and the target cannot.
+        var expressionCanBeNull = usedConditionalAccess
+            || IsNullableCapableType(receiverTypeForAccess, nullableEnabled);
+        if (expressionCanBeNull && !targetType.IsNullable())
         {
-            expression = $"{expression} ?? throw new System.NullReferenceException({CSharpLiteralHelper.ToStringLiteral($"\"{diagnosticPath}\" is null.")})";
+            var pathForDiagnostic = string.IsNullOrWhiteSpace(diagnosticPathOverride)
+                ? diagnosticPath
+                : diagnosticPathOverride;
+            expression = $"{expression} ?? throw new System.NullReferenceException({CSharpLiteralHelper.ToStringLiteral($"\"{pathForDiagnostic}\" is null.")})";
         }
 
         return expression;
@@ -93,19 +107,22 @@ internal static class PropertyPathExpressionBuilder
     }
 
     private static bool ShouldUseConditionalAccess(ITypeSymbol segmentType, bool nullableEnabled)
+        => IsNullableCapableType(segmentType, nullableEnabled);
+
+    private static bool IsNullableCapableType(ITypeSymbol typeSymbol, bool nullableEnabled)
     {
-        if (segmentType.IsValueTypeNullable())
+        if (typeSymbol.IsValueTypeNullable())
         {
             return true;
         }
 
-        if (!segmentType.IsReferenceType)
+        if (!typeSymbol.IsReferenceType)
         {
             return false;
         }
 
         return nullableEnabled
-            ? segmentType.NullableAnnotation is NullableAnnotation.Annotated
-            : segmentType.IsReferenceType;
+            ? typeSymbol.NullableAnnotation is NullableAnnotation.Annotated
+            : typeSymbol.IsReferenceType;
     }
 }

--- a/Mappa.Generator/Helpers/PropertyPathExpressionBuilder.cs
+++ b/Mappa.Generator/Helpers/PropertyPathExpressionBuilder.cs
@@ -58,7 +58,7 @@ internal static class PropertyPathExpressionBuilder
         }
 
         var expression = chainExpression;
-        var diagnosticPath = chainExpression;
+        var diagnosticPath = string.Empty;
         var usedConditionalAccess = false;
         var receiverTypeForAccess = pathStartingType;
 

--- a/Mappa.Generator/README.md
+++ b/Mappa.Generator/README.md
@@ -257,6 +257,10 @@ The constructor strategy has three sub-strategies, tried in order:
     - Those attributes accept flat names or [dot-separated nested property paths](../Documentation/mappa-attributes.md#nested-property-paths) (see also [algorithm — nested property paths](../Documentation/mappa-generator-algorithm.md#nested-property-paths));
     - When `MappaSettings.ProtobufOptional` is enabled, optional protobuf members are handled via companion `Has*` properties on the source and target types.
 
+### Nested property paths
+
+Leaf source chains use conditional access based on each **receiver** type, reuse nested source temps, and append `?? throw new System.NullReferenceException("...")` only when the expression can be null and the target cannot (never on plain non-nullable value-type leaves). Nested `[MappaIgnoreTargetProperty]` applies alongside sibling nested attributes under the same root. Nested `[MappaAssignToContext]` reads the leaf from the constructed result after mapping. Details: [Documentation/mappa-generator-algorithm.md — Nested property paths](../Documentation/mappa-generator-algorithm.md#nested-property-paths).
+
 ## Limitations
 
 Currently unsupported features include:

--- a/MappaVersion.targets
+++ b/MappaVersion.targets
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <MappaVersion>10.2.0-alpha.9</MappaVersion>
+        <MappaVersion>10.2.0-alpha.10</MappaVersion>
     </PropertyGroup>
 </Project>

--- a/MappaVersion.targets
+++ b/MappaVersion.targets
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <MappaVersion>10.2.0-alpha.8</MappaVersion>
+        <MappaVersion>10.2.0-alpha.9</MappaVersion>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Fix nested property-path follow-ups from #120 / #275: Ignore+UseProperty sibling matching (D4), receiver-based `?.` and conditional `?? throw` (D2), leaf chains reuse nested source temps (D1/D8), AssignFromConstant clears dead source reads (D5).
- Extend nullability/mix integration tests and restore coverage; bump to `10.2.0-alpha.10`.
- Document corrected nested-path rules and AssignToContext leaf-from-result behaviour; require uploading implementation plans to the GitHub issue when opening PRs.

## Test plan
- [x] `.\Scripts\RunTestsAndReportCoverage.ps1` — all tests passed; line/branch/method ≥ step-1 baseline (97.5% / 90.5% / 95.4%)
- [ ] Spot-check generated nested Ignore+UseProperty: ZipCode omitted, City mapped
- [ ] Spot-check non-nullable `int` leaf chain has no `?? throw`
- [ ] CI PR checks green (version increase vs main)

Closes #275