### PR TITLE
#277 Strengthen nested-path tests with HasNextSyntaxNode assertions

### DIFF
--- a/.cursor/rules/mappa-development-workflow.mdc
+++ b/.cursor/rules/mappa-development-workflow.mdc
@@ -111,7 +111,10 @@ A single feature may require **two** bumps (e.g. one after **Mappa**, one after 
 - Cover **happy path and negative paths** where possible.
 - Maintain or improve **code coverage** relative to the baseline recorded in plan step 1 (see **Code Coverage**).
 - For **Mappa.Generator**, test error/warning messages and corner cases.
-- For **Mappa.Generator.Tests** integration tests that assert generated syntax: when `blockSyntaxAssertions` (or nested block assertions) include `HasSyntaxNodesCount(X)`, there must be exactly **X** subsequent `HasNextSyntaxNode` entries chained after it. Tests that only assert diagnostic errors and do not inspect generated syntax are exempt.
+- **Mappa.Generator.Tests integration tests — generated syntax (mandatory):** when asserting that generated mapping code is correct, **always** walk the syntax tree with the `HasNextSyntaxNode` pattern (typically after `HaveDefaultMapMethod` / `blockSyntaxAssertions`, using helpers such as `BeLocalDeclarationStatementSyntax`, `BeReturnStatement`, `BeObjectCreationExpressionSyntax`, nested `HasSyntaxNodesCount` / `HasNextSyntaxNode` chains, etc.). See existing tests such as [`InvokeConstructorMapStrategyIntegrationTests.cs`](Mappa.Generator.Tests/InvokeConstructorMapStrategyIntegrationTests.cs) for the required style.
+- **Do NOT** assert generated output by checking whether a string is contained (or not contained) in the generated source text — for example, avoid `Contains(...)`, `DoesNotContain(...)`, `Should().Contain(...)`, `Should().NotContain(...)`, or any equivalent substring / full-text match on the generated code. This is a hard rule: string-based assertions on generated text are forbidden for new or updated integration tests.
+- When `blockSyntaxAssertions` (or nested block assertions) include `HasSyntaxNodesCount(X)`, there must be exactly **X** subsequent `HasNextSyntaxNode` entries chained after it.
+- Tests that only assert diagnostic errors/warnings and do not inspect generated syntax are exempt from the `HasNextSyntaxNode` requirement (they still must not use string-containment checks as a substitute for syntax assertions).
 - When adding samples in **Mappa.Samples**, also update **Mappa.Samples.Aot**.
 
 ## Samples

--- a/Mappa.Generator.Tests/Assertions/ExpressionSyntaxAssertions.cs
+++ b/Mappa.Generator.Tests/Assertions/ExpressionSyntaxAssertions.cs
@@ -99,6 +99,61 @@ internal sealed class ExpressionSyntaxAssertions
     }
 
     /// <summary>
+    /// Assert that the expression is a conditional access expression syntax
+    /// whose string representation is the same as <paramref name="fullAccessPath"/>.
+    /// </summary>
+    /// <param name="fullAccessPath">The string representation of the expression.</param>
+    /// <returns>The assertions.</returns>
+    internal ExpressionSyntaxAssertions BeConditionalAccessExpressionSyntax(string fullAccessPath)
+    {
+        this.Subject.Should().BeOfType<ConditionalAccessExpressionSyntax>();
+        var conditionalAccessExpressionSyntax = (ConditionalAccessExpressionSyntax)this.Subject;
+        conditionalAccessExpressionSyntax.ToString().Should().Be(fullAccessPath);
+        return this;
+    }
+
+    /// <summary>
+    /// Assert that the expression is a throw expression creating <typeparamref name="TException"/>.
+    /// </summary>
+    /// <param name="parameterAssertions">Assertions on the parameters of the created exception.</param>
+    /// <returns>The assertions.</returns>
+    /// <typeparam name="TException">The type of the exception thrown.</typeparam>
+    internal ExpressionSyntaxAssertions BeThrowExpressionSyntax<TException>(
+        params Action<ExpressionSyntaxAssertions>[] parameterAssertions)
+        where TException : Exception
+        => this.BeThrowExpressionSyntax(
+            typeof(TException).FullName ?? throw new ArgumentException("Cannot obtain exception type full name"),
+            parameterAssertions);
+
+    /// <summary>
+    /// Assert that the expression is a throw expression creating the given exception type.
+    /// </summary>
+    /// <param name="exceptionType">The type of the exception.</param>
+    /// <param name="parameterAssertions">Assertions on the parameters of the created exception.</param>
+    /// <returns>The assertions.</returns>
+    internal ExpressionSyntaxAssertions BeThrowExpressionSyntax(
+        string exceptionType,
+        params Action<ExpressionSyntaxAssertions>[] parameterAssertions)
+    {
+        ArgumentNullException.ThrowIfNull(parameterAssertions);
+
+        this.Subject.Should().BeOfType<ThrowExpressionSyntax>();
+        var throwExpressionSyntax = (ThrowExpressionSyntax)this.Subject;
+        throwExpressionSyntax.Expression.Should().BeOfType<ObjectCreationExpressionSyntax>();
+        var objectCreationExpressionSyntax = (ObjectCreationExpressionSyntax)throwExpressionSyntax.Expression;
+        objectCreationExpressionSyntax.Type.ToString().Should().Be(exceptionType);
+        objectCreationExpressionSyntax.ArgumentList.Should().NotBeNull();
+        objectCreationExpressionSyntax.ArgumentList!.Arguments.Should().HaveCount(parameterAssertions.Length);
+
+        for (int index = 0; index < parameterAssertions.Length; ++index)
+        {
+            parameterAssertions[index](new ExpressionSyntaxAssertions(objectCreationExpressionSyntax.ArgumentList!.Arguments[index].Expression, this.semanticModel, this.compilation));
+        }
+
+        return this;
+    }
+
+    /// <summary>
     /// Assert that the expression is a literal expression.
     /// </summary>
     /// <param name="value">The expected value of the expression.</param>
@@ -366,7 +421,14 @@ internal sealed class ExpressionSyntaxAssertions
         this.Subject.Should().BeOfType<BinaryExpressionSyntax>();
         var binaryExpressionSyntax = (BinaryExpressionSyntax)this.Subject;
 
-        binaryExpressionSyntax.OperatorToken.Kind().Should().Be(@operator);
+        if (@operator == binaryExpressionSyntax.Kind())
+        {
+            binaryExpressionSyntax.Kind().Should().Be(@operator);
+        }
+        else
+        {
+            binaryExpressionSyntax.OperatorToken.Kind().Should().Be(@operator);
+        }
 
         leftExpressionAssertions(new ExpressionSyntaxAssertions(binaryExpressionSyntax.Left, this.semanticModel, this.compilation));
         rightExpressionAssertions(new ExpressionSyntaxAssertions(binaryExpressionSyntax.Right, this.semanticModel, this.compilation));

