### PR TITLE
#276 Improve method coverage and coverage history SVG

### DIFF
--- a/Mappa.Generator/Extensions/AttributeDataExtensions.cs
+++ b/Mappa.Generator/Extensions/AttributeDataExtensions.cs
@@ -3,9 +3,7 @@
 // </copyright>
 
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Globalization;
-using System.Reflection;
 
 using Mappa.Attributes;
 using Mappa.Generator.Exceptions;
@@ -570,108 +568,5 @@ internal static class AttributeDataExtensions
         }
 
         return [..results];
-    }
-
-    [DebuggerDisplay("FullName = {FullName}")]
-    private sealed class FakeType(string fullName) : Type
-    {
-        public override Module Module => throw new NotImplementedException();
-
-        public override string? Namespace => throw new NotImplementedException();
-
-        public override string Name => throw new NotImplementedException();
-
-        public override Assembly Assembly => throw new NotImplementedException();
-
-        public override string? AssemblyQualifiedName => throw new NotImplementedException();
-
-        public override Type? BaseType => throw new NotImplementedException();
-
-        public override string? FullName => fullName;
-
-        public override Guid GUID => throw new NotImplementedException();
-
-        public override Type UnderlyingSystemType => throw new NotImplementedException();
-
-        public override object[] GetCustomAttributes(bool inherit)
-            => throw new NotImplementedException();
-
-        public override object[] GetCustomAttributes(Type attributeType, bool inherit)
-            => throw new NotImplementedException();
-
-        public override bool IsDefined(Type attributeType, bool inherit)
-            => throw new NotImplementedException();
-
-        public override ConstructorInfo[] GetConstructors(BindingFlags bindingAttr)
-            => throw new NotImplementedException();
-
-        public override Type? GetElementType()
-            => throw new NotImplementedException();
-
-        public override EventInfo? GetEvent(string name, BindingFlags bindingAttr)
-            => throw new NotImplementedException();
-
-        public override EventInfo[] GetEvents(BindingFlags bindingAttr)
-            => throw new NotImplementedException();
-
-        public override FieldInfo? GetField(string name, BindingFlags bindingAttr)
-            => throw new NotImplementedException();
-
-        public override FieldInfo[] GetFields(BindingFlags bindingAttr)
-            => throw new NotImplementedException();
-
-        public override MemberInfo[] GetMembers(BindingFlags bindingAttr)
-            => throw new NotImplementedException();
-
-        public override MethodInfo[] GetMethods(BindingFlags bindingAttr)
-            => throw new NotImplementedException();
-
-        public override PropertyInfo[] GetProperties(BindingFlags bindingAttr)
-            => throw new NotImplementedException();
-
-        public override object InvokeMember(string name, BindingFlags invokeAttr, Binder binder, object target, object[] args, ParameterModifier[] modifiers, CultureInfo culture, string[] namedParameters)
-            => throw new NotImplementedException();
-
-        public override Type GetNestedType(string name, BindingFlags bindingAttr)
-            => throw new NotImplementedException();
-
-        public override Type[] GetNestedTypes(BindingFlags bindingAttr)
-            => throw new NotImplementedException();
-
-        public override Type GetInterface(string name, bool ignoreCase)
-            => throw new NotImplementedException();
-
-        public override Type[] GetInterfaces()
-            => throw new NotImplementedException();
-
-        protected override MethodInfo? GetMethodImpl(string name, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers)
-            => throw new NotImplementedException();
-
-        protected override TypeAttributes GetAttributeFlagsImpl()
-            => throw new NotImplementedException();
-
-        protected override ConstructorInfo? GetConstructorImpl(BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers)
-            => throw new NotImplementedException();
-
-        protected override bool IsArrayImpl()
-            => throw new NotImplementedException();
-
-        protected override bool IsByRefImpl()
-            => throw new NotImplementedException();
-
-        protected override bool IsCOMObjectImpl()
-            => throw new NotImplementedException();
-
-        protected override bool IsPointerImpl()
-            => throw new NotImplementedException();
-
-        protected override bool IsPrimitiveImpl()
-            => throw new NotImplementedException();
-
-        protected override PropertyInfo? GetPropertyImpl(string name, BindingFlags bindingAttr, Binder binder, Type returnType, Type[] types, ParameterModifier[] modifiers)
-            => throw new NotImplementedException();
-
-        protected override bool HasElementTypeImpl()
-            => throw new NotImplementedException();
     }
 }