--- a/Mappa.Generator.Tests/Assertions/Extensions/SyntaxNodeAssertionsExtensions.cs
+++ b/Mappa.Generator.Tests/Assertions/Extensions/SyntaxNodeAssertionsExtensions.cs
@@ -16,19 +16,22 @@ internal static class SyntaxNodeAssertionsExtensions
     /// <param name="contextParameterName">The context parameter name.</param>
     /// <param name="contextKey">The context key.</param>
     /// <param name="targetTemporaryName">The target temporary variable name.</param>
-    /// <param name="memberName">The target member name.</param>
+    /// <param name="memberPath">
+    /// The target member path relative to <paramref name="targetTemporaryName"/>
+    /// (a single segment such as <c>Property</c>, or a nested path such as <c>Address.City</c>).
+    /// </param>
     /// <returns>The assertions instance.</returns>
     internal static SyntaxNodeAssertions BeAssignToContextStatement(
         this SyntaxNodeAssertions @this,
         string contextParameterName,
         string contextKey,
         string targetTemporaryName,
-        string memberName)
+        string memberPath)
     {
         ArgumentNullException.ThrowIfNull(@this);
 
         return @this.BeAssignmentExpressionStatement(
             leftExpressionAssertions => leftExpressionAssertions.BeElementAccessExpressionSyntaxWithLiteralSyntax(contextParameterName, contextKey),
-            rightExpressionAssertions => rightExpressionAssertions.BeMemberAccessExpressionSyntax($"{targetTemporaryName}.{memberName}"));
+            rightExpressionAssertions => rightExpressionAssertions.BeMemberAccessExpressionSyntax($"{targetTemporaryName}.{memberPath}"));
     }
 }

--- a/Mappa.Generator.Tests/NestedPropertyPathAttributeIntegrationTests.Diagnostics.cs
+++ b/Mappa.Generator.Tests/NestedPropertyPathAttributeIntegrationTests.Diagnostics.cs
@@ -4,6 +4,9 @@
 
 using Mappa.Generator.Diagnostics;
 using Mappa.Generator.Tests.Assertions;
+using Mappa.Generator.Tests.Assertions.Extensions;
+
+using Microsoft.CodeAnalysis;
 
 namespace Mappa.Generator.Tests;
 
@@ -311,13 +314,39 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
                                   """;
 
         var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
-        var generatedSource = GetGeneratedMapperSource(generatedResults);
 
         generatedResults.Should()
             .NotHaveDiagnostics()
-            .HaveGeneratedSourceCode();
-        generatedSource.Should().Contain(".City");
-        generatedSource.Should().NotContain(".ZipCode");
-        generatedSource.Should().NotContain("ZipCode =");
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                TargetTypeName,
+                NullableAnnotation.NotAnnotated,
+                SourceTypeName,
+                NullableAnnotation.NotAnnotated,
+                block => block
+                    .HasSyntaxNodesCount(5)
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                        "Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto",
+                        "__mappa_tmp_1",
+                        value => value.BeMemberAccessExpressionSyntax("input.Address")))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                        typeof(string).ToString(),
+                        "__mappa_tmp_2",
+                        value => value.BeMemberAccessExpressionSyntax("__mappa_tmp_1.City")))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                        "Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto",
+                        "__mappa_tmp_3",
+                        value => value.BeObjectCreationExpressionSyntax(
+                            "Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto",
+                            ("City", property => property.BeIdentifierNameSyntax("__mappa_tmp_2")))))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                        TargetTypeName,
+                        "__mappa_tmp_4",
+                        value => value.BeObjectCreationExpressionSyntax(
+                            TargetTypeName,
+                            ("Address", property => property.BeIdentifierNameSyntax("__mappa_tmp_3")))))
+                    .HasNextSyntaxNode(node => node.BeReturnStatement("__mappa_tmp_4")));
     }
 }

--- a/Mappa.Generator.Tests/NestedPropertyPathAttributeIntegrationTests.MappaUseProperty.cs
+++ b/Mappa.Generator.Tests/NestedPropertyPathAttributeIntegrationTests.MappaUseProperty.cs
@@ -4,6 +4,10 @@
 
 using Mappa.Generator.Diagnostics;
 using Mappa.Generator.Tests.Assertions;
+using Mappa.Generator.Tests.Assertions.Extensions;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace Mappa.Generator.Tests;
 
@@ -54,7 +58,21 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
 
         generatedResults.Should()
             .NotHaveDiagnostics()
-            .HaveGeneratedSourceCode();
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                TargetTypeName,
+                NullableAnnotation.NotAnnotated,
+                SourceTypeName,
+                NullableAnnotation.NotAnnotated,
+                block => block
+                    .HasSyntaxNodesCount(5)
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.Outer", "__mappa_tmp_1", value => value.BeMemberAccessExpressionSyntax("input.Outer")))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(typeof(string).ToString(), "__mappa_tmp_2", value => value.BeMemberAccessExpressionSyntax("__mappa_tmp_1.Value")))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.Outer", "__mappa_tmp_3", value => value.BeObjectCreationExpressionSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.Outer", ("Value", property => property.BeIdentifierNameSyntax("__mappa_tmp_2")))))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(TargetTypeName, "__mappa_tmp_4", value => value.BeObjectCreationExpressionSyntax(TargetTypeName, ("Outer", property => property.BeIdentifierNameSyntax("__mappa_tmp_3")))))
+                    .HasNextSyntaxNode(node => node.BeReturnStatement("__mappa_tmp_4")));
     }
 
     /// <summary>
@@ -101,14 +119,42 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
                                   """;
 
         var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
-        var generatedSource = GetGeneratedMapperSource(generatedResults);
 
         generatedResults.Should()
             .NotHaveDiagnostics()
-            .HaveGeneratedSourceCode();
-        generatedSource.Should().Contain("input.Location");
-        generatedSource.Should().Contain(".Address?.City");
-        generatedSource.Should().Contain("throw new System.NullReferenceException");
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                TargetTypeName,
+                NullableAnnotation.NotAnnotated,
+                SourceTypeName,
+                NullableAnnotation.NotAnnotated,
+                block => block
+                    .HasSyntaxNodesCount(5)
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.LocationDto?", "__mappa_tmp_1", value => value.BeMemberAccessExpressionSyntax("input.Location")))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto", "__mappa_tmp_2"))
+                    .HasNextSyntaxNode(node => node.BeIfStatementSyntax(
+                        condition => condition.BeIsPatternExpressionSyntax(
+                            expression => expression.BeIdentifierNameSyntax("__mappa_tmp_1"),
+                            pattern => pattern.BeUnaryPatternSyntax(SyntaxKind.NotKeyword, inner => inner.BeConstantPatternSyntax(null))),
+                        thenStatement => thenStatement.BeBlockStatement().AsBlock()
+                            .HasSyntaxNodesCount(4)
+                            .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.LocationDto", "__mappa_tmp_3", value => value.BeIdentifierNameSyntax("__mappa_tmp_1")))
+                            .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                                typeof(string).ToString(),
+                                "__mappa_tmp_4",
+                                value => value.BeBinaryExpressionSyntax(
+                                    left => left.BeConditionalAccessExpressionSyntax("__mappa_tmp_3?.Address?.City"),
+                                    SyntaxKind.CoalesceExpression,
+                                    right => right.BeThrowExpressionSyntax<NullReferenceException>(message => message.BeLiteralExpressionSyntax("\"Location.Address.City\" is null.")))))
+                            .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto", "__mappa_tmp_5", value => value.BeObjectCreationExpressionSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto", ("City", property => property.BeIdentifierNameSyntax("__mappa_tmp_4")))))
+                            .HasNextSyntaxNode(node => node.BeAssignmentExpressionStatement("__mappa_tmp_2", value => value.BeIdentifierNameSyntax("__mappa_tmp_5"))),
+                        elseStatement => elseStatement.BeBlockStatement().AsBlock()
+                            .HasSyntaxNodesCount(1)
+                            .HasNextSyntaxNode(node => node.BeThrowStatementSyntax<NullReferenceException>(message => message.BeLiteralExpressionSyntax("\"__mappa_tmp_1\" is null.")))))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(TargetTypeName, "__mappa_tmp_6", value => value.BeObjectCreationExpressionSyntax(TargetTypeName, ("Address", property => property.BeIdentifierNameSyntax("__mappa_tmp_2")))))
+                    .HasNextSyntaxNode(node => node.BeReturnStatement("__mappa_tmp_6")));
     }
 
     /// <summary>
@@ -155,14 +201,26 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
                                   """;
 
         var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
-        var generatedSource = GetGeneratedMapperSource(generatedResults);
 
         generatedResults.Should()
             .NotHaveDiagnostics()
-            .HaveGeneratedSourceCode();
-        generatedSource.Should().Contain("Location");
-        generatedSource.Should().Contain("Address");
-        generatedSource.Should().Contain("City");
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                TargetTypeName,
+                NullableAnnotation.NotAnnotated,
+                SourceTypeName,
+                NullableAnnotation.NotAnnotated,
+                block => block
+                    .HasSyntaxNodesCount(7)
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.LocationDto", "__mappa_tmp_1", value => value.BeMemberAccessExpressionSyntax("input.Location")))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto", "__mappa_tmp_2", value => value.BeMemberAccessExpressionSyntax("__mappa_tmp_1.Address")))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(typeof(string).ToString(), "__mappa_tmp_3", value => value.BeMemberAccessExpressionSyntax("__mappa_tmp_2.City")))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto", "__mappa_tmp_4", value => value.BeObjectCreationExpressionSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto", ("City", property => property.BeIdentifierNameSyntax("__mappa_tmp_3")))))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.LocationDto", "__mappa_tmp_5", value => value.BeObjectCreationExpressionSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.LocationDto", ("Address", property => property.BeIdentifierNameSyntax("__mappa_tmp_4")))))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(TargetTypeName, "__mappa_tmp_6", value => value.BeObjectCreationExpressionSyntax(TargetTypeName, ("Location", property => property.BeIdentifierNameSyntax("__mappa_tmp_5")))))
+                    .HasNextSyntaxNode(node => node.BeReturnStatement("__mappa_tmp_6")));
     }
 
     /// <summary>
@@ -209,7 +267,22 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
 
         generatedResults.Should()
             .NotHaveDiagnostics()
-            .HaveGeneratedSourceCode();
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                TargetTypeName,
+                NullableAnnotation.NotAnnotated,
+                SourceTypeName,
+                NullableAnnotation.NotAnnotated,
+                block => block
+                    .HasSyntaxNodesCount(6)
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto", "__mappa_tmp_1", value => value.BeMemberAccessExpressionSyntax("input.Address")))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(typeof(string).ToString(), "__mappa_tmp_2", value => value.BeMemberAccessExpressionSyntax("__mappa_tmp_1.City")))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(typeof(string).ToString(), "__mappa_tmp_3", value => value.BeMemberAccessExpressionSyntax("__mappa_tmp_1.ZipCode")))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto", "__mappa_tmp_4", value => value.BeObjectCreationExpressionSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto", ("City", property => property.BeIdentifierNameSyntax("__mappa_tmp_2")), ("ZipCode", property => property.BeIdentifierNameSyntax("__mappa_tmp_3")))))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(TargetTypeName, "__mappa_tmp_5", value => value.BeObjectCreationExpressionSyntax(TargetTypeName, ("Address", property => property.BeIdentifierNameSyntax("__mappa_tmp_4")))))
+                    .HasNextSyntaxNode(node => node.BeReturnStatement("__mappa_tmp_5")));
     }
 
     /// <summary>
@@ -262,7 +335,24 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
 
         generatedResults.Should()
             .NotHaveDiagnostics()
-            .HaveGeneratedSourceCode();
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                TargetTypeName,
+                NullableAnnotation.NotAnnotated,
+                SourceTypeName,
+                NullableAnnotation.NotAnnotated,
+                block => block
+                    .HasSyntaxNodesCount(8)
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto", "__mappa_tmp_1", value => value.BeMemberAccessExpressionSyntax("input.Address")))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(typeof(string).ToString(), "__mappa_tmp_2", value => value.BeMemberAccessExpressionSyntax("__mappa_tmp_1.City")))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto", "__mappa_tmp_3", value => value.BeObjectCreationExpressionSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto", ("City", property => property.BeIdentifierNameSyntax("__mappa_tmp_2")))))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.ContactDto", "__mappa_tmp_4", value => value.BeMemberAccessExpressionSyntax("input.Contact")))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(typeof(string).ToString(), "__mappa_tmp_5", value => value.BeMemberAccessExpressionSyntax("__mappa_tmp_4.Name")))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.ContactDto", "__mappa_tmp_6", value => value.BeObjectCreationExpressionSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.ContactDto", ("Name", property => property.BeIdentifierNameSyntax("__mappa_tmp_5")))))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(TargetTypeName, "__mappa_tmp_7", value => value.BeObjectCreationExpressionSyntax(TargetTypeName, ("Address", property => property.BeIdentifierNameSyntax("__mappa_tmp_3")), ("Contact", property => property.BeIdentifierNameSyntax("__mappa_tmp_6")))))
+                    .HasNextSyntaxNode(node => node.BeReturnStatement("__mappa_tmp_7")));
     }
 
     /// <summary>
@@ -312,14 +402,25 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
                                   """;
 
         var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