--- a/Mappa.Generator/Extensions/FakeType.cs
+++ b/Mappa.Generator/Extensions/FakeType.cs
@@ -1,0 +1,152 @@
+// <copyright file="FakeType.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using System.Diagnostics;
+using System.Globalization;
+using System.Reflection;
+
+namespace Mappa.Generator.Extensions;
+
+/// <summary>
+/// Minimal <see cref="Type"/> stub used when constructing attribute instances
+/// from Roslyn symbols that expose type arguments as <see cref="Type"/>.
+/// </summary>
+[DebuggerDisplay("FullName = {FullName}")]
+internal sealed class FakeType(string fullName) : Type
+{
+    /// <inheritdoc/>
+    public override Module Module => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    public override string? Namespace => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    public override string Name => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    public override Assembly Assembly => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    public override string? AssemblyQualifiedName => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    public override Type? BaseType => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    public override string? FullName => fullName;
+
+    /// <inheritdoc/>
+    public override Guid GUID => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    public override Type UnderlyingSystemType => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    public override object[] GetCustomAttributes(bool inherit)
+        => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    public override object[] GetCustomAttributes(Type attributeType, bool inherit)
+        => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    public override bool IsDefined(Type attributeType, bool inherit)
+        => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    public override ConstructorInfo[] GetConstructors(BindingFlags bindingAttr)
+        => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    public override Type? GetElementType()
+        => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    public override EventInfo? GetEvent(string name, BindingFlags bindingAttr)
+        => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    public override EventInfo[] GetEvents(BindingFlags bindingAttr)
+        => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    public override FieldInfo? GetField(string name, BindingFlags bindingAttr)
+        => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    public override FieldInfo[] GetFields(BindingFlags bindingAttr)
+        => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    public override MemberInfo[] GetMembers(BindingFlags bindingAttr)
+        => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    public override MethodInfo[] GetMethods(BindingFlags bindingAttr)
+        => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    public override PropertyInfo[] GetProperties(BindingFlags bindingAttr)
+        => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    public override object InvokeMember(string name, BindingFlags invokeAttr, Binder binder, object target, object[] args, ParameterModifier[] modifiers, CultureInfo culture, string[] namedParameters)
+        => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    public override Type GetNestedType(string name, BindingFlags bindingAttr)
+        => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    public override Type[] GetNestedTypes(BindingFlags bindingAttr)
+        => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    public override Type GetInterface(string name, bool ignoreCase)
+        => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    public override Type[] GetInterfaces()
+        => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    protected override MethodInfo? GetMethodImpl(string name, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers)
+        => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    protected override TypeAttributes GetAttributeFlagsImpl()
+        => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    protected override ConstructorInfo? GetConstructorImpl(BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers)
+        => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    protected override bool IsArrayImpl()
+        => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    protected override bool IsByRefImpl()
+        => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    protected override bool IsCOMObjectImpl()
+        => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    protected override bool IsPointerImpl()
+        => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    protected override bool IsPrimitiveImpl()
+        => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    protected override PropertyInfo? GetPropertyImpl(string name, BindingFlags bindingAttr, Binder binder, Type returnType, Type[] types, ParameterModifier[] modifiers)
+        => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    protected override bool HasElementTypeImpl()
+        => throw new NotImplementedException();
+}

--- a/Mappa.Generator/Extensions/TypeSymbolExtensions.cs
+++ b/Mappa.Generator/Extensions/TypeSymbolExtensions.cs
@@ -44,7 +44,6 @@ internal static class TypeSymbolExtensions
     private const string Tuple6Fullname = "System.Tuple`6";
     private const string Tuple7Fullname = "System.Tuple`7";
     private const string Tuple8Fullname = "System.Tuple`8";
-    private const string DictionaryFullName = "System.Collections.Generic.Dictionary`2";
     private const string ReadOnlyDictionaryFullName = "System.Collections.ObjectModel.ReadOnlyDictionary`2";
     private const string ReadOnlyCollectionFullName = "System.Collections.ObjectModel.ReadOnlyCollection`1";
     private const string ReadOnlySetFullName = "System.Collections.ObjectModel.ReadOnlySet`1";