-        var generatedSource = GetGeneratedMapperSource(generatedResults);
 
         generatedResults.Should()
             .NotHaveDiagnostics()
-            .HaveGeneratedSourceCode();
-        generatedSource.Should().Contain("input.Location");
-        generatedSource.Should().Contain(".City");
-        generatedSource.Should().Contain(".ZipCode");
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                TargetTypeName,
+                NullableAnnotation.NotAnnotated,
+                SourceTypeName,
+                NullableAnnotation.NotAnnotated,
+                block => block
+                    .HasSyntaxNodesCount(6)
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.LocationDto", "__mappa_tmp_1", value => value.BeMemberAccessExpressionSyntax("input.Location")))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(typeof(string).ToString(), "__mappa_tmp_2", value => value.BeMemberAccessExpressionSyntax("__mappa_tmp_1.Address.City")))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(typeof(string).ToString(), "__mappa_tmp_3", value => value.BeMemberAccessExpressionSyntax("__mappa_tmp_1.Address.ZipCode")))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto", "__mappa_tmp_4", value => value.BeObjectCreationExpressionSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto", ("City", property => property.BeIdentifierNameSyntax("__mappa_tmp_2")), ("ZipCode", property => property.BeIdentifierNameSyntax("__mappa_tmp_3")))))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(TargetTypeName, "__mappa_tmp_5", value => value.BeObjectCreationExpressionSyntax(TargetTypeName, ("Address", property => property.BeIdentifierNameSyntax("__mappa_tmp_4")))))
+                    .HasNextSyntaxNode(node => node.BeReturnStatement("__mappa_tmp_5")));
     }
 
     /// <summary>
@@ -449,12 +550,90 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
                                   """;
 
         var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
-        var generatedSource = GetGeneratedMapperSource(generatedResults);
 
         generatedResults.Should()
             .NotHaveDiagnostics()
-            .HaveGeneratedSourceCode();
-        generatedSource.Should().Contain("ParamB");
-        generatedSource.Should().Contain("input.ParamA");
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                TargetTypeName,
+                NullableAnnotation.NotAnnotated,
+                SourceTypeName,
+                NullableAnnotation.NotAnnotated,
+                block => block
+                    .HasSyntaxNodesCount(6)
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                        "Mappa.Generator.Tests.UnitTests.SourceCode.CountingValues",
+                        "__mappa_tmp_1",
+                        value => value.BeMemberAccessExpressionSyntax("input.ParamB")))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(typeof(string).ToString(), "__mappa_tmp_2"))
+                    .HasNextSyntaxNode(node => node.BeSwitchStatementSyntax(
+                        value => value.BeIdentifierNameSyntax("__mappa_tmp_1"),
+                        (labels, statements) =>
+                        {
+                            labels.Should().HaveCount(1);
+                            labels[0].IsCase();
+                            labels[0].AsCase().HasValue(value => value.BeMemberAccessExpressionSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.CountingValues.One"));
+                            statements.Should().HaveCount(1);
+                            statements[0].BeBlockStatement();
+                            statements[0].AsBlock()
+                                .HasSyntaxNodesCount(2)
+                                .HasNextSyntaxNode(statement => statement.BeAssignmentExpressionStatement(
+                                    "__mappa_tmp_2",
+                                    value => value.BeNameOf(argument => argument.BeMemberAccessExpressionSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.CountingValues.One"))))
+                                .HasNextSyntaxNode(statement => statement.BeBreakStatement());
+                        },
+                        (labels, statements) =>
+                        {
+                            labels.Should().HaveCount(1);
+                            labels[0].IsCase();
+                            labels[0].AsCase().HasValue(value => value.BeMemberAccessExpressionSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.CountingValues.Two"));
+                            statements.Should().HaveCount(1);
+                            statements[0].BeBlockStatement();
+                            statements[0].AsBlock()
+                                .HasSyntaxNodesCount(2)
+                                .HasNextSyntaxNode(statement => statement.BeAssignmentExpressionStatement(
+                                    "__mappa_tmp_2",
+                                    value => value.BeNameOf(argument => argument.BeMemberAccessExpressionSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.CountingValues.Two"))))
+                                .HasNextSyntaxNode(statement => statement.BeBreakStatement());
+                        },
+                        (labels, statements) =>
+                        {
+                            labels.Should().HaveCount(1);
+                            labels[0].IsCase();
+                            labels[0].AsCase().HasValue(value => value.BeMemberAccessExpressionSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.CountingValues.Three"));
+                            statements.Should().HaveCount(1);
+                            statements[0].BeBlockStatement();
+                            statements[0].AsBlock()
+                                .HasSyntaxNodesCount(2)
+                                .HasNextSyntaxNode(statement => statement.BeAssignmentExpressionStatement(
+                                    "__mappa_tmp_2",
+                                    value => value.BeNameOf(argument => argument.BeMemberAccessExpressionSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.CountingValues.Three"))))
+                                .HasNextSyntaxNode(statement => statement.BeBreakStatement());
+                        },
+                        (labels, statements) =>
+                        {
+                            labels.Should().HaveCount(1);
+                            labels[0].IsDefault();
+                            statements.Should().HaveCount(1);
+                            statements[0].BeBlockStatement();
+                            statements[0].AsBlock()
+                                .HasSyntaxNodesCount(1)
+                                .HasNextSyntaxNode(statement => statement.BeThrowStatementSyntax<ArgumentOutOfRangeException>(
+                                    argument => argument.BeLiteralExpressionSyntax("__mappa_tmp_1")));
+                        }))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                        typeof(int).ToString(),
+                        "__mappa_tmp_3",
+                        value => value.BeMemberAccessExpressionSyntax("input.ParamA")))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                        TargetTypeName,
+                        "__mappa_tmp_4",
+                        value => value.BeObjectCreationExpressionSyntax(
+                            TargetTypeName,
+                            ("ParamA", property => property.BeIdentifierNameSyntax("__mappa_tmp_2")),
+                            ("ParamB", property => property.BeIdentifierNameSyntax("__mappa_tmp_3")))))
+                    .HasNextSyntaxNode(node => node.BeReturnStatement("__mappa_tmp_4")));
     }
 }

--- a/Mappa.Generator.Tests/NestedPropertyPathAttributeIntegrationTests.Nullability.cs
+++ b/Mappa.Generator.Tests/NestedPropertyPathAttributeIntegrationTests.Nullability.cs
@@ -3,6 +3,10 @@
 // </copyright>
 
 using Mappa.Generator.Tests.Assertions;
+using Mappa.Generator.Tests.Assertions.Extensions;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace Mappa.Generator.Tests;
 
@@ -55,13 +59,36 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
                                   """;
 
         var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