@@ -247,19 +246,6 @@ internal static class TypeSymbolExtensions
         var listType = compilation.GetTypeByMetadataName(ReadOnlyDictionaryInterfaceFullName);
         var isList = SymbolEqualityComparer.Default.Equals(listType, typeSymbol.OriginalDefinition);
         return isList;
-    }
-
-    /// <summary>
-    /// Check if the type is <see cref="Dictionary{K,V}"/>.
-    /// </summary>
-    /// <param name="typeSymbol">The type symbol.</param>
-    /// <param name="compilation">The compilation.</param>
-    /// <returns><c>true</c> if the type symbol is <see cref="Dictionary{K,V}"/>.</returns>
-    internal static bool IsDictionary(this ITypeSymbol typeSymbol, Compilation compilation)
-    {
-        var dictionaryType = compilation.GetTypeByMetadataName(DictionaryFullName);
-        var isDictionary = SymbolEqualityComparer.Default.Equals(dictionaryType, typeSymbol.OriginalDefinition);
-        return isDictionary;
     }
 
     /// <summary>
@@ -551,15 +537,6 @@ internal static class TypeSymbolExtensions
     /// <returns><c>true</c> if the type symbol implements <see cref="IDictionary{K,V}"/>.</returns>
     internal static bool IsOrImplementIDictionary(this ITypeSymbol typeSymbol, Compilation compilation)
         => typeSymbol.IsIDictionary(compilation) || typeSymbol.AllInterfaces.Any(@interface => @interface.IsIDictionary(compilation));
-
-    /// <summary>
-    /// Check if the type is <see cref="IReadOnlyDictionary{K,V}"/> or implements <see cref="IReadOnlyDictionary{K,V}"/>.
-    /// </summary>
-    /// <param name="typeSymbol">The type symbol.</param>
-    /// <param name="compilation">The compilation.</param>
-    /// <returns><c>true</c> if the type symbol implements <see cref="IDictionary{K,V}"/>.</returns>
-    internal static bool IsOrImplementIReadOnlyDictionary(this ITypeSymbol typeSymbol, Compilation compilation)
-        => typeSymbol.IsIReadOnlyDictionary(compilation) || typeSymbol.AllInterfaces.Any(@interface => @interface.IsIReadOnlyDictionary(compilation));
 
     /// <summary>
     /// Check if the type is <see cref="Tuple"/>.
@@ -1651,19 +1628,6 @@ internal static class TypeSymbolExtensions
         }
 
         return false;
-    }
-
-    /// <summary>
-    /// Check if the type is <see cref="ConcurrentBag{T}"/>.
-    /// </summary>
-    /// <param name="typeSymbol">The type symbol.</param>
-    /// <param name="compilation">The compilation.</param>
-    /// <returns><c>true</c> if the type symbol is <see cref="ConcurrentBag{T}"/>.</returns>
-    internal static bool IsConcurrentBag(this ITypeSymbol typeSymbol, Compilation compilation)
-    {
-        var blockingCollectionSymbol = compilation.GetTypeByMetadataName(ConcurrentBagFullName);
-        var isConcurrentBags = SymbolEqualityComparer.Default.Equals(blockingCollectionSymbol, typeSymbol.OriginalDefinition);
-        return isConcurrentBags;
     }
 
     /// <summary>

--- a/Mappa.Tests/MappaCloningTests.cs
+++ b/Mappa.Tests/MappaCloningTests.cs
@@ -1,0 +1,66 @@
+// <copyright file="MappaCloningTests.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using AwesomeAssertions;
+
+using Xunit;
+using Xunit.OpenCategories.V3;
+
+namespace Mappa.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="MappaCloning"/>.
+/// </summary>
+public sealed class MappaCloningTests
+{
+    /// <summary>
+    /// Tests <see cref="MappaCloning.MemberwiseClone{T}"/> creates a shallow clone.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void MemberwiseCloneCreatesShallowCopy()
+    {
+        // Arrange
+        var nested = new NestedType { Value = 42 };
+        var source = new CloneableType { Name = "alpha", Nested = nested };
+
+        // Act
+        var clone = MappaCloning.MemberwiseClone(source);
+
+        // Assert
+        ReferenceEquals(clone, source).Should().BeFalse();
+        clone.Name.Should().Be("alpha");
+        clone.Nested.Should().BeSameAs(nested);
+        clone.Nested.Value.Should().Be(42);
+    }
+
+    /// <summary>
+    /// Tests <see cref="MappaCloning.MemberwiseClone{T}"/> throws when source is <see langword="null"/>.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void MemberwiseCloneThrowsWhenSourceIsNull()
+    {
+        // Act
+#pragma warning disable CS8625 // Intentional null argument to exercise ArgumentNullException path
+        var act = () => MappaCloning.MemberwiseClone<CloneableType>(null);
+#pragma warning restore CS8625
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>()
+            .Which.ParamName.Should().Be("source");
+    }
+
+    private sealed class CloneableType
+    {
+        public string Name { get; set; } = string.Empty;
+
+        public NestedType Nested { get; set; } = new();
+    }
+
+    private sealed class NestedType
+    {
+        public int Value { get; set; }
+    }
+}

--- a/MappaVersion.targets
+++ b/MappaVersion.targets
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <MappaVersion>10.2.0-alpha.12</MappaVersion>
+        <MappaVersion>10.2.0-alpha.13</MappaVersion>
     </PropertyGroup>
 </Project>

--- a/MappaVersion.targets
+++ b/MappaVersion.targets
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <MappaVersion>10.2.0-alpha.11</MappaVersion>
+        <MappaVersion>10.2.0-alpha.12</MappaVersion>
     </PropertyGroup>
 </Project>

--- a/Scripts/RunTestsAndReportCoverage.ps1
+++ b/Scripts/RunTestsAndReportCoverage.ps1
@@ -60,7 +60,7 @@ if (-not $?)
 }
 
 dotnet tool restore
-dotnet reportgenerator -reports:"$MappaTestsAndCoveragePath/coverage.cobertura*.xml" -targetdir:"$MappaTestsAndCoveragePath" -title:"Mappa" -reporttypes:"Html;MarkdownSummary;XmlSummary" -filefilters:"-*.g.cs" -assemblyfilters:"-Mappa.Samples;-Moq" -classfilters:"-Mappa.Generator.Exceptions.MappaGeneratorException;-Mappa.Generator.Diagnostics.Debug.MappaDebug;-Mappa.Generator.Diagnostics.DiagnosticsResources;-Mappa.Generator.Diagnostics.MappaDiagnosticDescriptors"
+dotnet reportgenerator -reports:"$MappaTestsAndCoveragePath/coverage.cobertura*.xml" -targetdir:"$MappaTestsAndCoveragePath" -title:"Mappa" -reporttypes:"Html;MarkdownSummary;XmlSummary" -filefilters:"-*.g.cs" -assemblyfilters:"-Mappa.Samples;-Moq" -classfilters:"-Mappa.Generator.Exceptions.MappaGeneratorException;-Mappa.Generator.Diagnostics.Debug.MappaDebug;-Mappa.Generator.Diagnostics.DiagnosticsResources;-Mappa.Generator.Diagnostics.MappaDiagnosticDescriptors;-Mappa.Generator.Extensions.AttributeDataExtensions/FakeType"
 if (-not $?)
 {
     Write-Host "Report failed" -ForegroundColor Red

--- a/Scripts/RunTestsAndReportCoverage.ps1
+++ b/Scripts/RunTestsAndReportCoverage.ps1
@@ -60,7 +60,7 @@ if (-not $?)
 }
 
 dotnet tool restore