-        var generatedSource = GetGeneratedMapperSource(generatedResults);
 
         generatedResults.Should()
             .NotHaveDiagnostics()
-            .HaveGeneratedSourceCode();
-        generatedSource.Should().Contain("input.Location");
-        generatedSource.Should().Contain(".Address?.City");
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                TargetTypeName,
+                NullableAnnotation.NotAnnotated,
+                SourceTypeName,
+                NullableAnnotation.NotAnnotated,
+                block => block
+                    .HasSyntaxNodesCount(5)
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.LocationDto?", "__mappa_tmp_1", value => value.BeMemberAccessExpressionSyntax("input.Location")))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto", "__mappa_tmp_2"))
+                    .HasNextSyntaxNode(node => node.BeIfStatementSyntax(
+                        condition => condition.BeIsPatternExpressionSyntax(
+                            expression => expression.BeIdentifierNameSyntax("__mappa_tmp_1"),
+                            pattern => pattern.BeUnaryPatternSyntax(SyntaxKind.NotKeyword, inner => inner.BeConstantPatternSyntax(null))),
+                        thenStatement => thenStatement.BeBlockStatement().AsBlock()
+                            .HasSyntaxNodesCount(4)
+                            .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.LocationDto", "__mappa_tmp_3", value => value.BeIdentifierNameSyntax("__mappa_tmp_1")))
+                            .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("string?", "__mappa_tmp_4", value => value.BeConditionalAccessExpressionSyntax("__mappa_tmp_3?.Address?.City")))
+                            .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto", "__mappa_tmp_5", value => value.BeObjectCreationExpressionSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto", ("City", property => property.BeIdentifierNameSyntax("__mappa_tmp_4")))))
+                            .HasNextSyntaxNode(node => node.BeAssignmentExpressionStatement("__mappa_tmp_2", value => value.BeIdentifierNameSyntax("__mappa_tmp_5"))),
+                        elseStatement => elseStatement.BeBlockStatement().AsBlock()
+                            .HasSyntaxNodesCount(1)
+                            .HasNextSyntaxNode(node => node.BeThrowStatementSyntax<NullReferenceException>(message => message.BeLiteralExpressionSyntax("\"__mappa_tmp_1\" is null.")))))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(TargetTypeName, "__mappa_tmp_6", value => value.BeObjectCreationExpressionSyntax(TargetTypeName, ("Address", property => property.BeIdentifierNameSyntax("__mappa_tmp_2")))))
+                    .HasNextSyntaxNode(node => node.BeReturnStatement("__mappa_tmp_6")));
     }
 
     /// <summary>
@@ -108,13 +135,57 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
                                   """;
 
         var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
-        var generatedSource = GetGeneratedMapperSource(generatedResults);
 
         generatedResults.Should()
             .NotHaveDiagnostics()
-            .HaveGeneratedSourceCode();
-        generatedSource.Should().Contain(".Location");
-        generatedSource.Should().Contain("?.Address?.City");
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                TargetTypeName,
+                NullableAnnotation.None,
+                SourceTypeName,
+                NullableAnnotation.None,
+                1,
+                NullableSetup.Disable,
+                PragmaWarning.NoBlock,
+                block => block
+                    .HasSyntaxNodesCount(3)
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(TargetTypeName, "__mappa_tmp_1"))
+                    .HasNextSyntaxNode(node => node.BeIfStatementSyntax(
+                        condition => condition.BeIsPatternExpressionSyntax(
+                            expression => expression.BeIdentifierNameSyntax("input"),
+                            pattern => pattern.BeUnaryPatternSyntax(SyntaxKind.NotKeyword, inner => inner.BeConstantPatternSyntax(null))),
+                        thenStatement => thenStatement.BeBlockStatement().AsBlock()
+                            .HasSyntaxNodesCount(6)
+                            .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(SourceTypeName, "__mappa_tmp_2", value => value.BeIdentifierNameSyntax("input")))
+                            .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.LocationDto", "__mappa_tmp_3", value => value.BeMemberAccessExpressionSyntax("__mappa_tmp_2.Location")))
+                            .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto", "__mappa_tmp_4"))
+                            .HasNextSyntaxNode(node => node.BeIfStatementSyntax(
+                                condition => condition.BeIsPatternExpressionSyntax(
+                                    expression => expression.BeIdentifierNameSyntax("__mappa_tmp_3"),
+                                    pattern => pattern.BeUnaryPatternSyntax(SyntaxKind.NotKeyword, inner => inner.BeConstantPatternSyntax(null))),
+                                thenStatement => thenStatement.BeBlockStatement().AsBlock()
+                                    .HasSyntaxNodesCount(4)
+                                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.LocationDto", "__mappa_tmp_5", value => value.BeIdentifierNameSyntax("__mappa_tmp_3")))
+                                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(typeof(string).ToString(), "__mappa_tmp_6", value => value.BeConditionalAccessExpressionSyntax("__mappa_tmp_5?.Address?.City")))
+                                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto", "__mappa_tmp_7", value => value.BeObjectCreationExpressionSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto", ("City", property => property.BeIdentifierNameSyntax("__mappa_tmp_6")))))
+                                    .HasNextSyntaxNode(node => node.BeAssignmentExpressionStatement("__mappa_tmp_4", value => value.BeIdentifierNameSyntax("__mappa_tmp_7"))),
+                                elseStatement => elseStatement.BeBlockStatement().AsBlock()
+                                    .HasSyntaxNodesCount(1)
+                                    .HasNextSyntaxNode(node => node.BeAssignmentExpressionStatement(
+                                        "__mappa_tmp_4",
+                                        value => value.BeCastExpressionSyntax(
+                                            "Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto",
+                                            cast => cast.BeLiteralExpressionSyntax(null))))))
+                            .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(TargetTypeName, "__mappa_tmp_8", value => value.BeObjectCreationExpressionSyntax(TargetTypeName, ("Address", property => property.BeIdentifierNameSyntax("__mappa_tmp_4")))))
+                            .HasNextSyntaxNode(node => node.BeAssignmentExpressionStatement("__mappa_tmp_1", value => value.BeIdentifierNameSyntax("__mappa_tmp_8"))),
+                        elseStatement => elseStatement.BeBlockStatement().AsBlock()
+                            .HasSyntaxNodesCount(1)
+                            .HasNextSyntaxNode(node => node.BeAssignmentExpressionStatement(
+                                "__mappa_tmp_1",
+                                value => value.BeCastExpressionSyntax(TargetTypeName, cast => cast.BeLiteralExpressionSyntax(null))))))
+                    .HasNextSyntaxNode(node => node.BeReturnStatement("__mappa_tmp_1")));
     }
 
     /// <summary>
@@ -156,13 +227,30 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
                                   """;
 
         var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
-        var generatedSource = GetGeneratedMapperSource(generatedResults);
 
         generatedResults.Should()
             .NotHaveDiagnostics()
-            .HaveGeneratedSourceCode();
-        generatedSource.Should().Contain("input.Outer?.Code");
-        generatedSource.Should().NotContain("?? throw");
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                TargetTypeName,
+                NullableAnnotation.NotAnnotated,
+                SourceTypeName,
+                NullableAnnotation.NotAnnotated,
+                block => block
+                    .HasSyntaxNodesCount(3)
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                        "int?",
+                        "__mappa_tmp_1",
+                        value => value.BeConditionalAccessExpressionSyntax("input.Outer?.Code")))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                        TargetTypeName,
+                        "__mappa_tmp_2",
+                        value => value.BeObjectCreationExpressionSyntax(
+                            TargetTypeName,
+                            ("Code", property => property.BeIdentifierNameSyntax("__mappa_tmp_1")))))
+                    .HasNextSyntaxNode(node => node.BeReturnStatement("__mappa_tmp_2")));
     }
 
     /// <summary>
@@ -204,14 +292,24 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
                                   """;
 
         var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
-        var generatedSource = GetGeneratedMapperSource(generatedResults);
 
         generatedResults.Should()
             .NotHaveDiagnostics()
-            .HaveGeneratedSourceCode();
-        generatedSource.Should().Contain(".Code");
-        generatedSource.Should().NotContain("?.Code");
-        generatedSource.Should().NotContain("?? throw");
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                TargetTypeName,
+                NullableAnnotation.NotAnnotated,
+                SourceTypeName,
+                NullableAnnotation.NotAnnotated,
+                block => block
+                    .HasSyntaxNodesCount(5)
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.Outer", "__mappa_tmp_1", value => value.BeMemberAccessExpressionSyntax("input.Outer")))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(typeof(int).ToString(), "__mappa_tmp_2", value => value.BeMemberAccessExpressionSyntax("__mappa_tmp_1.Code")))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.Outer", "__mappa_tmp_3", value => value.BeObjectCreationExpressionSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.Outer", ("Code", property => property.BeIdentifierNameSyntax("__mappa_tmp_2")))))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(TargetTypeName, "__mappa_tmp_4", value => value.BeObjectCreationExpressionSyntax(TargetTypeName, ("Outer", property => property.BeIdentifierNameSyntax("__mappa_tmp_3")))))
+                    .HasNextSyntaxNode(node => node.BeReturnStatement("__mappa_tmp_4")));
     }
 
     /// <summary>
@@ -258,15 +356,30 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
                                   """;
 
         var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
-        var generatedSource = GetGeneratedMapperSource(generatedResults);
 
         generatedResults.Should()
             .NotHaveDiagnostics()
-            .HaveGeneratedSourceCode();
-        generatedSource.Should().Contain("input.Location");
-        generatedSource.Should().Contain(".Address?.City");
-        generatedSource.Should().Contain("?? throw");
-        generatedSource.Should().NotContain("Location?.Address");
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                TargetTypeName,
+                NullableAnnotation.NotAnnotated,
+                SourceTypeName,
+                NullableAnnotation.NotAnnotated,
+                block => block
+                    .HasSyntaxNodesCount(5)
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.LocationDto", "__mappa_tmp_1", value => value.BeMemberAccessExpressionSyntax("input.Location")))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                        typeof(string).ToString(),
+                        "__mappa_tmp_2",
+                        value => value.BeBinaryExpressionSyntax(
+                            left => left.BeConditionalAccessExpressionSyntax("__mappa_tmp_1.Address?.City"),
+                            SyntaxKind.CoalesceExpression,
+                            right => right.BeThrowExpressionSyntax<NullReferenceException>(message => message.BeLiteralExpressionSyntax("\"Location.Address.City\" is null.")))))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto", "__mappa_tmp_3", value => value.BeObjectCreationExpressionSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto", ("City", property => property.BeIdentifierNameSyntax("__mappa_tmp_2")))))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(TargetTypeName, "__mappa_tmp_4", value => value.BeObjectCreationExpressionSyntax(TargetTypeName, ("Address", property => property.BeIdentifierNameSyntax("__mappa_tmp_3")))))
+                    .HasNextSyntaxNode(node => node.BeReturnStatement("__mappa_tmp_4")));
     }
 
     /// <summary>
@@ -313,14 +426,36 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
                                   """;
 
         var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
-        var generatedSource = GetGeneratedMapperSource(generatedResults);
 
         generatedResults.Should()
             .NotHaveDiagnostics()
-            .HaveGeneratedSourceCode();
-        generatedSource.Should().Contain("input.Container");
-        generatedSource.Should().Contain(".Metrics.Score");
-        generatedSource.Should().NotContain("?? throw");
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                TargetTypeName,
+                NullableAnnotation.NotAnnotated,
+                SourceTypeName,
+                NullableAnnotation.NotAnnotated,
+                block => block
+                    .HasSyntaxNodesCount(5)
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.Container?", "__mappa_tmp_1", value => value.BeMemberAccessExpressionSyntax("input.Container")))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.Metrics", "__mappa_tmp_2"))
+                    .HasNextSyntaxNode(node => node.BeIfStatementSyntax(
+                        condition => condition.BeIsPatternExpressionSyntax(
+                            expression => expression.BeIdentifierNameSyntax("__mappa_tmp_1"),
+                            pattern => pattern.BeUnaryPatternSyntax(SyntaxKind.NotKeyword, inner => inner.BeConstantPatternSyntax(null))),
+                        thenStatement => thenStatement.BeBlockStatement().AsBlock()
+                            .HasSyntaxNodesCount(4)
+                            .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.Container", "__mappa_tmp_3", value => value.BeIdentifierNameSyntax("__mappa_tmp_1")))
+                            .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("int?", "__mappa_tmp_4", value => value.BeConditionalAccessExpressionSyntax("__mappa_tmp_3?.Metrics.Score")))
+                            .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.Metrics", "__mappa_tmp_5", value => value.BeObjectCreationExpressionSyntax("Mappa.Generator.Tests.UnitTests.SourceCode.Metrics", ("Score", property => property.BeIdentifierNameSyntax("__mappa_tmp_4")))))
+                            .HasNextSyntaxNode(node => node.BeAssignmentExpressionStatement("__mappa_tmp_2", value => value.BeIdentifierNameSyntax("__mappa_tmp_5"))),
+                        elseStatement => elseStatement.BeBlockStatement().AsBlock()
+                            .HasSyntaxNodesCount(1)
+                            .HasNextSyntaxNode(node => node.BeThrowStatementSyntax<NullReferenceException>(message => message.BeLiteralExpressionSyntax("\"__mappa_tmp_1\" is null.")))))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(TargetTypeName, "__mappa_tmp_6", value => value.BeObjectCreationExpressionSyntax(TargetTypeName, ("Metrics", property => property.BeIdentifierNameSyntax("__mappa_tmp_2")))))
+                    .HasNextSyntaxNode(node => node.BeReturnStatement("__mappa_tmp_6")));
     }
 
     /// <summary>
@@ -362,13 +497,32 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
                                   """;
 
         var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