-dotnet reportgenerator -reports:"$MappaTestsAndCoveragePath/coverage.cobertura*.xml" -targetdir:"$MappaTestsAndCoveragePath" -title:"Mappa" -reporttypes:"Html;MarkdownSummary;XmlSummary" -filefilters:"-*.g.cs" -assemblyfilters:"-Mappa.Samples;-Moq" -classfilters:"-Mappa.Generator.Exceptions.MappaGeneratorException;-Mappa.Generator.Diagnostics.Debug.MappaDebug;-Mappa.Generator.Diagnostics.DiagnosticsResources;-Mappa.Generator.Diagnostics.MappaDiagnosticDescriptors;-Mappa.Generator.Extensions.AttributeDataExtensions/FakeType"
+dotnet reportgenerator -reports:"$MappaTestsAndCoveragePath/coverage.cobertura*.xml" -targetdir:"$MappaTestsAndCoveragePath" -title:"Mappa" -reporttypes:"Html;MarkdownSummary;XmlSummary" -filefilters:"-*.g.cs" -assemblyfilters:"-Mappa.Samples;-Moq" -classfilters:"-Mappa.Generator.Exceptions.MappaGeneratorException;-Mappa.Generator.Diagnostics.Debug.MappaDebug;-Mappa.Generator.Diagnostics.DiagnosticsResources;-Mappa.Generator.Diagnostics.MappaDiagnosticDescriptors;-Mappa.Generator.Extensions.FakeType"
 if (-not $?)
 {
     Write-Host "Report failed" -ForegroundColor Red

--- a/Scripts/UpdateCodeCoverageGists.ps1
+++ b/Scripts/UpdateCodeCoverageGists.ps1
@@ -12,21 +12,19 @@ function Out-Svg
 
     # Generate line coverage (and text version)
     $LineCoveragePoints = ""
-    $LineCoverageCircles = ""
     $xLabels = ""
     $x = 90
     foreach ($line in $html.table.tbody.tr)
     {
         $line = $line.td
-        if (-not ($line[1].Contains("-")))
-        {
-            $xLabels = "$xLabels<text x=`"$x`" y=`"400`">$( $line[1] )</text>"
-        }
-
         if ($line[2] -eq "LINE")
         {
-            [double]$y = 375.00 - [System.Double]::Parse($line[3]) * 370.00 / 100.00
-            $LineCoverageCircles = "$LineCoverageCircles<circle cx=`"$x`" cy=`"$y`" r=`"4`"/>"
+            if (-not ($line[1].Contains("-")))
+            {
+                $xLabels = "$xLabels<text x=`"$x`" y=`"400`">$( $line[1] )</text>"
+            }
+
+            [double]$y = 375.00 - ([System.Double]::Parse($line[3]) - 80.00) * 370.00 / 20.00
             $LineCoveragePoints = "$LineCoveragePoints$x,$y "
             $x = $x + $xSpacing
         }
@@ -34,15 +32,13 @@ function Out-Svg
 
     # Generate branch coverage
     $BranchCoveragePoints = ""
-    $BranchCoverageCircles = ""
     $x = 90
     foreach ($line in $html.table.tbody.tr)
     {
         $line = $line.td
         if ($line[2] -eq "BRANCH")
         {
-            [double]$y = 375.00 - [System.Double]::Parse($line[3]) * 370.00 / 100.00
-            $BranchCoverageCircles = "$BranchCoverageCircles<circle cx=`"$x`" cy=`"$y`" r=`"4`"/>"
+            [double]$y = 375.00 - ([System.Double]::Parse($line[3]) - 80.00) * 370.00 / 20.00
             $BranchCoveragePoints = "$BranchCoveragePoints$x,$y "
             $x = $x + $xSpacing
         }
@@ -50,15 +46,13 @@ function Out-Svg
 
     # Generate method coverage
     $MethodCoveragePoints = ""
-    $MethodCoverageCircles = ""
     $x = 90
     foreach ($line in $html.table.tbody.tr)
     {
         $line = $line.td
         if ($line[2] -eq "METHOD")
         {
-            [double]$y = 375.00 - [System.Double]::Parse($line[3]) * 370.00 / 100.00
-            $MethodCoverageCircles = "$MethodCoverageCircles$circles<circle cx=`"$x`" cy=`"$y`" r=`"4`"/>"
+            [double]$y = 375.00 - ([System.Double]::Parse($line[3]) - 80.00) * 370.00 / 20.00
             $MethodCoveragePoints = "$MethodCoveragePoints$x,$y "
             $x = $x + $xSpacing
         }
@@ -74,22 +68,17 @@ function Out-Svg
     "            <text x=`"400`" y=`"440`" style=`"font-weight: bold;text-transform: uppercase;font-size: 12px;fill: black;`">Versions</text>" | Out-File -Append $SvgFilename
     "    </g>" | Out-File -Append $SvgFilename
     "    <g style=`"text-anchor: end;font-size: 13px;`">" | Out-File -Append $SvgFilename
-    "        <text x=`"80`" y=`"15`">100</text><text x=`"80`" y=`"52`">90</text><text x=`"80`" y=`"89`">80</text><text x=`"80`" y=`"126`">70</text>" | Out-File -Append $SvgFilename
-    "        <text x=`"80`" y=`"163`">60</text><text x=`"80`" y=`"200`">50</text><text x=`"80`" y=`"237`">40</text><text x=`"80`" y=`"274`">30</text>" | Out-File -Append $SvgFilename
-    "        <text x=`"80`" y=`"311`">20</text><text x=`"80`" y=`"340`">10</text><text x=`"80`" y=`"375`">0</text>" | Out-File -Append $SvgFilename
+    "        <text x=`"80`" y=`"15`">100</text><text x=`"80`" y=`"107.5`">95</text><text x=`"80`" y=`"200`">90</text><text x=`"80`" y=`"292.5`">85</text><text x=`"80`" y=`"375`">80</text>" | Out-File -Append $SvgFilename
     "        <text x=`"50`" y=`"200`" style=`"font-weight: bold;text-transform: uppercase;font-size: 12px;fill: black;`">%</text>" | Out-File -Append $SvgFilename
     "    </g>"  | Out-File -Append $SvgFilename
     "    <g style=`"stroke:red; fill:red`" data-setname=`"Line coverage`">" | Out-File -Append $SvgFilename
     "        <polyline points=`"$LineCoveragePoints`" style=`"fill:none`" />" | Out-File -Append $SvgFilename
-    "        $LineCoverageCircles" | Out-File -Append $SvgFilename
     "    </g>"  | Out-File -Append $SvgFilename
     "    <g style=`"stroke:blue; fill:blue`" data-setname=`"Branch coverage`">" | Out-File -Append $SvgFilename
     "        <polyline points=`"$BranchCoveragePoints`" style=`"fill:none`" />" | Out-File -Append $SvgFilename
-    "        $BranchCoverageCircles" | Out-File -Append $SvgFilename
     "    </g>"  | Out-File -Append $SvgFilename
     "    <g style=`"stroke:green; fill:green`" data-setname=`"Method coverage`">" | Out-File -Append $SvgFilename
     "        <polyline points=`"$MethodCoveragePoints`" style=`"fill:none`" />" | Out-File -Append $SvgFilename
-    "        $MethodCoverageCircles" | Out-File -Append $SvgFilename
     "    </g>"  | Out-File -Append $SvgFilename
     "</svg>" | Out-File -Append $SvgFilename
 }

--- a/Scripts/UpdateCodeCoverageGists.ps1
+++ b/Scripts/UpdateCodeCoverageGists.ps1
@@ -12,6 +12,7 @@ function Out-Svg
 
     # Generate line coverage (and text version)
     $LineCoveragePoints = ""
+    $LineCoverageCircles = ""
     $xLabels = ""
     $x = 90
     foreach ($line in $html.table.tbody.tr)
@@ -19,6 +20,7 @@ function Out-Svg
         $line = $line.td
         if ($line[2] -eq "LINE")
         {
+            # Plot every version (main + intermediate); label only main releases on the X axis.
             if (-not ($line[1].Contains("-")))
             {
                 $xLabels = "$xLabels<text x=`"$x`" y=`"400`">$( $line[1] )</text>"
@@ -26,12 +28,18 @@ function Out-Svg
 
             [double]$y = 375.00 - ([System.Double]::Parse($line[3]) - 80.00) * 370.00 / 20.00
             $LineCoveragePoints = "$LineCoveragePoints$x,$y "
+            if (-not ($line[1].Contains("-")))
+            {
+                $LineCoverageCircles = "$LineCoverageCircles<circle cx=`"$x`" cy=`"$y`" r=`"4`"/>"
+            }
+
             $x = $x + $xSpacing
         }
     }
 
     # Generate branch coverage
     $BranchCoveragePoints = ""
+    $BranchCoverageCircles = ""
     $x = 90
     foreach ($line in $html.table.tbody.tr)
     {
@@ -40,12 +48,18 @@ function Out-Svg
         {
             [double]$y = 375.00 - ([System.Double]::Parse($line[3]) - 80.00) * 370.00 / 20.00
             $BranchCoveragePoints = "$BranchCoveragePoints$x,$y "
+            if (-not ($line[1].Contains("-")))
+            {
+                $BranchCoverageCircles = "$BranchCoverageCircles<circle cx=`"$x`" cy=`"$y`" r=`"4`"/>"
+            }
+
             $x = $x + $xSpacing
         }
     }
 
     # Generate method coverage
     $MethodCoveragePoints = ""
+    $MethodCoverageCircles = ""
     $x = 90
     foreach ($line in $html.table.tbody.tr)
     {
@@ -54,6 +68,11 @@ function Out-Svg
         {
             [double]$y = 375.00 - ([System.Double]::Parse($line[3]) - 80.00) * 370.00 / 20.00
             $MethodCoveragePoints = "$MethodCoveragePoints$x,$y "
+            if (-not ($line[1].Contains("-")))
+            {
+                $MethodCoverageCircles = "$MethodCoverageCircles<circle cx=`"$x`" cy=`"$y`" r=`"4`"/>"
+            }
+
             $x = $x + $xSpacing
         }
     }
@@ -71,14 +90,22 @@ function Out-Svg
     "        <text x=`"80`" y=`"15`">100</text><text x=`"80`" y=`"107.5`">95</text><text x=`"80`" y=`"200`">90</text><text x=`"80`" y=`"292.5`">85</text><text x=`"80`" y=`"375`">80</text>" | Out-File -Append $SvgFilename
     "        <text x=`"50`" y=`"200`" style=`"font-weight: bold;text-transform: uppercase;font-size: 12px;fill: black;`">%</text>" | Out-File -Append $SvgFilename
     "    </g>"  | Out-File -Append $SvgFilename
+    "    <g style=`"font-size: 12px;`" aria-label=`"Legend`">" | Out-File -Append $SvgFilename
+    "        <line x1=`"520`" y1=`"310`" x2=`"550`" y2=`"310`" style=`"stroke:red;stroke-width:2`" /><circle cx=`"535`" cy=`"310`" r=`"4`" style=`"fill:red;stroke:red`" /><text x=`"560`" y=`"314`" style=`"fill:black`">Line coverage</text>" | Out-File -Append $SvgFilename
+    "        <line x1=`"520`" y1=`"330`" x2=`"550`" y2=`"330`" style=`"stroke:blue;stroke-width:2`" /><circle cx=`"535`" cy=`"330`" r=`"4`" style=`"fill:blue;stroke:blue`" /><text x=`"560`" y=`"334`" style=`"fill:black`">Branch coverage</text>" | Out-File -Append $SvgFilename
+    "        <line x1=`"520`" y1=`"350`" x2=`"550`" y2=`"350`" style=`"stroke:green;stroke-width:2`" /><circle cx=`"535`" cy=`"350`" r=`"4`" style=`"fill:green;stroke:green`" /><text x=`"560`" y=`"354`" style=`"fill:black`">Method coverage</text>" | Out-File -Append $SvgFilename
+    "    </g>" | Out-File -Append $SvgFilename
     "    <g style=`"stroke:red; fill:red`" data-setname=`"Line coverage`">" | Out-File -Append $SvgFilename
     "        <polyline points=`"$LineCoveragePoints`" style=`"fill:none`" />" | Out-File -Append $SvgFilename
+    "        $LineCoverageCircles" | Out-File -Append $SvgFilename
     "    </g>"  | Out-File -Append $SvgFilename
     "    <g style=`"stroke:blue; fill:blue`" data-setname=`"Branch coverage`">" | Out-File -Append $SvgFilename
     "        <polyline points=`"$BranchCoveragePoints`" style=`"fill:none`" />" | Out-File -Append $SvgFilename
+    "        $BranchCoverageCircles" | Out-File -Append $SvgFilename
     "    </g>"  | Out-File -Append $SvgFilename
     "    <g style=`"stroke:green; fill:green`" data-setname=`"Method coverage`">" | Out-File -Append $SvgFilename
     "        <polyline points=`"$MethodCoveragePoints`" style=`"fill:none`" />" | Out-File -Append $SvgFilename
+    "        $MethodCoverageCircles" | Out-File -Append $SvgFilename
     "    </g>"  | Out-File -Append $SvgFilename
     "</svg>" | Out-File -Append $SvgFilename
 }


### PR DESCRIPTION
## Summary
- Raise method coverage to 100% by adding `MappaCloning` unit tests, removing unused `TypeSymbolExtensions` helpers, and extracting `FakeType` so ReportGenerator can exclude it cleanly.
- Fix coverage-history SVG generation: plot all intermediate versions, label/circle only main releases, Y axis 80–100%, and add a series legend.
- Bump `MappaVersion` to `10.2.0-alpha.13`.

## Test plan
- [ ] `.\Scripts\RunTestsAndReportCoverage.ps1` passes
- [ ] Summary shows method coverage 100% and no `FakeType` class in the report
- [ ] `AttributeDataExtensions` method coverage is complete (no nested stub inflation)
- [ ] Review SVG changes in `Scripts/UpdateCodeCoverageGists.ps1` (labels, circles, legend, 80–100% Y scale)

Closes #276