-        var generatedSource = GetGeneratedMapperSource(generatedResults);
 
         generatedResults.Should()
             .NotHaveDiagnostics()
-            .HaveGeneratedSourceCode();
-        generatedSource.Should().Contain("input.Outer.Code");
-        generatedSource.Should().Contain("?? throw");
-        generatedSource.Should().NotContain("?.Code");
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                TargetTypeName,
+                NullableAnnotation.NotAnnotated,
+                SourceTypeName,
+                NullableAnnotation.NotAnnotated,
+                block => block
+                    .HasSyntaxNodesCount(3)
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                        "int?",
+                        "__mappa_tmp_1",
+                        value => value.BeBinaryExpressionSyntax(
+                            left => left.BeMemberAccessExpressionSyntax("input.Outer.Code"),
+                            SyntaxKind.CoalesceExpression,
+                            right => right.BeThrowExpressionSyntax<NullReferenceException>(message => message.BeLiteralExpressionSyntax("\"Outer.Code\" is null.")))))
+                    .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                        TargetTypeName,
+                        "__mappa_tmp_2",
+                        value => value.BeObjectCreationExpressionSyntax(
+                            TargetTypeName,
+                            ("Code", property => property.BeIdentifierNameSyntax("__mappa_tmp_1")))))
+                    .HasNextSyntaxNode(node => node.BeReturnStatement("__mappa_tmp_2")));
     }
 }

--- a/Mappa.Generator.Tests/NestedPropertyPathAttributeIntegrationTests.OtherAttributes.cs
+++ b/Mappa.Generator.Tests/NestedPropertyPathAttributeIntegrationTests.OtherAttributes.cs
@@ -5,6 +5,9 @@
 using Mappa.Generator.Tests.Assertions;
 using Mappa.Generator.Tests.Assertions.Extensions;
 
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
 namespace Mappa.Generator.Tests;
 
 /// <summary>
@@ -57,7 +60,46 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
 
         generatedResults.Should()
             .NotHaveDiagnostics()
-            .HaveGeneratedSourceCode();
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                TargetTypeName,
+                NullableAnnotation.NotAnnotated,
+                SourceTypeName,
+                NullableAnnotation.NotAnnotated,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(6)
+                        .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                            "Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto",
+                            "__mappa_tmp_1",
+                            expression => expression.BeMemberAccessExpressionSyntax("input.Address")))
+                        .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                            typeof(string).ToString(),
+                            "__mappa_tmp_2",
+                            expression => expression.BeMemberAccessExpressionSyntax("__mappa_tmp_1.City")))
+                        .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                            typeof(string).ToString(),
+                            "__mappa_tmp_3",
+                            expression => expression.BeInvocationExpressionSyntax(
+                                "this.CustomMapCity",
+                                argument => argument.BeIdentifierNameSyntax("__mappa_tmp_2"))))
+                        .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                            "Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto",
+                            "__mappa_tmp_4",
+                            expression => expression.BeObjectCreationExpressionSyntax(
+                                "Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto",
+                                ("City", value => value.BeIdentifierNameSyntax("__mappa_tmp_3")))))
+                        .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                            TargetTypeName,
+                            "__mappa_tmp_5",
+                            expression => expression.BeObjectCreationExpressionSyntax(
+                                TargetTypeName,
+                                ("Address", value => value.BeIdentifierNameSyntax("__mappa_tmp_4")))))
+                        .HasNextSyntaxNode(node => node.BeReturnStatement("__mappa_tmp_5"));
+                });
     }
 
     /// <summary>
@@ -104,13 +146,37 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
                                   """;
 
         var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
-        var generatedSource = GetGeneratedMapperSource(generatedResults);
 
         generatedResults.Should()
             .NotHaveDiagnostics()
-            .HaveGeneratedSourceCode();
-        generatedSource.Should().Contain("input.Location?.Address?.City");
-        generatedSource.Should().Contain("throw new System.NullReferenceException");
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                TargetTypeName,
+                NullableAnnotation.NotAnnotated,
+                SourceTypeName,
+                NullableAnnotation.NotAnnotated,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(3)
+                        .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                            typeof(string).ToString(),
+                            "__mappa_tmp_1",
+                            expression => expression.BeBinaryExpressionSyntax(
+                                left => left.BeConditionalAccessExpressionSyntax("input.Location?.Address?.City"),
+                                SyntaxKind.CoalesceExpression,
+                                right => right.BeThrowExpressionSyntax<NullReferenceException>(
+                                    message => message.BeLiteralExpressionSyntax("\"Location.Address.City\" is null.")))))
+                        .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                            TargetTypeName,
+                            "__mappa_tmp_2",
+                            expression => expression.BeObjectCreationExpressionSyntax(
+                                TargetTypeName,
+                                ("City", value => value.BeIdentifierNameSyntax("__mappa_tmp_1")))))
+                        .HasNextSyntaxNode(node => node.BeReturnStatement("__mappa_tmp_2"));
+                });
     }
 
     /// <summary>
@@ -153,13 +219,43 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
                                   """;
 
         var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
-        var generatedSource = GetGeneratedMapperSource(generatedResults);
 
         generatedResults.Should()
             .NotHaveDiagnostics()
-            .HaveGeneratedSourceCode();
-        generatedSource.Should().Contain("= \"London\"");
-        generatedSource.Should().NotContain("\\\"London\\\"");
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethodWithContext(
+                TargetTypeName,
+                NullableAnnotation.NotAnnotated,
+                SourceTypeName,
+                NullableAnnotation.NotAnnotated,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(5)
+                        .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                            "Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto",
+                            "__mappa_tmp_1",
+                            expression => expression.BeMemberAccessExpressionSyntax("input.Address")))
+                        .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                            typeof(string).ToString(),
+                            "__mappa_tmp_2",
+                            expression => expression.BeLiteralExpressionSyntax("London")))
+                        .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                            "Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto",
+                            "__mappa_tmp_3",
+                            expression => expression.BeObjectCreationExpressionSyntax(
+                                "Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto",
+                                ("City", value => value.BeIdentifierNameSyntax("__mappa_tmp_2")))))
+                        .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                            TargetTypeName,
+                            "__mappa_tmp_4",
+                            expression => expression.BeObjectCreationExpressionSyntax(
+                                TargetTypeName,
+                                ("Address", value => value.BeIdentifierNameSyntax("__mappa_tmp_3")))))
+                        .HasNextSyntaxNode(node => node.BeReturnStatement("__mappa_tmp_4"));
+                });
     }
 
     /// <summary>
@@ -202,13 +298,45 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
                                   """;
 
         var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
-        var generatedSource = GetGeneratedMapperSource(generatedResults);
 
         generatedResults.Should()
             .NotHaveDiagnostics()
-            .HaveGeneratedSourceCode();
-        generatedSource.Should().Contain("context[\"city\"]");
-        generatedSource.Should().NotContain(".City;");
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethodWithContext(
+                TargetTypeName,
+                NullableAnnotation.NotAnnotated,
+                SourceTypeName,
+                NullableAnnotation.NotAnnotated,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(5)
+                        .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                            "Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto",
+                            "__mappa_tmp_1",
+                            expression => expression.BeMemberAccessExpressionSyntax("input.Address")))
+                        .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                            typeof(string).ToString(),
+                            "__mappa_tmp_2",
+                            expression => expression.BeCastExpressionSyntax(
+                                typeof(string).ToString(),
+                                cast => cast.BeElementAccessExpressionSyntaxWithLiteralSyntax("context", "city"))))
+                        .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                            "Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto",
+                            "__mappa_tmp_3",
+                            expression => expression.BeObjectCreationExpressionSyntax(
+                                "Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto",
+                                ("City", value => value.BeIdentifierNameSyntax("__mappa_tmp_2")))))
+                        .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                            TargetTypeName,
+                            "__mappa_tmp_4",
+                            expression => expression.BeObjectCreationExpressionSyntax(
+                                TargetTypeName,
+                                ("Address", value => value.BeIdentifierNameSyntax("__mappa_tmp_3")))))
+                        .HasNextSyntaxNode(node => node.BeReturnStatement("__mappa_tmp_4"));
+                });
     }
 
     /// <summary>
@@ -251,13 +379,34 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
                                   """;
 
         var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
-        var generatedSource = GetGeneratedMapperSource(generatedResults);
 
         generatedResults.Should()
             .NotHaveDiagnostics()
-            .HaveGeneratedSourceCode();
-        generatedSource.Should().Contain("context[\"caboom\"] = __mappa_tmp_");
-        generatedSource.Should().Contain(".Address.City");
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethodWithContext(
+                TargetTypeName,
+                NullableAnnotation.NotAnnotated,
+                SourceTypeName,
+                NullableAnnotation.NotAnnotated,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(4)
+                        .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                            "Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto",
+                            "__mappa_tmp_1",
+                            expression => expression.BeMemberAccessExpressionSyntax("input.Address")))
+                        .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                            TargetTypeName,
+                            "__mappa_tmp_2",
+                            expression => expression.BeObjectCreationExpressionSyntax(
+                                TargetTypeName,
+                                ("Address", value => value.BeIdentifierNameSyntax("__mappa_tmp_1")))))
+                        .HasNextSyntaxNode(node => node.BeAssignToContextStatement("context", "caboom", "__mappa_tmp_2", "Address.City"))
+                        .HasNextSyntaxNode(node => node.BeReturnStatement("__mappa_tmp_2"));
+                });
     }
 
     /// <summary>
@@ -303,6 +452,39 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
 
         generatedResults.Should()
             .NotHaveDiagnostics()
-            .HaveGeneratedSourceCode();
+            .HaveGeneratedSourceCode()
+            .WithCompilationUnit()
+            .NotBeNull().And
+            .HaveDefaultMapMethod(
+                TargetTypeName,
+                NullableAnnotation.NotAnnotated,
+                SourceTypeName,
+                NullableAnnotation.NotAnnotated,
+                blockSyntaxAssertions =>
+                {
+                    blockSyntaxAssertions
+                        .HasSyntaxNodesCount(5)
+                        .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                            "Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto",
+                            "__mappa_tmp_1",
+                            expression => expression.BeMemberAccessExpressionSyntax("input.Address")))
+                        .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                            typeof(string).ToString(),
+                            "__mappa_tmp_2",
+                            expression => expression.BeMemberAccessExpressionSyntax("__mappa_tmp_1.City")))
+                        .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                            "Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto",
+                            "__mappa_tmp_3",
+                            expression => expression.BeObjectCreationExpressionSyntax(
+                                "Mappa.Generator.Tests.UnitTests.SourceCode.AddressDto",
+                                ("City", value => value.BeIdentifierNameSyntax("__mappa_tmp_2")))))
+                        .HasNextSyntaxNode(node => node.BeLocalDeclarationStatementSyntax(
+                            TargetTypeName,
+                            "__mappa_tmp_4",
+                            expression => expression.BeObjectCreationExpressionSyntax(
+                                TargetTypeName,
+                                ("Address", value => value.BeIdentifierNameSyntax("__mappa_tmp_3")))))
+                        .HasNextSyntaxNode(node => node.BeReturnStatement("__mappa_tmp_4"));
+                });
     }
 }

--- a/Mappa.Generator.Tests/NestedPropertyPathAttributeIntegrationTests.cs
+++ b/Mappa.Generator.Tests/NestedPropertyPathAttributeIntegrationTests.cs
@@ -3,7 +3,6 @@
 // </copyright>
 
 using Mappa.Generator.Tests.Abstractions;
-using Mappa.Generator.Tests.Models;
 
 namespace Mappa.Generator.Tests;
 
@@ -15,9 +14,4 @@ public sealed partial class NestedPropertyPathAttributeIntegrationTests
 {
     private const string TargetTypeName = "Mappa.Generator.Tests.UnitTests.SourceCode.Target";
     private const string SourceTypeName = "Mappa.Generator.Tests.UnitTests.SourceCode.Source";
-
-    private static string GetGeneratedMapperSource(GeneratedResults generatedResults)
-        => string.Join(
-            Environment.NewLine,
-            generatedResults.OutputCompilation.SyntaxTrees.Skip(1).Select(tree => tree.ToString()));
 }

--- a/MappaVersion.targets
+++ b/MappaVersion.targets
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <MappaVersion>10.2.0-alpha.10</MappaVersion>
+        <MappaVersion>10.2.0-alpha.11</MappaVersion>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Strengthen all successful nested property-path generator integration tests to assert generated map method bodies with `HasSyntaxNodesCount` / `HasNextSyntaxNode` (no string containment on generated source).
- Add `BeConditionalAccessExpressionSyntax` and `BeThrowExpressionSyntax` assertion helpers (and nested `BeAssignToContextStatement` path support).
- Bump `MappaVersion` to `10.2.0-alpha.11` for CI.

## Test plan
- [x] Filtered nested-path suite: 28/28 passed
- [x] `.\Scripts\RunTestsAndReportCoverage.ps1` — 2392 passed; coverage matches baseline (line 97.5%, branch 90.5%, method 95.4%)
- [ ] CI green on PR

Closes #277
