### PR TITLE
#134 Better benchmarks across mappers with CI charts and gist history

### DIFF
--- a/.cursor/rules/mappa-development-workflow.mdc
+++ b/.cursor/rules/mappa-development-workflow.mdc
@@ -79,7 +79,7 @@ The development environment uses **PowerShell**. All commands run in the termina
 - Post the plan as an issue comment with `gh issue comment <number>` after the PR exists (so the comment can include the PR URL).
 - Include: a short heading (e.g. `## Implementation plan`), a link to the PR, and the full contents of the plan file under `.cursor/plans/` (e.g. `issue_<number>_*.plan.md`). Prefer `--body-file` with a temporary markdown file built in PowerShell rather than bash heredocs.
 - If no issue number is known when creating the PR, ask the user for one before posting the plan.
-- **Pre-PR dependency check:** before creating a pull request, check whether NuGet libraries used across solution projects have newer **stable** versions available. If updates are available, search open GitHub issues for an existing dependency-update task; if **none** exists, ask the user whether they want a new GitHub issue created to track updating those libraries. Do **not** silently open the issue.
+- **Pre-PR dependency check:** before creating a pull request, run `dotnet package list --outdated` (from the repository root, or per project as needed) and **report every package whose Latest version is greater than the Requested/Resolved version**. Search open GitHub issues for an existing dependency-update task. Then ask the user whether they want to **create a new GitHub issue** (if none is open) or **update the existing open issue** (if one already tracks dependency updates) with the outdated packages found. Do **not** silently open or edit the issue.
 
 ## Versioning
 

--- a/.cursor/rules/mappa-development-workflow.mdc
+++ b/.cursor/rules/mappa-development-workflow.mdc
@@ -1,5 +1,5 @@
 ---
-description: Mappa development workflow — planning, code, code coverage, git, pull requests, versioning, tests, and samples
+description: Mappa development workflow — planning, code, code coverage, git, pull requests, versioning, tests, samples, benchmarks, and documentation
 alwaysApply: true
 ---
 
@@ -79,6 +79,7 @@ The development environment uses **PowerShell**. All commands run in the termina
 - Post the plan as an issue comment with `gh issue comment <number>` after the PR exists (so the comment can include the PR URL).
 - Include: a short heading (e.g. `## Implementation plan`), a link to the PR, and the full contents of the plan file under `.cursor/plans/` (e.g. `issue_<number>_*.plan.md`). Prefer `--body-file` with a temporary markdown file built in PowerShell rather than bash heredocs.
 - If no issue number is known when creating the PR, ask the user for one before posting the plan.
+- **Pre-PR dependency check:** before creating a pull request, check whether NuGet libraries used across solution projects have newer **stable** versions available. If updates are available, search open GitHub issues for an existing dependency-update task; if **none** exists, ask the user whether they want a new GitHub issue created to track updating those libraries. Do **not** silently open the issue.
 
 ## Versioning
 
@@ -123,6 +124,11 @@ A single feature may require **two** bumps (e.g. one after **Mappa**, one after 
 - **Do not** add new samples for bug fixes alone.
 - Before adding samples, ensure the **Mappa.Generator** version bump and rebuild described in **Versioning** has already been done.
 - **Warning suppression:** when a sample intentionally triggers a Mappa analyzer warning (e.g. MP00013, MP00016, MP00039), suppress it with `#pragma warning disable` / `#pragma warning restore` at the method or file level, including a short explanatory comment. Do **not** suppress sample warnings via `WarningsNotAsErrors`, `NoWarn`, or global analyzer config in the `.csproj`. Exception: `MP00000` may remain in `WarningsNotAsErrors` (debug diagnostic infrastructure). See [`InvokeParseMapper.cs`](Mappa.Samples/InvokeParseMapper.cs), [`MappaIgnoreMappers.cs`](Mappa.Samples/MappaIgnoreMappers.cs), and [`EnumToEnumMapper.cs`](Mappa.Samples/EnumToEnumMapper.cs) for examples.
+
+## Benchmarks
+
+- For each new user-facing feature (mapping strategy, attribute, `MappaSettings` property, or other capability that can be exercised at runtime), investigate whether it is worth adding a scenario to [`Mappa.Benchmark`](Mappa.Benchmark/). If yes, include that work in the issue plan (or note an explicit deferral with rationale).
+- When a new benchmark **is** added, do **not** add it to the SVG / CI chart subset (`$script:BenchmarkChartNames` in [`Scripts/BenchmarkChartsSvg.ps1`](Scripts/BenchmarkChartsSvg.ps1), used by `-ChartBenchmarksOnly` and the TIME/MEMORY / history charts) unless the user **explicitly** asks to include it in those charts.
 
 ## Documentation
 

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -29,3 +29,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: ./Scripts/UpdateCodeCoverageGists.ps1
+      - name: Run benchmarks
+        shell: pwsh
+        run: ./Scripts/RunBenchmarks.ps1 -ChartBenchmarksOnly
+      - name: Update benchmark Gist
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: ./Scripts/UpdateBenchmarkGists.ps1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Test and code coverage
         shell: pwsh
         run: ./Scripts/RunTestsAndReportCoverage.ps1
+      - name: Run benchmarks
+        shell: pwsh
+        run: ./Scripts/RunBenchmarks.ps1 -ChartBenchmarksOnly
       - name: Comment pull request coverage
         shell: pwsh
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ dlldata.c
 
 # Benchmark Results
 BenchmarkDotNet.Artifacts/
+.mappa-benchmark/
 
 # .NET Core
 project.lock.json

--- a/Documentation/development.md
+++ b/Documentation/development.md
@@ -39,6 +39,7 @@ Runs [BenchmarkDotNet](https://benchmarkdotnet.org/) in **Release** with job **S
 
 - `Benchmark.Summary.md` — mean time (ns) and allocated bytes for AutoMapper / Mapster / Mapperly / Mappa
 - `MAPPA-BENCHMARK-TIME.svg` / `MAPPA-BENCHMARK-MEMORY.svg` — grouped bar charts for the shared chart subset
+- `MAPPA-BENCHMARK-TIME-PERCENTAGES.svg` / `MAPPA-BENCHMARK-MEMORY-PERCENTAGES.svg` — competitor / Mappa percentage bar charts for the same subset
 - `history-table.md` — Mappa-only rows (`TIME_NS` / `ALLOC_B`) for gist history
 
 Useful switches:
@@ -57,6 +58,8 @@ That script downloads `MAPPA-BENCHMARK-HISTORY.md` from gist [`7f4a85bc809328b48
 - `MAPPA-BENCHMARK-HISTORY.md`
 - `MAPPA-BENCHMARK-TIME.svg`
 - `MAPPA-BENCHMARK-MEMORY.svg`
+- `MAPPA-BENCHMARK-TIME-PERCENTAGES.svg`
+- `MAPPA-BENCHMARK-MEMORY-PERCENTAGES.svg`
 - `MAPPA-BENCHMARK-TIME-HISTORY.svg`
 - `MAPPA-BENCHMARK-MEMORY-HISTORY.svg`
 

--- a/Documentation/development.md
+++ b/Documentation/development.md
@@ -17,6 +17,7 @@ The `nuget.config` can be generated automatically by running: `./Scripts/CreateN
 
 The solution automatically stores all NuGet packages in the `.packages\` folder;
 in order to have all the projects compiled, invoke the script `./Scripts/RebuildUponVersionChange.ps1`.
+That script builds every project with **`-c Release`**.
 
 Every time a change in the Mappa or Mappa.Generator project is made, a new version should be generated locally by:
 - Updating the `MappaVersion.targets` by increasing the alpha version
@@ -33,6 +34,33 @@ Reports are:
 
 ### Run benchmarks
 `./Scripts/RunBenchmarks.ps1`
+
+Runs [BenchmarkDotNet](https://benchmarkdotnet.org/) in **Release** with job **Short** (same job used by CI). Outputs land under the gitignored `.mappa-benchmark/` folder:
+
+- `Benchmark.Summary.md` — mean time (ns) and allocated bytes for AutoMapper / Mapster / Mapperly / Mappa
+- `MAPPA-BENCHMARK-TIME.svg` / `MAPPA-BENCHMARK-MEMORY.svg` — grouped bar charts for the shared chart subset
+- `history-table.md` — Mappa-only rows (`TIME_NS` / `ALLOC_B`) for gist history
+
+Useful switches:
+
+- `-ChartBenchmarksOnly` — run only the benchmarks used by the TIME/MEMORY SVGs (what CI uses)
+- `-SkipRun` — regenerate markdown/SVG outputs from existing `BenchmarkDotNet.Artifacts/results`
+- `-Filter "<pattern>"` — custom BenchmarkDotNet filter (default `*`)
+- `-ListAvailable` — list matching benchmarks without running them
+
+After a local run (or on `main` CI), publish history + SVGs to the shared gist with:
+
+`./Scripts/UpdateBenchmarkGists.ps1`
+
+That script downloads `MAPPA-BENCHMARK-HISTORY.md` from gist [`7f4a85bc809328b4821b03125f9190cb`](https://gist.github.com/sanelli/7f4a85bc809328b4821b03125f9190cb), appends `history-table.md`, regenerates the TIME/MEMORY history SVGs, and uploads:
+
+- `MAPPA-BENCHMARK-HISTORY.md`
+- `MAPPA-BENCHMARK-TIME.svg`
+- `MAPPA-BENCHMARK-MEMORY.svg`
+- `MAPPA-BENCHMARK-TIME-HISTORY.svg`
+- `MAPPA-BENCHMARK-MEMORY-HISTORY.svg`
+
+See [`Mappa.Benchmark/README.md`](../Mappa.Benchmark/README.md) for the scenario suite and how to read results.
 
 ## References
 - [Roslyn API FAQ](https://github.com/dotnet/roslyn-sdk/blob/main/samples/CSharp/APISamples/FAQ.cs)

--- a/Mappa.Benchmark/Collections/ArrayToListBenchmark.cs
+++ b/Mappa.Benchmark/Collections/ArrayToListBenchmark.cs
@@ -1,0 +1,76 @@
+// <copyright file="ArrayToListBenchmark.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using BenchmarkDotNet.Attributes;
+
+using Mappa.Benchmark.Collections.Mappers;
+using Mappa.Benchmark.Collections.Models;
+
+using Mapster;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Mappa.Benchmark.Collections;
+
+/// <summary>
+/// Benchmark mapping arrays to lists (elements include dictionaries).
+/// </summary>
+[MemoryDiagnoser]
+#pragma warning disable CA1002
+#pragma warning disable CA1515
+public class ArrayToListBenchmark
+#pragma warning restore CA1515
+{
+    private readonly CollectionItemDto[] input;
+    private readonly AutoMapper.IMapper automapperMapper;
+    private readonly MapperlyMapper mapperlyMapper;
+    private readonly MappaMapper mappaMapper;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArrayToListBenchmark"/> class.
+    /// </summary>
+    public ArrayToListBenchmark()
+    {
+        this.automapperMapper = new AutoMapper.MapperConfiguration(
+            cfg => cfg.AddMaps(typeof(AutomapperMapperProfile)),
+#pragma warning disable CA2000
+            new NullLoggerFactory()).CreateMapper();
+#pragma warning restore CA2000
+        this.mapperlyMapper = new();
+        this.mappaMapper = new();
+        this.input = CollectionDataFactory.CreateArray();
+    }
+
+    /// <summary>
+    /// Map using AutoMapper.
+    /// </summary>
+    /// <returns>The mapped list.</returns>
+    [Benchmark(Baseline = true)]
+    public List<CollectionItem> Automapper()
+        => this.automapperMapper.Map<List<CollectionItem>>(this.input);
+
+    /// <summary>
+    /// Map using Mapperly.
+    /// </summary>
+    /// <returns>The mapped list.</returns>
+    [Benchmark]
+    public List<CollectionItem> Mapperly()
+        => this.mapperlyMapper.MapToList(this.input);
+
+    /// <summary>
+    /// Map using Mapster.
+    /// </summary>
+    /// <returns>The mapped list.</returns>
+    [Benchmark]
+    public List<CollectionItem> Mapster()
+        => this.input.Adapt<List<CollectionItem>>();
+
+    /// <summary>
+    /// Map using Mappa.
+    /// </summary>
+    /// <returns>The mapped list.</returns>
+    [Benchmark]
+    public List<CollectionItem> Mappa()
+        => this.mappaMapper.MapToList(this.input);
+}

--- a/Mappa.Benchmark/Collections/ArrayToListBenchmark.cs
+++ b/Mappa.Benchmark/Collections/ArrayToListBenchmark.cs
@@ -33,7 +33,7 @@ public class ArrayToListBenchmark
     public ArrayToListBenchmark()
     {
         this.automapperMapper = new AutoMapper.MapperConfiguration(
-            cfg => cfg.AddMaps(typeof(AutomapperMapperProfile)),
+            cfg => cfg.AddProfile(new AutomapperMapperProfile()),
 #pragma warning disable CA2000
             new NullLoggerFactory()).CreateMapper();
 #pragma warning restore CA2000

--- a/Mappa.Benchmark/Collections/CollectionDataFactory.cs
+++ b/Mappa.Benchmark/Collections/CollectionDataFactory.cs
@@ -1,0 +1,105 @@
+// <copyright file="CollectionDataFactory.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using Mappa.Benchmark.Collections.Models;
+using Mappa.Benchmark.Common;
+
+namespace Mappa.Benchmark.Collections;
+
+/// <summary>
+/// Builds deterministic collection inputs with a few hundred entries.
+/// </summary>
+internal static class CollectionDataFactory
+{
+    /// <summary>
+    /// Creates a list of <see cref="CollectionItemDto"/> with nested dictionaries.
+    /// </summary>
+    /// <returns>The list.</returns>
+    public static List<CollectionItemDto> CreateList()
+    {
+        var list = new List<CollectionItemDto>(BenchmarkConstants.CollectionSize);
+        for (var index = 0; index < BenchmarkConstants.CollectionSize; index++)
+        {
+            list.Add(CreateItem(index));
+        }
+
+        return list;
+    }
+
+    /// <summary>
+    /// Creates an array of <see cref="CollectionItemDto"/> with nested dictionaries.
+    /// </summary>
+    /// <returns>The array.</returns>
+    public static CollectionItemDto[] CreateArray()
+    {
+        var array = new CollectionItemDto[BenchmarkConstants.CollectionSize];
+        for (var index = 0; index < BenchmarkConstants.CollectionSize; index++)
+        {
+            array[index] = CreateItem(index);
+        }
+
+        return array;
+    }
+
+    /// <summary>
+    /// Creates a dictionary of <see cref="CollectionItemDto"/> with nested dictionaries.
+    /// </summary>
+    /// <returns>The dictionary.</returns>
+    public static Dictionary<string, CollectionItemDto> CreateDictionary()
+    {
+        var dictionary = new Dictionary<string, CollectionItemDto>(BenchmarkConstants.CollectionSize);
+        for (var index = 0; index < BenchmarkConstants.CollectionSize; index++)
+        {
+            dictionary[$"key-{index}"] = CreateItem(index);
+        }
+
+        return dictionary;
+    }
+
+    /// <summary>
+    /// Creates a list of integers.
+    /// </summary>
+    /// <returns>The list.</returns>
+    public static List<int> CreateIntList()
+    {
+        var list = new List<int>(BenchmarkConstants.CollectionSize);
+        for (var index = 0; index < BenchmarkConstants.CollectionSize; index++)
+        {
+            list.Add(index);
+        }
+
+        return list;
+    }
+
+    /// <summary>
+    /// Creates an integer array.
+    /// </summary>
+    /// <returns>The array.</returns>
+    public static int[] CreateIntArray()
+    {
+        var array = new int[BenchmarkConstants.CollectionSize];
+        for (var index = 0; index < BenchmarkConstants.CollectionSize; index++)
+        {
+            array[index] = index;
+        }
+
+        return array;
+    }
+
+    private static CollectionItemDto CreateItem(int index)
+    {
+        var attributes = new Dictionary<string, string>(BenchmarkConstants.AttributesPerItem);
+        for (var attributeIndex = 0; attributeIndex < BenchmarkConstants.AttributesPerItem; attributeIndex++)
+        {
+            attributes[$"attr-{attributeIndex}"] = $"value-{index}-{attributeIndex}";
+        }
+
+        return new CollectionItemDto
+        {
+            Id = index,
+            Name = $"item-{index}",
+            Attributes = attributes,
+        };
+    }
+}

--- a/Mappa.Benchmark/Collections/DictionaryBenchmark.cs
+++ b/Mappa.Benchmark/Collections/DictionaryBenchmark.cs
@@ -32,7 +32,7 @@ public class DictionaryBenchmark
     public DictionaryBenchmark()
     {
         this.automapperMapper = new AutoMapper.MapperConfiguration(
-            cfg => cfg.AddMaps(typeof(AutomapperMapperProfile)),
+            cfg => cfg.AddProfile(new AutomapperMapperProfile()),
 #pragma warning disable CA2000
             new NullLoggerFactory()).CreateMapper();
 #pragma warning restore CA2000

--- a/Mappa.Benchmark/Collections/DictionaryBenchmark.cs
+++ b/Mappa.Benchmark/Collections/DictionaryBenchmark.cs
@@ -1,0 +1,75 @@
+// <copyright file="DictionaryBenchmark.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using BenchmarkDotNet.Attributes;
+
+using Mappa.Benchmark.Collections.Mappers;
+using Mappa.Benchmark.Collections.Models;
+
+using Mapster;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Mappa.Benchmark.Collections;
+
+/// <summary>
+/// Benchmark mapping dictionaries (values include nested dictionaries).
+/// </summary>
+[MemoryDiagnoser]
+#pragma warning disable CA1515
+public class DictionaryBenchmark
+#pragma warning restore CA1515
+{
+    private readonly Dictionary<string, CollectionItemDto> input;
+    private readonly AutoMapper.IMapper automapperMapper;
+    private readonly MapperlyMapper mapperlyMapper;
+    private readonly MappaMapper mappaMapper;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DictionaryBenchmark"/> class.
+    /// </summary>
+    public DictionaryBenchmark()
+    {
+        this.automapperMapper = new AutoMapper.MapperConfiguration(
+            cfg => cfg.AddMaps(typeof(AutomapperMapperProfile)),
+#pragma warning disable CA2000
+            new NullLoggerFactory()).CreateMapper();
+#pragma warning restore CA2000
+        this.mapperlyMapper = new();
+        this.mappaMapper = new();
+        this.input = CollectionDataFactory.CreateDictionary();
+    }
+
+    /// <summary>
+    /// Map using AutoMapper.
+    /// </summary>
+    /// <returns>The mapped dictionary.</returns>
+    [Benchmark(Baseline = true)]
+    public Dictionary<string, CollectionItem> Automapper()
+        => this.automapperMapper.Map<Dictionary<string, CollectionItem>>(this.input);
+
+    /// <summary>
+    /// Map using Mapperly.
+    /// </summary>
+    /// <returns>The mapped dictionary.</returns>
+    [Benchmark]
+    public Dictionary<string, CollectionItem> Mapperly()
+        => this.mapperlyMapper.Map(this.input);
+
+    /// <summary>
+    /// Map using Mapster.
+    /// </summary>
+    /// <returns>The mapped dictionary.</returns>
+    [Benchmark]
+    public Dictionary<string, CollectionItem> Mapster()
+        => this.input.Adapt<Dictionary<string, CollectionItem>>();
+
+    /// <summary>
+    /// Map using Mappa.
+    /// </summary>
+    /// <returns>The mapped dictionary.</returns>
+    [Benchmark]
+    public Dictionary<string, CollectionItem> Mappa()
+        => this.mappaMapper.Map(this.input);
+}

--- a/Mappa.Benchmark/Collections/FastListToArrayBenchmark.cs
+++ b/Mappa.Benchmark/Collections/FastListToArrayBenchmark.cs
@@ -1,0 +1,75 @@
+// <copyright file="FastListToArrayBenchmark.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using BenchmarkDotNet.Attributes;
+
+using Mappa.Benchmark.Collections.Mappers;
+using Mappa.Benchmark.Collections.Models;
+
+using Mapster;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Mappa.Benchmark.Collections;
+
+/// <summary>
+/// Benchmark mapping lists to arrays with Mappa fast collections enabled.
+/// </summary>
+[MemoryDiagnoser]
+#pragma warning disable CA1515
+public class FastListToArrayBenchmark
+#pragma warning restore CA1515
+{
+    private readonly List<CollectionItemDto> input;
+    private readonly AutoMapper.IMapper automapperMapper;
+    private readonly MapperlyMapper mapperlyMapper;
+    private readonly MappaFastMapper mappaMapper;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FastListToArrayBenchmark"/> class.
+    /// </summary>
+    public FastListToArrayBenchmark()
+    {
+        this.automapperMapper = new AutoMapper.MapperConfiguration(
+            cfg => cfg.AddMaps(typeof(AutomapperMapperProfile)),
+#pragma warning disable CA2000
+            new NullLoggerFactory()).CreateMapper();
+#pragma warning restore CA2000
+        this.mapperlyMapper = new();
+        this.mappaMapper = new();
+        this.input = CollectionDataFactory.CreateList();
+    }
+
+    /// <summary>
+    /// Map using AutoMapper.
+    /// </summary>
+    /// <returns>The mapped array.</returns>
+    [Benchmark(Baseline = true)]
+    public CollectionItem[] Automapper()
+        => this.automapperMapper.Map<CollectionItem[]>(this.input);
+
+    /// <summary>
+    /// Map using Mapperly.
+    /// </summary>
+    /// <returns>The mapped array.</returns>
+    [Benchmark]
+    public CollectionItem[] Mapperly()
+        => this.mapperlyMapper.MapToArray(this.input);
+
+    /// <summary>
+    /// Map using Mapster.
+    /// </summary>
+    /// <returns>The mapped array.</returns>
+    [Benchmark]
+    public CollectionItem[] Mapster()
+        => this.input.Adapt<CollectionItem[]>();
+
+    /// <summary>
+    /// Map using Mappa with fast collections.
+    /// </summary>
+    /// <returns>The mapped array.</returns>
+    [Benchmark]
+    public CollectionItem[] Mappa()
+        => this.mappaMapper.MapToArray(this.input);
+}

--- a/Mappa.Benchmark/Collections/FastListToArrayBenchmark.cs
+++ b/Mappa.Benchmark/Collections/FastListToArrayBenchmark.cs
@@ -32,7 +32,7 @@ public class FastListToArrayBenchmark
     public FastListToArrayBenchmark()
     {
         this.automapperMapper = new AutoMapper.MapperConfiguration(
-            cfg => cfg.AddMaps(typeof(AutomapperMapperProfile)),
+            cfg => cfg.AddProfile(new AutomapperMapperProfile()),
 #pragma warning disable CA2000
             new NullLoggerFactory()).CreateMapper();
 #pragma warning restore CA2000

--- a/Mappa.Benchmark/Collections/ListToArrayBenchmark.cs
+++ b/Mappa.Benchmark/Collections/ListToArrayBenchmark.cs
@@ -1,0 +1,75 @@
+// <copyright file="ListToArrayBenchmark.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using BenchmarkDotNet.Attributes;
+
+using Mappa.Benchmark.Collections.Mappers;
+using Mappa.Benchmark.Collections.Models;
+
+using Mapster;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Mappa.Benchmark.Collections;
+
+/// <summary>
+/// Benchmark mapping lists to arrays (elements include dictionaries).
+/// </summary>
+[MemoryDiagnoser]
+#pragma warning disable CA1515
+public class ListToArrayBenchmark
+#pragma warning restore CA1515
+{
+    private readonly List<CollectionItemDto> input;
+    private readonly AutoMapper.IMapper automapperMapper;
+    private readonly MapperlyMapper mapperlyMapper;
+    private readonly MappaMapper mappaMapper;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ListToArrayBenchmark"/> class.
+    /// </summary>
+    public ListToArrayBenchmark()
+    {
+        this.automapperMapper = new AutoMapper.MapperConfiguration(
+            cfg => cfg.AddMaps(typeof(AutomapperMapperProfile)),
+#pragma warning disable CA2000
+            new NullLoggerFactory()).CreateMapper();
+#pragma warning restore CA2000
+        this.mapperlyMapper = new();
+        this.mappaMapper = new();
+        this.input = CollectionDataFactory.CreateList();
+    }
+
+    /// <summary>
+    /// Map using AutoMapper.
+    /// </summary>
+    /// <returns>The mapped array.</returns>
+    [Benchmark(Baseline = true)]
+    public CollectionItem[] Automapper()
+        => this.automapperMapper.Map<CollectionItem[]>(this.input);
+
+    /// <summary>
+    /// Map using Mapperly.
+    /// </summary>
+    /// <returns>The mapped array.</returns>
+    [Benchmark]
+    public CollectionItem[] Mapperly()
+        => this.mapperlyMapper.MapToArray(this.input);
+
+    /// <summary>
+    /// Map using Mapster.
+    /// </summary>
+    /// <returns>The mapped array.</returns>
+    [Benchmark]
+    public CollectionItem[] Mapster()
+        => this.input.Adapt<CollectionItem[]>();
+
+    /// <summary>
+    /// Map using Mappa.
+    /// </summary>
+    /// <returns>The mapped array.</returns>
+    [Benchmark]
+    public CollectionItem[] Mappa()
+        => this.mappaMapper.MapToArray(this.input);
+}

--- a/Mappa.Benchmark/Collections/ListToArrayBenchmark.cs
+++ b/Mappa.Benchmark/Collections/ListToArrayBenchmark.cs
@@ -32,7 +32,7 @@ public class ListToArrayBenchmark
     public ListToArrayBenchmark()
     {
         this.automapperMapper = new AutoMapper.MapperConfiguration(
-            cfg => cfg.AddMaps(typeof(AutomapperMapperProfile)),
+            cfg => cfg.AddProfile(new AutomapperMapperProfile()),
 #pragma warning disable CA2000
             new NullLoggerFactory()).CreateMapper();
 #pragma warning restore CA2000

--- a/Mappa.Benchmark/Collections/ListToHashSetBenchmark.cs
+++ b/Mappa.Benchmark/Collections/ListToHashSetBenchmark.cs
@@ -1,0 +1,74 @@
+// <copyright file="ListToHashSetBenchmark.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using BenchmarkDotNet.Attributes;
+
+using Mappa.Benchmark.Collections.Mappers;
+
+using Mapster;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Mappa.Benchmark.Collections;
+
+/// <summary>
+/// Benchmark mapping lists to hash sets.
+/// </summary>
+[MemoryDiagnoser]
+#pragma warning disable CA1515
+public class ListToHashSetBenchmark
+#pragma warning restore CA1515
+{
+    private readonly List<int> input;
+    private readonly AutoMapper.IMapper automapperMapper;
+    private readonly MapperlyMapper mapperlyMapper;
+    private readonly MappaMapper mappaMapper;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ListToHashSetBenchmark"/> class.
+    /// </summary>
+    public ListToHashSetBenchmark()
+    {
+        this.automapperMapper = new AutoMapper.MapperConfiguration(
+            cfg => cfg.AddMaps(typeof(AutomapperMapperProfile)),
+#pragma warning disable CA2000
+            new NullLoggerFactory()).CreateMapper();
+#pragma warning restore CA2000
+        this.mapperlyMapper = new();
+        this.mappaMapper = new();
+        this.input = CollectionDataFactory.CreateIntList();
+    }
+
+    /// <summary>
+    /// Map using AutoMapper.
+    /// </summary>
+    /// <returns>The mapped hash set.</returns>
+    [Benchmark(Baseline = true)]
+    public HashSet<int> Automapper()
+        => this.automapperMapper.Map<HashSet<int>>(this.input);
+
+    /// <summary>
+    /// Map using Mapperly.
+    /// </summary>
+    /// <returns>The mapped hash set.</returns>
+    [Benchmark]
+    public HashSet<int> Mapperly()
+        => this.mapperlyMapper.MapToHashSet(this.input);
+
+    /// <summary>
+    /// Map using Mapster.
+    /// </summary>
+    /// <returns>The mapped hash set.</returns>
+    [Benchmark]
+    public HashSet<int> Mapster()
+        => this.input.Adapt<HashSet<int>>();
+
+    /// <summary>
+    /// Map using Mappa.
+    /// </summary>
+    /// <returns>The mapped hash set.</returns>
+    [Benchmark]
+    public HashSet<int> Mappa()
+        => this.mappaMapper.MapToHashSet(this.input);
+}

--- a/Mappa.Benchmark/Collections/ListToHashSetBenchmark.cs
+++ b/Mappa.Benchmark/Collections/ListToHashSetBenchmark.cs
@@ -31,7 +31,7 @@ public class ListToHashSetBenchmark
     public ListToHashSetBenchmark()
     {
         this.automapperMapper = new AutoMapper.MapperConfiguration(
-            cfg => cfg.AddMaps(typeof(AutomapperMapperProfile)),
+            cfg => cfg.AddProfile(new AutomapperMapperProfile()),
 #pragma warning disable CA2000
             new NullLoggerFactory()).CreateMapper();
 #pragma warning restore CA2000

--- a/Mappa.Benchmark/Collections/Mappers/AutomapperMapperProfile.cs
+++ b/Mappa.Benchmark/Collections/Mappers/AutomapperMapperProfile.cs
@@ -1,0 +1,28 @@
+// <copyright file="AutomapperMapperProfile.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using AutoMapper;
+
+using Mappa.Benchmark.Collections.Models;
+
+namespace Mappa.Benchmark.Collections.Mappers;
+
+/// <summary>
+/// AutoMapper profile for collection benchmarks.
+/// </summary>
+internal sealed class AutomapperMapperProfile
+    : Profile
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AutomapperMapperProfile"/> class.
+    /// </summary>
+    public AutomapperMapperProfile()
+    {
+        this.CreateMap<CollectionItemDto, CollectionItem>();
+        this.CreateMap<CollectionItemDto[], List<CollectionItem>>();
+        this.CreateMap<List<CollectionItemDto>, CollectionItem[]>();
+        this.CreateMap<List<int>, HashSet<int>>();
+        this.CreateMap<Dictionary<string, CollectionItemDto>, Dictionary<string, CollectionItem>>();
+    }
+}

--- a/Mappa.Benchmark/Collections/Mappers/AutomapperMapperProfile.cs
+++ b/Mappa.Benchmark/Collections/Mappers/AutomapperMapperProfile.cs
@@ -23,6 +23,16 @@ internal sealed class AutomapperMapperProfile
         this.CreateMap<CollectionItemDto[], List<CollectionItem>>();
         this.CreateMap<List<CollectionItemDto>, CollectionItem[]>();
         this.CreateMap<List<int>, HashSet<int>>();
-        this.CreateMap<Dictionary<string, CollectionItemDto>, Dictionary<string, CollectionItem>>();
+        this.CreateMap<Dictionary<string, CollectionItemDto>, Dictionary<string, CollectionItem>>()
+            .ConvertUsing((source, _, context) =>
+            {
+                var result = new Dictionary<string, CollectionItem>(source.Count);
+                foreach (var pair in source)
+                {
+                    result[pair.Key] = context.Mapper.Map<CollectionItem>(pair.Value);
+                }
+
+                return result;
+            });
     }
 }

--- a/Mappa.Benchmark/Collections/Mappers/MappaMapper.cs
+++ b/Mappa.Benchmark/Collections/Mappers/MappaMapper.cs
@@ -1,0 +1,60 @@
+// <copyright file="MappaMapper.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+#pragma warning disable SA1402
+
+using Mappa.Attributes;
+using Mappa.Benchmark.Collections.Models;
+
+namespace Mappa.Benchmark.Collections.Mappers;
+
+/// <summary>
+/// Mappa mapper for collection benchmarks.
+/// </summary>
+[Mappa]
+internal sealed partial class MappaMapper
+{
+    /// <summary>
+    /// Maps an array to a list.
+    /// </summary>
+    /// <param name="source">The source.</param>
+    /// <returns>The target.</returns>
+    public partial List<CollectionItem> MapToList(CollectionItemDto[] source);
+
+    /// <summary>
+    /// Maps a list to an array.
+    /// </summary>
+    /// <param name="source">The source.</param>
+    /// <returns>The target.</returns>
+    public partial CollectionItem[] MapToArray(List<CollectionItemDto> source);
+
+    /// <summary>
+    /// Maps a list to a hash set of identifiers.
+    /// </summary>
+    /// <param name="source">The source.</param>
+    /// <returns>The target.</returns>
+    public partial HashSet<int> MapToHashSet(List<int> source);
+
+    /// <summary>
+    /// Maps a dictionary of items.
+    /// </summary>
+    /// <param name="source">The source.</param>
+    /// <returns>The target.</returns>
+    public partial Dictionary<string, CollectionItem> Map(Dictionary<string, CollectionItemDto> source);
+}
+
+/// <summary>
+/// Mappa mapper with fast-collection settings enabled.
+/// </summary>
+[Mappa]
+[MappaSettings(FastCollections = BooleanSetting.Enable, ContainerCapacityConstructors = BooleanSetting.Enable)]
+internal sealed partial class MappaFastMapper
+{
+    /// <summary>
+    /// Maps a list to an array using fast collections.
+    /// </summary>
+    /// <param name="source">The source.</param>
+    /// <returns>The target.</returns>
+    public partial CollectionItem[] MapToArray(List<CollectionItemDto> source);
+}

--- a/Mappa.Benchmark/Collections/Mappers/MapperlyMapper.cs
+++ b/Mappa.Benchmark/Collections/Mappers/MapperlyMapper.cs
@@ -1,0 +1,44 @@
+// <copyright file="MapperlyMapper.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using Mappa.Benchmark.Collections.Models;
+
+using Riok.Mapperly.Abstractions;
+
+namespace Mappa.Benchmark.Collections.Mappers;
+
+/// <summary>
+/// Mapperly mapper for collection benchmarks.
+/// </summary>
+[Mapper]
+internal sealed partial class MapperlyMapper
+{
+    /// <summary>
+    /// Maps an array to a list.
+    /// </summary>
+    /// <param name="source">The source.</param>
+    /// <returns>The target.</returns>
+    public partial List<CollectionItem> MapToList(CollectionItemDto[] source);
+
+    /// <summary>
+    /// Maps a list to an array.
+    /// </summary>
+    /// <param name="source">The source.</param>
+    /// <returns>The target.</returns>
+    public partial CollectionItem[] MapToArray(List<CollectionItemDto> source);
+
+    /// <summary>
+    /// Maps a list to a hash set of identifiers.
+    /// </summary>
+    /// <param name="source">The source.</param>
+    /// <returns>The target.</returns>
+    public partial HashSet<int> MapToHashSet(List<int> source);
+
+    /// <summary>
+    /// Maps a dictionary of items.
+    /// </summary>
+    /// <param name="source">The source.</param>
+    /// <returns>The target.</returns>
+    public partial Dictionary<string, CollectionItem> Map(Dictionary<string, CollectionItemDto> source);
+}

--- a/Mappa.Benchmark/Collections/Models/CollectionModels.cs
+++ b/Mappa.Benchmark/Collections/Models/CollectionModels.cs
@@ -1,0 +1,49 @@
+// <copyright file="CollectionModels.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+#pragma warning disable CA1002, CA1515, CA1724, CA1815, CA1819, CA2227, SA1201, SA1402, SA1649
+
+namespace Mappa.Benchmark.Collections.Models;
+
+/// <summary>
+/// Collection element DTO that includes a nested dictionary.
+/// </summary>
+public sealed class CollectionItemDto
+{
+    /// <summary>
+    /// Gets or sets the identifier.
+    /// </summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets per-item attributes.
+    /// </summary>
+    public Dictionary<string, string> Attributes { get; set; } = new();
+}
+
+/// <summary>
+/// Collection element target that includes a nested dictionary.
+/// </summary>
+public sealed class CollectionItem
+{
+    /// <summary>
+    /// Gets or sets the identifier.
+    /// </summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets per-item attributes.
+    /// </summary>
+    public Dictionary<string, string> Attributes { get; set; } = new();
+}

--- a/Mappa.Benchmark/Common/BenchmarkConstants.cs
+++ b/Mappa.Benchmark/Common/BenchmarkConstants.cs
@@ -1,0 +1,26 @@
+// <copyright file="BenchmarkConstants.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+namespace Mappa.Benchmark.Common;
+
+/// <summary>
+/// Shared sizes and seeds for reproducible benchmarks.
+/// </summary>
+internal static class BenchmarkConstants
+{
+    /// <summary>
+    /// Number of entries used when building collection inputs (a few hundred).
+    /// </summary>
+    public const int CollectionSize = 300;
+
+    /// <summary>
+    /// Number of dictionary entries attached to each collection element.
+    /// </summary>
+    public const int AttributesPerItem = 5;
+
+    /// <summary>
+    /// Fixed seed for AutoBogus / Bogus randomization.
+    /// </summary>
+    public const int RandomSeed = 134;
+}

--- a/Mappa.Benchmark/Enums/EnumToEnumBenchmark.cs
+++ b/Mappa.Benchmark/Enums/EnumToEnumBenchmark.cs
@@ -1,0 +1,77 @@
+// <copyright file="EnumToEnumBenchmark.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using BenchmarkDotNet.Attributes;
+
+using Mappa.Benchmark.Enums.Mappers;
+using Mappa.Benchmark.Enums.Models;
+
+using Mapster;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Mappa.Benchmark.Enums;
+
+/// <summary>
+/// Benchmark mapping enums to enums.
+/// </summary>
+[MemoryDiagnoser]
+#pragma warning disable CA1515
+public class EnumToEnumBenchmark
+#pragma warning restore CA1515
+{
+    private const SourceStatus Input = SourceStatus.Active;
+
+    private readonly AutoMapper.IMapper automapperMapper;
+    private readonly MapperlyMapper mapperlyMapper;
+    private readonly MappaMapper mappaMapper;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EnumToEnumBenchmark"/> class.
+    /// </summary>
+    public EnumToEnumBenchmark()
+    {
+        this.automapperMapper = new AutoMapper.MapperConfiguration(
+            cfg => cfg.AddMaps(typeof(AutomapperMapperProfile)),
+#pragma warning disable CA2000
+            new NullLoggerFactory()).CreateMapper();
+#pragma warning restore CA2000
+        this.mapperlyMapper = new();
+        this.mappaMapper = new();
+    }
+
+    /// <summary>
+    /// Map using AutoMapper.
+    /// </summary>
+    /// <returns>The mapped enum.</returns>
+    [Benchmark(Baseline = true)]
+    public TargetStatus Automapper()
+        => this.automapperMapper.Map<TargetStatus>(Input);
+
+    /// <summary>
+    /// Map using Mapperly.
+    /// </summary>
+    /// <returns>The mapped enum.</returns>
+    [Benchmark]
+    public TargetStatus Mapperly()
+        => this.mapperlyMapper.Map(Input);
+
+    /// <summary>
+    /// Map using Mapster.
+    /// </summary>
+    /// <returns>The mapped enum.</returns>
+    [Benchmark]
+#pragma warning disable CA1822
+    public TargetStatus Mapster()
+#pragma warning restore CA1822
+        => Input.Adapt<TargetStatus>();
+
+    /// <summary>
+    /// Map using Mappa.
+    /// </summary>
+    /// <returns>The mapped enum.</returns>
+    [Benchmark]
+    public TargetStatus Mappa()
+        => this.mappaMapper.Map(Input);
+}

--- a/Mappa.Benchmark/Enums/EnumToEnumBenchmark.cs
+++ b/Mappa.Benchmark/Enums/EnumToEnumBenchmark.cs
@@ -33,7 +33,7 @@ public class EnumToEnumBenchmark
     public EnumToEnumBenchmark()
     {
         this.automapperMapper = new AutoMapper.MapperConfiguration(
-            cfg => cfg.AddMaps(typeof(AutomapperMapperProfile)),
+            cfg => cfg.AddProfile(new AutomapperMapperProfile()),
 #pragma warning disable CA2000
             new NullLoggerFactory()).CreateMapper();
 #pragma warning restore CA2000

--- a/Mappa.Benchmark/Enums/EnumToIntBenchmark.cs
+++ b/Mappa.Benchmark/Enums/EnumToIntBenchmark.cs
@@ -35,7 +35,7 @@ public class EnumToIntBenchmark
         this.automapperMapper = new AutoMapper.MapperConfiguration(
             cfg =>
             {
-                cfg.AddMaps(typeof(AutomapperMapperProfile));
+                cfg.AddProfile(new AutomapperMapperProfile());
             },
             #pragma warning disable CA2000
             new NullLoggerFactory()).CreateMapper();

--- a/Mappa.Benchmark/Enums/EnumToIntBenchmark.cs
+++ b/Mappa.Benchmark/Enums/EnumToIntBenchmark.cs
@@ -50,7 +50,7 @@ public class EnumToIntBenchmark
     /// Map using <see cref="AutoMapper"/>.
     /// </summary>
     /// <returns>The mapper model.</returns>
-    [Benchmark]
+    [Benchmark(Baseline = true)]
     public int Automapper()
         => this.automapperMapper.Map<int>(Input);
 
@@ -76,7 +76,7 @@ public class EnumToIntBenchmark
     /// Map using <see cref="Mappa.Attributes"/>.
     /// </summary>
     /// <returns>The mapper model.</returns>
-    [Benchmark(Baseline = true)]
+    [Benchmark]
     public int Mappa()
         => this.mappaMapper.MapToInt(Input);
 }

--- a/Mappa.Benchmark/Enums/EnumToStringBenchmark.cs
+++ b/Mappa.Benchmark/Enums/EnumToStringBenchmark.cs
@@ -50,7 +50,7 @@ public class EnumToStringBenchmark
     /// Map using <see cref="AutoMapper"/>.
     /// </summary>
     /// <returns>The mapper model.</returns>
-    [Benchmark]
+    [Benchmark(Baseline = true)]
     public string Automapper()
         => this.automapperMapper.Map<string>(Input);
 
@@ -76,7 +76,7 @@ public class EnumToStringBenchmark
     /// Map using <see cref="Mappa.Attributes"/>.
     /// </summary>
     /// <returns>The mapper model.</returns>
-    [Benchmark(Baseline = true)]
+    [Benchmark]
     public string Mappa()
         => this.mappaMapper.MapToString(Input);
 }

--- a/Mappa.Benchmark/Enums/EnumToStringBenchmark.cs
+++ b/Mappa.Benchmark/Enums/EnumToStringBenchmark.cs
@@ -35,7 +35,7 @@ public class EnumToStringBenchmark
         this.automapperMapper = new AutoMapper.MapperConfiguration(
             cfg =>
                         {
-                            cfg.AddMaps(typeof(AutomapperMapperProfile));
+                            cfg.AddProfile(new AutomapperMapperProfile());
                         },
         #pragma warning disable CA2000
             new NullLoggerFactory()).CreateMapper();

--- a/Mappa.Benchmark/Enums/IntToEnumBenchmark.cs
+++ b/Mappa.Benchmark/Enums/IntToEnumBenchmark.cs
@@ -35,7 +35,7 @@ public class IntToEnumBenchmark
         this.automapperMapper = new AutoMapper.MapperConfiguration(
             cfg =>
                 {
-                    cfg.AddMaps(typeof(AutomapperMapperProfile));
+                    cfg.AddProfile(new AutomapperMapperProfile());
                 },
 #pragma warning disable CA2000
             new NullLoggerFactory()).CreateMapper();

--- a/Mappa.Benchmark/Enums/IntToEnumBenchmark.cs
+++ b/Mappa.Benchmark/Enums/IntToEnumBenchmark.cs
@@ -50,7 +50,7 @@ public class IntToEnumBenchmark
     /// Map using <see cref="AutoMapper"/>.
     /// </summary>
     /// <returns>The mapper model.</returns>
-    [Benchmark]
+    [Benchmark(Baseline = true)]
     public StringComparison Automapper()
         => this.automapperMapper.Map<StringComparison>(Input);
 
@@ -76,7 +76,7 @@ public class IntToEnumBenchmark
     /// Map using <see cref="Mappa.Attributes"/>.
     /// </summary>
     /// <returns>The mapper model.</returns>
-    [Benchmark(Baseline = true)]
+    [Benchmark]
     public StringComparison Mappa()
         => this.mappaMapper.Map(Input);
 }

--- a/Mappa.Benchmark/Enums/Mappers/MappaMapper.cs
+++ b/Mappa.Benchmark/Enums/Mappers/MappaMapper.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using Mappa.Attributes;
+using Mappa.Benchmark.Enums.Models;
 
 namespace Mappa.Benchmark.Enums.Mappers;
 
@@ -27,6 +28,13 @@ internal sealed partial class MappaMapper
     /// <param name="stringComparison">The input object.</param>
     /// <returns>The output object.</returns>
     public partial StringComparison Map(int stringComparison);
+
+    /// <summary>
+    /// Map from <see cref="SourceStatus"/> to <see cref="TargetStatus"/>.
+    /// </summary>
+    /// <param name="status">The input enum.</param>
+    /// <returns>The output enum.</returns>
+    public partial TargetStatus Map(SourceStatus status);
 
     /// <summary>
     /// Map from <see cref="StringComparison"/>

--- a/Mappa.Benchmark/Enums/Mappers/MapperlyMapper.cs
+++ b/Mappa.Benchmark/Enums/Mappers/MapperlyMapper.cs
@@ -2,12 +2,14 @@
 // Copyright (c) Stefano Anelli. All rights reserved.
 // </copyright>
 
+using Mappa.Benchmark.Enums.Models;
+
 using Riok.Mapperly.Abstractions;
 
 namespace Mappa.Benchmark.Enums.Mappers;
 
 /// <summary>
-/// Mapper using <see cref="Mappa"/>.
+/// Mapper using Mapperly.
 /// </summary>
 [Mapper]
 internal sealed partial class MapperlyMapper
@@ -27,6 +29,13 @@ internal sealed partial class MapperlyMapper
     /// <param name="stringComparison">The input object.</param>
     /// <returns>The output object.</returns>
     public partial StringComparison Map(int stringComparison);
+
+    /// <summary>
+    /// Map from <see cref="SourceStatus"/> to <see cref="TargetStatus"/>.
+    /// </summary>
+    /// <param name="status">The input enum.</param>
+    /// <returns>The output enum.</returns>
+    public partial TargetStatus Map(SourceStatus status);
 
     /// <summary>
     /// Map from <see cref="StringComparison"/>

--- a/Mappa.Benchmark/Enums/Models/EnumModels.cs
+++ b/Mappa.Benchmark/Enums/Models/EnumModels.cs
@@ -1,0 +1,59 @@
+// <copyright file="EnumModels.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+#pragma warning disable CA1002, CA1515, CA1724, CA1815, CA1819, CA2227, SA1201, SA1402, SA1649
+
+namespace Mappa.Benchmark.Enums.Models;
+
+/// <summary>
+/// Source enum for enum-to-enum benchmarks.
+/// </summary>
+public enum SourceStatus
+{
+    /// <summary>
+    /// Unknown status.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// Active status.
+    /// </summary>
+    Active = 1,
+
+    /// <summary>
+    /// Inactive status.
+    /// </summary>
+    Inactive = 2,
+
+    /// <summary>
+    /// Archived status.
+    /// </summary>
+    Archived = 3,
+}
+
+/// <summary>
+/// Target enum for enum-to-enum benchmarks.
+/// </summary>
+public enum TargetStatus
+{
+    /// <summary>
+    /// Unknown status.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// Active status.
+    /// </summary>
+    Active = 1,
+
+    /// <summary>
+    /// Inactive status.
+    /// </summary>
+    Inactive = 2,
+
+    /// <summary>
+    /// Archived status.
+    /// </summary>
+    Archived = 3,
+}

--- a/Mappa.Benchmark/Enums/StringToEnumBenchmark.cs
+++ b/Mappa.Benchmark/Enums/StringToEnumBenchmark.cs
@@ -35,7 +35,7 @@ public class StringToEnumBenchmark
         this.automapperMapper = new AutoMapper.MapperConfiguration(
             cfg =>
                 {
-                    cfg.AddMaps(typeof(AutomapperMapperProfile));
+                    cfg.AddProfile(new AutomapperMapperProfile());
                 },
 #pragma warning disable CA2000
             new NullLoggerFactory()).CreateMapper();

--- a/Mappa.Benchmark/Enums/StringToEnumBenchmark.cs
+++ b/Mappa.Benchmark/Enums/StringToEnumBenchmark.cs
@@ -50,7 +50,7 @@ public class StringToEnumBenchmark
     /// Map using <see cref="AutoMapper"/>.
     /// </summary>
     /// <returns>The mapper model.</returns>
-    [Benchmark]
+    [Benchmark(Baseline = true)]
     public StringComparison Automapper()
         => this.automapperMapper.Map<StringComparison>(Input);
 
@@ -76,7 +76,7 @@ public class StringToEnumBenchmark
     /// Map using <see cref="Mappa.Attributes"/>.
     /// </summary>
     /// <returns>The mapper model.</returns>
-    [Benchmark(Baseline = true)]
+    [Benchmark]
     public StringComparison Mappa()
         => this.mappaMapper.Map(Input);
 }

--- a/Mappa.Benchmark/Mappa.Benchmark.csproj
+++ b/Mappa.Benchmark/Mappa.Benchmark.csproj
@@ -17,9 +17,9 @@
     <ItemGroup>
         <PackageReference Include="Mappa" Version="$(MappaVersion)" />
         <PackageReference Include="AutoBogus" Version="2.13.1" />
-        <PackageReference Include="AutoMapper" Version="16.1.1" />
+        <PackageReference Include="AutoMapper" Version="16.2.0" />
         <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
-        <PackageReference Include="Mapster" Version="7.4.0" />
+        <PackageReference Include="Mapster" Version="10.0.11" />
         <PackageReference Include="Riok.Mapperly" Version="4.3.1" />
         <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
             <PrivateAssets>all</PrivateAssets>

--- a/Mappa.Benchmark/Memory/ArrayToMemoryBenchmark.cs
+++ b/Mappa.Benchmark/Memory/ArrayToMemoryBenchmark.cs
@@ -32,7 +32,7 @@ public class ArrayToMemoryBenchmark
     public ArrayToMemoryBenchmark()
     {
         this.automapperMapper = new AutoMapper.MapperConfiguration(
-            cfg => cfg.AddMaps(typeof(AutomapperMapperProfile)),
+            cfg => cfg.AddProfile(new AutomapperMapperProfile()),
 #pragma warning disable CA2000
             new NullLoggerFactory()).CreateMapper();
 #pragma warning restore CA2000

--- a/Mappa.Benchmark/Memory/ArrayToMemoryBenchmark.cs
+++ b/Mappa.Benchmark/Memory/ArrayToMemoryBenchmark.cs
@@ -1,0 +1,76 @@
+// <copyright file="ArrayToMemoryBenchmark.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using BenchmarkDotNet.Attributes;
+
+using Mappa.Benchmark.Collections;
+using Mappa.Benchmark.Memory.Mappers;
+
+using Mapster;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Mappa.Benchmark.Memory;
+
+/// <summary>
+/// Benchmark mapping arrays to <see cref="Memory{T}"/>.
+/// </summary>
+[MemoryDiagnoser]
+#pragma warning disable CA1515
+public class ArrayToMemoryBenchmark
+#pragma warning restore CA1515
+{
+    private readonly int[] input;
+    private readonly AutoMapper.IMapper automapperMapper;
+    private readonly MapperlyMapper mapperlyMapper;
+    private readonly MappaMapper mappaMapper;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArrayToMemoryBenchmark"/> class.
+    /// </summary>
+    public ArrayToMemoryBenchmark()
+    {
+        this.automapperMapper = new AutoMapper.MapperConfiguration(
+            cfg => cfg.AddMaps(typeof(AutomapperMapperProfile)),
+#pragma warning disable CA2000
+            new NullLoggerFactory()).CreateMapper();
+#pragma warning restore CA2000
+        this.mapperlyMapper = new();
+        this.mappaMapper = new();
+        this.input = CollectionDataFactory.CreateIntArray();
+        TypeAdapterConfig<int[], Memory<int>>.NewConfig().MapWith(array => new Memory<int>(array));
+    }
+
+    /// <summary>
+    /// Map using AutoMapper.
+    /// </summary>
+    /// <returns>The mapped memory.</returns>
+    [Benchmark(Baseline = true)]
+    public Memory<int> Automapper()
+        => this.automapperMapper.Map<Memory<int>>(this.input);
+
+    /// <summary>
+    /// Map using Mapperly.
+    /// </summary>
+    /// <returns>The mapped memory.</returns>
+    [Benchmark]
+    public Memory<int> Mapperly()
+        => this.mapperlyMapper.MapToMemory(this.input);
+
+    /// <summary>
+    /// Map using Mapster.
+    /// </summary>
+    /// <returns>The mapped memory.</returns>
+    [Benchmark]
+    public Memory<int> Mapster()
+        => this.input.Adapt<Memory<int>>();
+
+    /// <summary>
+    /// Map using Mappa.
+    /// </summary>
+    /// <returns>The mapped memory.</returns>
+    [Benchmark]
+    public Memory<int> Mappa()
+        => this.mappaMapper.MapToMemory(this.input);
+}

--- a/Mappa.Benchmark/Memory/Mappers/AutomapperMapperProfile.cs
+++ b/Mappa.Benchmark/Memory/Mappers/AutomapperMapperProfile.cs
@@ -4,12 +4,10 @@
 
 using AutoMapper;
 
-using Mappa.Benchmark.Enums.Models;
-
-namespace Mappa.Benchmark.Enums.Mappers;
+namespace Mappa.Benchmark.Memory.Mappers;
 
 /// <summary>
-/// The mapper profile for <see cref="AutoMapper"/>.
+/// AutoMapper profile for memory/array benchmarks.
 /// </summary>
 internal sealed class AutomapperMapperProfile
     : Profile
@@ -19,12 +17,7 @@ internal sealed class AutomapperMapperProfile
     /// </summary>
     public AutomapperMapperProfile()
     {
-        this.CreateMap<StringComparison, string>();
-        this.CreateMap<string, StringComparison>();
-
-        this.CreateMap<StringComparison, int>();
-        this.CreateMap<int, StringComparison>();
-
-        this.CreateMap<SourceStatus, TargetStatus>();
+        this.CreateMap<Memory<int>, int[]>().ConvertUsing(memory => memory.ToArray());
+        this.CreateMap<int[], Memory<int>>().ConvertUsing(array => new Memory<int>(array));
     }
 }

--- a/Mappa.Benchmark/Memory/Mappers/MappaMapper.cs
+++ b/Mappa.Benchmark/Memory/Mappers/MappaMapper.cs
@@ -1,0 +1,28 @@
+// <copyright file="MappaMapper.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using Mappa.Attributes;
+
+namespace Mappa.Benchmark.Memory.Mappers;
+
+/// <summary>
+/// Mappa mapper for memory/array benchmarks.
+/// </summary>
+[Mappa]
+internal sealed partial class MappaMapper
+{
+    /// <summary>
+    /// Maps <see cref="Memory{T}"/> to an array.
+    /// </summary>
+    /// <param name="source">The source.</param>
+    /// <returns>The target.</returns>
+    public partial int[] MapToArray(Memory<int> source);
+
+    /// <summary>
+    /// Maps an array to <see cref="Memory{T}"/>.
+    /// </summary>
+    /// <param name="source">The source.</param>
+    /// <returns>The target.</returns>
+    public partial Memory<int> MapToMemory(int[] source);
+}

--- a/Mappa.Benchmark/Memory/Mappers/MapperlyMapper.cs
+++ b/Mappa.Benchmark/Memory/Mappers/MapperlyMapper.cs
@@ -1,0 +1,28 @@
+// <copyright file="MapperlyMapper.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using Riok.Mapperly.Abstractions;
+
+namespace Mappa.Benchmark.Memory.Mappers;
+
+/// <summary>
+/// Mapperly mapper for memory/array benchmarks.
+/// </summary>
+[Mapper]
+internal sealed partial class MapperlyMapper
+{
+    /// <summary>
+    /// Maps <see cref="Memory{T}"/> to an array.
+    /// </summary>
+    /// <param name="source">The source.</param>
+    /// <returns>The target.</returns>
+    public partial int[] MapToArray(Memory<int> source);
+
+    /// <summary>
+    /// Maps an array to <see cref="Memory{T}"/>.
+    /// </summary>
+    /// <param name="source">The source.</param>
+    /// <returns>The target.</returns>
+    public partial Memory<int> MapToMemory(int[] source);
+}

--- a/Mappa.Benchmark/Memory/MemoryToArrayBenchmark.cs
+++ b/Mappa.Benchmark/Memory/MemoryToArrayBenchmark.cs
@@ -32,7 +32,7 @@ public class MemoryToArrayBenchmark
     public MemoryToArrayBenchmark()
     {
         this.automapperMapper = new AutoMapper.MapperConfiguration(
-            cfg => cfg.AddMaps(typeof(AutomapperMapperProfile)),
+            cfg => cfg.AddProfile(new AutomapperMapperProfile()),
 #pragma warning disable CA2000
             new NullLoggerFactory()).CreateMapper();
 #pragma warning restore CA2000

--- a/Mappa.Benchmark/Memory/MemoryToArrayBenchmark.cs
+++ b/Mappa.Benchmark/Memory/MemoryToArrayBenchmark.cs
@@ -1,0 +1,76 @@
+// <copyright file="MemoryToArrayBenchmark.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using BenchmarkDotNet.Attributes;
+
+using Mappa.Benchmark.Collections;
+using Mappa.Benchmark.Memory.Mappers;
+
+using Mapster;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Mappa.Benchmark.Memory;
+
+/// <summary>
+/// Benchmark mapping <see cref="Memory{T}"/> to arrays.
+/// </summary>
+[MemoryDiagnoser]
+#pragma warning disable CA1515
+public class MemoryToArrayBenchmark
+#pragma warning restore CA1515
+{
+    private readonly Memory<int> input;
+    private readonly AutoMapper.IMapper automapperMapper;
+    private readonly MapperlyMapper mapperlyMapper;
+    private readonly MappaMapper mappaMapper;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MemoryToArrayBenchmark"/> class.
+    /// </summary>
+    public MemoryToArrayBenchmark()
+    {
+        this.automapperMapper = new AutoMapper.MapperConfiguration(
+            cfg => cfg.AddMaps(typeof(AutomapperMapperProfile)),
+#pragma warning disable CA2000
+            new NullLoggerFactory()).CreateMapper();
+#pragma warning restore CA2000
+        this.mapperlyMapper = new();
+        this.mappaMapper = new();
+        this.input = CollectionDataFactory.CreateIntArray();
+        TypeAdapterConfig<Memory<int>, int[]>.NewConfig().MapWith(memory => memory.ToArray());
+    }
+
+    /// <summary>
+    /// Map using AutoMapper.
+    /// </summary>
+    /// <returns>The mapped array.</returns>
+    [Benchmark(Baseline = true)]
+    public int[] Automapper()
+        => this.automapperMapper.Map<int[]>(this.input);
+
+    /// <summary>
+    /// Map using Mapperly.
+    /// </summary>
+    /// <returns>The mapped array.</returns>
+    [Benchmark]
+    public int[] Mapperly()
+        => this.mapperlyMapper.MapToArray(this.input);
+
+    /// <summary>
+    /// Map using Mapster.
+    /// </summary>
+    /// <returns>The mapped array.</returns>
+    [Benchmark]
+    public int[] Mapster()
+        => this.input.Adapt<int[]>();
+
+    /// <summary>
+    /// Map using Mappa.
+    /// </summary>
+    /// <returns>The mapped array.</returns>
+    [Benchmark]
+    public int[] Mappa()
+        => this.mappaMapper.MapToArray(this.input);
+}

--- a/Mappa.Benchmark/Nested/Mappers/AutomapperMapperProfile.cs
+++ b/Mappa.Benchmark/Nested/Mappers/AutomapperMapperProfile.cs
@@ -4,12 +4,12 @@
 
 using AutoMapper;
 
-using Mappa.Benchmark.Enums.Models;
+using Mappa.Benchmark.Nested.Models;
 
-namespace Mappa.Benchmark.Enums.Mappers;
+namespace Mappa.Benchmark.Nested.Mappers;
 
 /// <summary>
-/// The mapper profile for <see cref="AutoMapper"/>.
+/// AutoMapper profile for nested DTO benchmarks.
 /// </summary>
 internal sealed class AutomapperMapperProfile
     : Profile
@@ -19,12 +19,8 @@ internal sealed class AutomapperMapperProfile
     /// </summary>
     public AutomapperMapperProfile()
     {
-        this.CreateMap<StringComparison, string>();
-        this.CreateMap<string, StringComparison>();
-
-        this.CreateMap<StringComparison, int>();
-        this.CreateMap<int, StringComparison>();
-
-        this.CreateMap<SourceStatus, TargetStatus>();
+        this.CreateMap<LineItemDto, LineItem>();
+        this.CreateMap<CustomerDto, Customer>();
+        this.CreateMap<NestedOrderDto, NestedOrder>();
     }
 }

--- a/Mappa.Benchmark/Nested/Mappers/MappaMapper.cs
+++ b/Mappa.Benchmark/Nested/Mappers/MappaMapper.cs
@@ -1,0 +1,22 @@
+// <copyright file="MappaMapper.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using Mappa.Attributes;
+using Mappa.Benchmark.Nested.Models;
+
+namespace Mappa.Benchmark.Nested.Mappers;
+
+/// <summary>
+/// Mappa mapper for nested DTO benchmarks.
+/// </summary>
+[Mappa]
+internal sealed partial class MappaMapper
+{
+    /// <summary>
+    /// Maps an order DTO.
+    /// </summary>
+    /// <param name="source">The source.</param>
+    /// <returns>The target.</returns>
+    public partial NestedOrder Map(NestedOrderDto source);
+}

--- a/Mappa.Benchmark/Nested/Mappers/MapperlyMapper.cs
+++ b/Mappa.Benchmark/Nested/Mappers/MapperlyMapper.cs
@@ -1,0 +1,23 @@
+// <copyright file="MapperlyMapper.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using Mappa.Benchmark.Nested.Models;
+
+using Riok.Mapperly.Abstractions;
+
+namespace Mappa.Benchmark.Nested.Mappers;
+
+/// <summary>
+/// Mapperly mapper for nested DTO benchmarks.
+/// </summary>
+[Mapper]
+internal sealed partial class MapperlyMapper
+{
+    /// <summary>
+    /// Maps an order DTO.
+    /// </summary>
+    /// <param name="source">The source.</param>
+    /// <returns>The target.</returns>
+    public partial NestedOrder Map(NestedOrderDto source);
+}

--- a/Mappa.Benchmark/Nested/Models/NestedModels.cs
+++ b/Mappa.Benchmark/Nested/Models/NestedModels.cs
@@ -1,0 +1,173 @@
+// <copyright file="NestedModels.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+#pragma warning disable CA1002, CA1515, CA1724, CA1815, CA1819, CA2227, SA1201, SA1402, SA1649
+
+namespace Mappa.Benchmark.Nested.Models;
+
+/// <summary>
+/// Nested line-item DTO with a dictionary of attributes.
+/// </summary>
+public sealed class LineItemDto
+{
+    /// <summary>
+    /// Gets or sets the SKU.
+    /// </summary>
+    public string Sku { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the quantity.
+    /// </summary>
+    public int Quantity { get; set; }
+
+    /// <summary>
+    /// Gets or sets item attributes.
+    /// </summary>
+    public Dictionary<string, string> Attributes { get; set; } = new();
+}
+
+/// <summary>
+/// Nested line-item target.
+/// </summary>
+public sealed class LineItem
+{
+    /// <summary>
+    /// Gets or sets the SKU.
+    /// </summary>
+    public string Sku { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the quantity.
+    /// </summary>
+    public int Quantity { get; set; }
+
+    /// <summary>
+    /// Gets or sets item attributes.
+    /// </summary>
+    public Dictionary<string, string> Attributes { get; set; } = new();
+}
+
+/// <summary>
+/// Customer DTO nested under an order.
+/// </summary>
+public sealed class CustomerDto
+{
+    /// <summary>
+    /// Gets or sets the customer name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the email.
+    /// </summary>
+    public string Email { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets preference flags keyed by name.
+    /// </summary>
+    public Dictionary<string, bool> Preferences { get; set; } = new();
+}
+
+/// <summary>
+/// Customer target nested under an order.
+/// </summary>
+public sealed class Customer
+{
+    /// <summary>
+    /// Gets or sets the customer name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the email.
+    /// </summary>
+    public string Email { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets preference flags keyed by name.
+    /// </summary>
+    public Dictionary<string, bool> Preferences { get; set; } = new();
+}
+
+/// <summary>
+/// Order DTO containing lists, arrays, hash sets, and dictionaries.
+/// </summary>
+public sealed class NestedOrderDto
+{
+    /// <summary>
+    /// Gets or sets the order identifier.
+    /// </summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the order title.
+    /// </summary>
+    public string Title { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the customer.
+    /// </summary>
+    public CustomerDto Customer { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets line items (list).
+    /// </summary>
+    public List<LineItemDto> LineItems { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets coupon codes (array).
+    /// </summary>
+    public string[] Coupons { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Gets or sets category tags (hash set).
+    /// </summary>
+    public HashSet<string> Categories { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets order-level metadata (dictionary).
+    /// </summary>
+    public Dictionary<string, string> Metadata { get; set; } = new();
+}
+
+/// <summary>
+/// Order target containing lists, arrays, hash sets, and dictionaries.
+/// </summary>
+public sealed class NestedOrder
+{
+    /// <summary>
+    /// Gets or sets the order identifier.
+    /// </summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the order title.
+    /// </summary>
+    public string Title { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the customer.
+    /// </summary>
+    public Customer Customer { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets line items (list).
+    /// </summary>
+    public List<LineItem> LineItems { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets coupon codes (array).
+    /// </summary>
+    public string[] Coupons { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Gets or sets category tags (hash set).
+    /// </summary>
+    public HashSet<string> Categories { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets order-level metadata (dictionary).
+    /// </summary>
+    public Dictionary<string, string> Metadata { get; set; } = new();
+}

--- a/Mappa.Benchmark/Nested/NestedDataFactory.cs
+++ b/Mappa.Benchmark/Nested/NestedDataFactory.cs
@@ -1,0 +1,67 @@
+// <copyright file="NestedDataFactory.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using Mappa.Benchmark.Common;
+using Mappa.Benchmark.Nested.Models;
+
+namespace Mappa.Benchmark.Nested;
+
+/// <summary>
+/// Builds deterministic nested DTO graphs with a few hundred collection entries.
+/// </summary>
+internal static class NestedDataFactory
+{
+    /// <summary>
+    /// Creates an <see cref="NestedOrderDto"/> with populated nested collections.
+    /// </summary>
+    /// <returns>The order DTO.</returns>
+    public static NestedOrderDto CreateNestedOrder()
+    {
+        var lineItems = new List<LineItemDto>(BenchmarkConstants.CollectionSize);
+        var coupons = new string[BenchmarkConstants.CollectionSize];
+        var categories = new HashSet<string>(BenchmarkConstants.CollectionSize);
+        var metadata = new Dictionary<string, string>(BenchmarkConstants.CollectionSize);
+        var preferences = new Dictionary<string, bool>(BenchmarkConstants.AttributesPerItem);
+
+        for (var index = 0; index < BenchmarkConstants.CollectionSize; index++)
+        {
+            var attributes = new Dictionary<string, string>(BenchmarkConstants.AttributesPerItem);
+            for (var attributeIndex = 0; attributeIndex < BenchmarkConstants.AttributesPerItem; attributeIndex++)
+            {
+                attributes[$"attr-{attributeIndex}"] = $"value-{index}-{attributeIndex}";
+            }
+
+            lineItems.Add(new LineItemDto
+            {
+                Sku = $"SKU-{index}",
+                Quantity = index % 10,
+                Attributes = attributes,
+            });
+            coupons[index] = $"COUPON-{index}";
+            categories.Add($"category-{index}");
+            metadata[$"meta-{index}"] = $"value-{index}";
+        }
+
+        for (var preferenceIndex = 0; preferenceIndex < BenchmarkConstants.AttributesPerItem; preferenceIndex++)
+        {
+            preferences[$"pref-{preferenceIndex}"] = preferenceIndex % 2 == 0;
+        }
+
+        return new NestedOrderDto
+        {
+            Id = 42,
+            Title = "Benchmark Order",
+            Customer = new CustomerDto
+            {
+                Name = "Ada Lovelace",
+                Email = "ada@example.com",
+                Preferences = preferences,
+            },
+            LineItems = lineItems,
+            Coupons = coupons,
+            Categories = categories,
+            Metadata = metadata,
+        };
+    }
+}

--- a/Mappa.Benchmark/Nested/NestedDtoBenchmark.cs
+++ b/Mappa.Benchmark/Nested/NestedDtoBenchmark.cs
@@ -32,7 +32,7 @@ public class NestedDtoBenchmark
     public NestedDtoBenchmark()
     {
         this.automapperMapper = new AutoMapper.MapperConfiguration(
-            cfg => cfg.AddMaps(typeof(AutomapperMapperProfile)),
+            cfg => cfg.AddProfile(new AutomapperMapperProfile()),
 #pragma warning disable CA2000
             new NullLoggerFactory()).CreateMapper();
 #pragma warning restore CA2000

--- a/Mappa.Benchmark/Nested/NestedDtoBenchmark.cs
+++ b/Mappa.Benchmark/Nested/NestedDtoBenchmark.cs
@@ -1,0 +1,75 @@
+// <copyright file="NestedDtoBenchmark.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using BenchmarkDotNet.Attributes;
+
+using Mappa.Benchmark.Nested.Mappers;
+using Mappa.Benchmark.Nested.Models;
+
+using Mapster;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Mappa.Benchmark.Nested;
+
+/// <summary>
+/// Benchmark mapping nested DTOs that contain lists, arrays, hash sets, and dictionaries.
+/// </summary>
+[MemoryDiagnoser]
+#pragma warning disable CA1515
+public class NestedDtoBenchmark
+#pragma warning restore CA1515
+{
+    private readonly NestedOrderDto input;
+    private readonly AutoMapper.IMapper automapperMapper;
+    private readonly MapperlyMapper mapperlyMapper;
+    private readonly MappaMapper mappaMapper;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NestedDtoBenchmark"/> class.
+    /// </summary>
+    public NestedDtoBenchmark()
+    {
+        this.automapperMapper = new AutoMapper.MapperConfiguration(
+            cfg => cfg.AddMaps(typeof(AutomapperMapperProfile)),
+#pragma warning disable CA2000
+            new NullLoggerFactory()).CreateMapper();
+#pragma warning restore CA2000
+        this.mapperlyMapper = new();
+        this.mappaMapper = new();
+        this.input = NestedDataFactory.CreateNestedOrder();
+    }
+
+    /// <summary>
+    /// Map using AutoMapper.
+    /// </summary>
+    /// <returns>The mapped nested order.</returns>
+    [Benchmark(Baseline = true)]
+    public NestedOrder Automapper()
+        => this.automapperMapper.Map<NestedOrder>(this.input);
+
+    /// <summary>
+    /// Map using Mapperly.
+    /// </summary>
+    /// <returns>The mapped nested order.</returns>
+    [Benchmark]
+    public NestedOrder Mapperly()
+        => this.mapperlyMapper.Map(this.input);
+
+    /// <summary>
+    /// Map using Mapster.
+    /// </summary>
+    /// <returns>The mapped nested order.</returns>
+    [Benchmark]
+    public NestedOrder Mapster()
+        => this.input.Adapt<NestedOrder>();
+
+    /// <summary>
+    /// Map using Mappa.
+    /// </summary>
+    /// <returns>The mapped nested order.</returns>
+    [Benchmark]
+    public NestedOrder Mappa()
+        => this.mappaMapper.Map(this.input);
+}

--- a/Mappa.Benchmark/Objects/ClassToClassBenchmark.cs
+++ b/Mappa.Benchmark/Objects/ClassToClassBenchmark.cs
@@ -1,0 +1,81 @@
+// <copyright file="ClassToClassBenchmark.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using BenchmarkDotNet.Attributes;
+
+using Mappa.Benchmark.Objects.Mappers;
+using Mappa.Benchmark.Objects.Models;
+
+using Mapster;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Mappa.Benchmark.Objects;
+
+/// <summary>
+/// Benchmark mapping class DTOs to class models.
+/// </summary>
+[MemoryDiagnoser]
+#pragma warning disable CA1515
+public class ClassToClassBenchmark
+#pragma warning restore CA1515
+{
+    private readonly PersonClassDto input;
+    private readonly AutoMapper.IMapper automapperMapper;
+    private readonly MapperlyMapper mapperlyMapper;
+    private readonly MappaMapper mappaMapper;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ClassToClassBenchmark"/> class.
+    /// </summary>
+    public ClassToClassBenchmark()
+    {
+        this.automapperMapper = new AutoMapper.MapperConfiguration(
+            cfg => cfg.AddMaps(typeof(AutomapperMapperProfile)),
+#pragma warning disable CA2000
+            new NullLoggerFactory()).CreateMapper();
+#pragma warning restore CA2000
+        this.mapperlyMapper = new();
+        this.mappaMapper = new();
+        this.input = new PersonClassDto
+        {
+            Id = 1,
+            Name = "Ada Lovelace",
+            Age = 36,
+            Address = new AddressDto { Street = "Analytical Engine Way", City = "London", Zip = "SW1A" },
+        };
+    }
+
+    /// <summary>
+    /// Map using AutoMapper.
+    /// </summary>
+    /// <returns>The mapped model.</returns>
+    [Benchmark(Baseline = true)]
+    public PersonClass Automapper()
+        => this.automapperMapper.Map<PersonClass>(this.input);
+
+    /// <summary>
+    /// Map using Mapperly.
+    /// </summary>
+    /// <returns>The mapped model.</returns>
+    [Benchmark]
+    public PersonClass Mapperly()
+        => this.mapperlyMapper.Map(this.input);
+
+    /// <summary>
+    /// Map using Mapster.
+    /// </summary>
+    /// <returns>The mapped model.</returns>
+    [Benchmark]
+    public PersonClass Mapster()
+        => this.input.Adapt<PersonClass>();
+
+    /// <summary>
+    /// Map using Mappa.
+    /// </summary>
+    /// <returns>The mapped model.</returns>
+    [Benchmark]
+    public PersonClass Mappa()
+        => this.mappaMapper.Map(this.input);
+}

--- a/Mappa.Benchmark/Objects/ClassToClassBenchmark.cs
+++ b/Mappa.Benchmark/Objects/ClassToClassBenchmark.cs
@@ -32,7 +32,7 @@ public class ClassToClassBenchmark
     public ClassToClassBenchmark()
     {
         this.automapperMapper = new AutoMapper.MapperConfiguration(
-            cfg => cfg.AddMaps(typeof(AutomapperMapperProfile)),
+            cfg => cfg.AddProfile(new AutomapperMapperProfile()),
 #pragma warning disable CA2000
             new NullLoggerFactory()).CreateMapper();
 #pragma warning restore CA2000

--- a/Mappa.Benchmark/Objects/Mappers/AutomapperMapperProfile.cs
+++ b/Mappa.Benchmark/Objects/Mappers/AutomapperMapperProfile.cs
@@ -4,12 +4,12 @@
 
 using AutoMapper;
 
-using Mappa.Benchmark.Enums.Models;
+using Mappa.Benchmark.Objects.Models;
 
-namespace Mappa.Benchmark.Enums.Mappers;
+namespace Mappa.Benchmark.Objects.Mappers;
 
 /// <summary>
-/// The mapper profile for <see cref="AutoMapper"/>.
+/// AutoMapper profile for class/record/struct person models.
 /// </summary>
 internal sealed class AutomapperMapperProfile
     : Profile
@@ -19,12 +19,9 @@ internal sealed class AutomapperMapperProfile
     /// </summary>
     public AutomapperMapperProfile()
     {
-        this.CreateMap<StringComparison, string>();
-        this.CreateMap<string, StringComparison>();
-
-        this.CreateMap<StringComparison, int>();
-        this.CreateMap<int, StringComparison>();
-
-        this.CreateMap<SourceStatus, TargetStatus>();
+        this.CreateMap<AddressDto, Address>();
+        this.CreateMap<PersonClassDto, PersonClass>();
+        this.CreateMap<PersonRecordDto, PersonRecord>();
+        this.CreateMap<PersonStructDto, PersonStruct>();
     }
 }

--- a/Mappa.Benchmark/Objects/Mappers/MappaMapper.cs
+++ b/Mappa.Benchmark/Objects/Mappers/MappaMapper.cs
@@ -1,0 +1,36 @@
+// <copyright file="MappaMapper.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using Mappa.Attributes;
+using Mappa.Benchmark.Objects.Models;
+
+namespace Mappa.Benchmark.Objects.Mappers;
+
+/// <summary>
+/// Mappa mapper for class/record/struct person models.
+/// </summary>
+[Mappa]
+internal sealed partial class MappaMapper
+{
+    /// <summary>
+    /// Maps a class person DTO.
+    /// </summary>
+    /// <param name="source">The source.</param>
+    /// <returns>The target.</returns>
+    public partial PersonClass Map(PersonClassDto source);
+
+    /// <summary>
+    /// Maps a record person DTO.
+    /// </summary>
+    /// <param name="source">The source.</param>
+    /// <returns>The target.</returns>
+    public partial PersonRecord Map(PersonRecordDto source);
+
+    /// <summary>
+    /// Maps a struct person DTO.
+    /// </summary>
+    /// <param name="source">The source.</param>
+    /// <returns>The target.</returns>
+    public partial PersonStruct Map(PersonStructDto source);
+}

--- a/Mappa.Benchmark/Objects/Mappers/MapperlyMapper.cs
+++ b/Mappa.Benchmark/Objects/Mappers/MapperlyMapper.cs
@@ -1,0 +1,37 @@
+// <copyright file="MapperlyMapper.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using Mappa.Benchmark.Objects.Models;
+
+using Riok.Mapperly.Abstractions;
+
+namespace Mappa.Benchmark.Objects.Mappers;
+
+/// <summary>
+/// Mapperly mapper for class/record/struct person models.
+/// </summary>
+[Mapper]
+internal sealed partial class MapperlyMapper
+{
+    /// <summary>
+    /// Maps a class person DTO.
+    /// </summary>
+    /// <param name="source">The source.</param>
+    /// <returns>The target.</returns>
+    public partial PersonClass Map(PersonClassDto source);
+
+    /// <summary>
+    /// Maps a record person DTO.
+    /// </summary>
+    /// <param name="source">The source.</param>
+    /// <returns>The target.</returns>
+    public partial PersonRecord Map(PersonRecordDto source);
+
+    /// <summary>
+    /// Maps a struct person DTO.
+    /// </summary>
+    /// <param name="source">The source.</param>
+    /// <returns>The target.</returns>
+    public partial PersonStruct Map(PersonStructDto source);
+}

--- a/Mappa.Benchmark/Objects/Models/PersonModels.cs
+++ b/Mappa.Benchmark/Objects/Models/PersonModels.cs
@@ -1,0 +1,217 @@
+// <copyright file="PersonModels.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+#pragma warning disable CA1002, CA1515, CA1724, CA1815, CA1819, CA2227, SA1201, SA1402, SA1649
+
+namespace Mappa.Benchmark.Objects.Models;
+
+/// <summary>
+/// Nested address DTO used by class/record/struct benchmarks.
+/// </summary>
+public sealed class AddressDto
+{
+    /// <summary>
+    /// Gets or sets the street.
+    /// </summary>
+    public string Street { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the city.
+    /// </summary>
+    public string City { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the postal code.
+    /// </summary>
+    public string Zip { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Nested address target model.
+/// </summary>
+public sealed class Address
+{
+    /// <summary>
+    /// Gets or sets the street.
+    /// </summary>
+    public string Street { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the city.
+    /// </summary>
+    public string City { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the postal code.
+    /// </summary>
+    public string Zip { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Class-based person DTO.
+/// </summary>
+public sealed class PersonClassDto
+{
+    /// <summary>
+    /// Gets or sets the identifier.
+    /// </summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the display name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the age.
+    /// </summary>
+    public int Age { get; set; }
+
+    /// <summary>
+    /// Gets or sets the address.
+    /// </summary>
+    public AddressDto Address { get; set; } = new();
+}
+
+/// <summary>
+/// Class-based person target.
+/// </summary>
+public sealed class PersonClass
+{
+    /// <summary>
+    /// Gets or sets the identifier.
+    /// </summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the display name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the age.
+    /// </summary>
+    public int Age { get; set; }
+
+    /// <summary>
+    /// Gets or sets the address.
+    /// </summary>
+    public Address Address { get; set; } = new();
+}
+
+/// <summary>
+/// Record-based person DTO.
+/// </summary>
+/// <param name="Id">The identifier.</param>
+/// <param name="Name">The display name.</param>
+/// <param name="Age">The age.</param>
+/// <param name="Address">The address.</param>
+public sealed record PersonRecordDto(int Id, string Name, int Age, AddressDto Address);
+
+/// <summary>
+/// Record-based person target.
+/// </summary>
+/// <param name="Id">The identifier.</param>
+/// <param name="Name">The display name.</param>
+/// <param name="Age">The age.</param>
+/// <param name="Address">The address.</param>
+public sealed record PersonRecord(int Id, string Name, int Age, Address Address);
+
+/// <summary>
+/// Struct-based person DTO.
+/// </summary>
+public struct PersonStructDto
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PersonStructDto"/> struct.
+    /// </summary>
+    public PersonStructDto()
+    {
+        this.Id = 0;
+        this.Name = string.Empty;
+        this.Age = 0;
+        this.Street = string.Empty;
+        this.City = string.Empty;
+        this.Zip = string.Empty;
+    }
+
+    /// <summary>
+    /// Gets or sets the identifier.
+    /// </summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the display name.
+    /// </summary>
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the age.
+    /// </summary>
+    public int Age { get; set; }
+
+    /// <summary>
+    /// Gets or sets the street.
+    /// </summary>
+    public string Street { get; set; }
+
+    /// <summary>
+    /// Gets or sets the city.
+    /// </summary>
+    public string City { get; set; }
+
+    /// <summary>
+    /// Gets or sets the postal code.
+    /// </summary>
+    public string Zip { get; set; }
+}
+
+/// <summary>
+/// Struct-based person target.
+/// </summary>
+public struct PersonStruct
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PersonStruct"/> struct.
+    /// </summary>
+    public PersonStruct()
+    {
+        this.Id = 0;
+        this.Name = string.Empty;
+        this.Age = 0;
+        this.Street = string.Empty;
+        this.City = string.Empty;
+        this.Zip = string.Empty;
+    }
+
+    /// <summary>
+    /// Gets or sets the identifier.
+    /// </summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the display name.
+    /// </summary>
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the age.
+    /// </summary>
+    public int Age { get; set; }
+
+    /// <summary>
+    /// Gets or sets the street.
+    /// </summary>
+    public string Street { get; set; }
+
+    /// <summary>
+    /// Gets or sets the city.
+    /// </summary>
+    public string City { get; set; }
+
+    /// <summary>
+    /// Gets or sets the postal code.
+    /// </summary>
+    public string Zip { get; set; }
+}

--- a/Mappa.Benchmark/Objects/RecordToRecordBenchmark.cs
+++ b/Mappa.Benchmark/Objects/RecordToRecordBenchmark.cs
@@ -1,0 +1,79 @@
+// <copyright file="RecordToRecordBenchmark.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using BenchmarkDotNet.Attributes;
+
+using Mappa.Benchmark.Objects.Mappers;
+using Mappa.Benchmark.Objects.Models;
+
+using Mapster;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Mappa.Benchmark.Objects;
+
+/// <summary>
+/// Benchmark mapping record DTOs to record models.
+/// </summary>
+[MemoryDiagnoser]
+#pragma warning disable CA1515
+public class RecordToRecordBenchmark
+#pragma warning restore CA1515
+{
+    private readonly PersonRecordDto input;
+    private readonly AutoMapper.IMapper automapperMapper;
+    private readonly MapperlyMapper mapperlyMapper;
+    private readonly MappaMapper mappaMapper;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RecordToRecordBenchmark"/> class.
+    /// </summary>
+    public RecordToRecordBenchmark()
+    {
+        this.automapperMapper = new AutoMapper.MapperConfiguration(
+            cfg => cfg.AddMaps(typeof(AutomapperMapperProfile)),
+#pragma warning disable CA2000
+            new NullLoggerFactory()).CreateMapper();
+#pragma warning restore CA2000
+        this.mapperlyMapper = new();
+        this.mappaMapper = new();
+        this.input = new PersonRecordDto(
+            1,
+            "Ada Lovelace",
+            36,
+            new AddressDto { Street = "Analytical Engine Way", City = "London", Zip = "SW1A" });
+    }
+
+    /// <summary>
+    /// Map using AutoMapper.
+    /// </summary>
+    /// <returns>The mapped model.</returns>
+    [Benchmark(Baseline = true)]
+    public PersonRecord Automapper()
+        => this.automapperMapper.Map<PersonRecord>(this.input);
+
+    /// <summary>
+    /// Map using Mapperly.
+    /// </summary>
+    /// <returns>The mapped model.</returns>
+    [Benchmark]
+    public PersonRecord Mapperly()
+        => this.mapperlyMapper.Map(this.input);
+
+    /// <summary>
+    /// Map using Mapster.
+    /// </summary>
+    /// <returns>The mapped model.</returns>
+    [Benchmark]
+    public PersonRecord Mapster()
+        => this.input.Adapt<PersonRecord>();
+
+    /// <summary>
+    /// Map using Mappa.
+    /// </summary>
+    /// <returns>The mapped model.</returns>
+    [Benchmark]
+    public PersonRecord Mappa()
+        => this.mappaMapper.Map(this.input);
+}

--- a/Mappa.Benchmark/Objects/RecordToRecordBenchmark.cs
+++ b/Mappa.Benchmark/Objects/RecordToRecordBenchmark.cs
@@ -32,7 +32,7 @@ public class RecordToRecordBenchmark
     public RecordToRecordBenchmark()
     {
         this.automapperMapper = new AutoMapper.MapperConfiguration(
-            cfg => cfg.AddMaps(typeof(AutomapperMapperProfile)),
+            cfg => cfg.AddProfile(new AutomapperMapperProfile()),
 #pragma warning disable CA2000
             new NullLoggerFactory()).CreateMapper();
 #pragma warning restore CA2000

--- a/Mappa.Benchmark/Objects/StructToStructBenchmark.cs
+++ b/Mappa.Benchmark/Objects/StructToStructBenchmark.cs
@@ -1,0 +1,83 @@
+// <copyright file="StructToStructBenchmark.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using BenchmarkDotNet.Attributes;
+
+using Mappa.Benchmark.Objects.Mappers;
+using Mappa.Benchmark.Objects.Models;
+
+using Mapster;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Mappa.Benchmark.Objects;
+
+/// <summary>
+/// Benchmark mapping struct DTOs to struct models.
+/// </summary>
+[MemoryDiagnoser]
+#pragma warning disable CA1515
+public class StructToStructBenchmark
+#pragma warning restore CA1515
+{
+    private readonly PersonStructDto input;
+    private readonly AutoMapper.IMapper automapperMapper;
+    private readonly MapperlyMapper mapperlyMapper;
+    private readonly MappaMapper mappaMapper;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StructToStructBenchmark"/> class.
+    /// </summary>
+    public StructToStructBenchmark()
+    {
+        this.automapperMapper = new AutoMapper.MapperConfiguration(
+            cfg => cfg.AddMaps(typeof(AutomapperMapperProfile)),
+#pragma warning disable CA2000
+            new NullLoggerFactory()).CreateMapper();
+#pragma warning restore CA2000
+        this.mapperlyMapper = new();
+        this.mappaMapper = new();
+        this.input = new PersonStructDto
+        {
+            Id = 1,
+            Name = "Ada Lovelace",
+            Age = 36,
+            Street = "Analytical Engine Way",
+            City = "London",
+            Zip = "SW1A",
+        };
+    }
+
+    /// <summary>
+    /// Map using AutoMapper.
+    /// </summary>
+    /// <returns>The mapped model.</returns>
+    [Benchmark(Baseline = true)]
+    public PersonStruct Automapper()
+        => this.automapperMapper.Map<PersonStruct>(this.input);
+
+    /// <summary>
+    /// Map using Mapperly.
+    /// </summary>
+    /// <returns>The mapped model.</returns>
+    [Benchmark]
+    public PersonStruct Mapperly()
+        => this.mapperlyMapper.Map(this.input);
+
+    /// <summary>
+    /// Map using Mapster.
+    /// </summary>
+    /// <returns>The mapped model.</returns>
+    [Benchmark]
+    public PersonStruct Mapster()
+        => this.input.Adapt<PersonStruct>();
+
+    /// <summary>
+    /// Map using Mappa.
+    /// </summary>
+    /// <returns>The mapped model.</returns>
+    [Benchmark]
+    public PersonStruct Mappa()
+        => this.mappaMapper.Map(this.input);
+}

--- a/Mappa.Benchmark/Objects/StructToStructBenchmark.cs
+++ b/Mappa.Benchmark/Objects/StructToStructBenchmark.cs
@@ -32,7 +32,7 @@ public class StructToStructBenchmark
     public StructToStructBenchmark()
     {
         this.automapperMapper = new AutoMapper.MapperConfiguration(
-            cfg => cfg.AddMaps(typeof(AutomapperMapperProfile)),
+            cfg => cfg.AddProfile(new AutomapperMapperProfile()),
 #pragma warning disable CA2000
             new NullLoggerFactory()).CreateMapper();
 #pragma warning restore CA2000

--- a/Mappa.Benchmark/Polymorphism/Mappers/AutomapperMapperProfile.cs
+++ b/Mappa.Benchmark/Polymorphism/Mappers/AutomapperMapperProfile.cs
@@ -4,12 +4,12 @@
 
 using AutoMapper;
 
-using Mappa.Benchmark.Enums.Models;
+using Mappa.Benchmark.Polymorphism.Models;
 
-namespace Mappa.Benchmark.Enums.Mappers;
+namespace Mappa.Benchmark.Polymorphism.Mappers;
 
 /// <summary>
-/// The mapper profile for <see cref="AutoMapper"/>.
+/// AutoMapper profile for polymorphic benchmarks.
 /// </summary>
 internal sealed class AutomapperMapperProfile
     : Profile
@@ -19,12 +19,12 @@ internal sealed class AutomapperMapperProfile
     /// </summary>
     public AutomapperMapperProfile()
     {
-        this.CreateMap<StringComparison, string>();
-        this.CreateMap<string, StringComparison>();
-
-        this.CreateMap<StringComparison, int>();
-        this.CreateMap<int, StringComparison>();
-
-        this.CreateMap<SourceStatus, TargetStatus>();
+        this.CreateMap<AnimalDto, Animal>()
+            .Include<DogDto, Dog>()
+            .Include<CatDto, Cat>()
+            .Include<BirdDto, Bird>();
+        this.CreateMap<DogDto, Dog>();
+        this.CreateMap<CatDto, Cat>();
+        this.CreateMap<BirdDto, Bird>();
     }
 }

--- a/Mappa.Benchmark/Polymorphism/Mappers/MappaMapper.cs
+++ b/Mappa.Benchmark/Polymorphism/Mappers/MappaMapper.cs
@@ -1,0 +1,25 @@
+// <copyright file="MappaMapper.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using Mappa.Attributes;
+using Mappa.Benchmark.Polymorphism.Models;
+
+namespace Mappa.Benchmark.Polymorphism.Mappers;
+
+/// <summary>
+/// Mappa mapper for polymorphic benchmarks.
+/// </summary>
+[Mappa]
+internal sealed partial class MappaMapper
+{
+    /// <summary>
+    /// Maps a polymorphic animal DTO.
+    /// </summary>
+    /// <param name="source">The source.</param>
+    /// <returns>The target.</returns>
+    [MappaTypeMapping(typeof(Dog), typeof(DogDto))]
+    [MappaTypeMapping(typeof(Cat), typeof(CatDto))]
+    [MappaTypeMapping(typeof(Bird), typeof(BirdDto))]
+    public partial Animal Map(AnimalDto source);
+}

--- a/Mappa.Benchmark/Polymorphism/Mappers/MapperlyMapper.cs
+++ b/Mappa.Benchmark/Polymorphism/Mappers/MapperlyMapper.cs
@@ -1,0 +1,26 @@
+// <copyright file="MapperlyMapper.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using Mappa.Benchmark.Polymorphism.Models;
+
+using Riok.Mapperly.Abstractions;
+
+namespace Mappa.Benchmark.Polymorphism.Mappers;
+
+/// <summary>
+/// Mapperly mapper for polymorphic benchmarks.
+/// </summary>
+[Mapper]
+internal sealed partial class MapperlyMapper
+{
+    /// <summary>
+    /// Maps a polymorphic animal DTO.
+    /// </summary>
+    /// <param name="source">The source.</param>
+    /// <returns>The target.</returns>
+    [MapDerivedType(typeof(DogDto), typeof(Dog))]
+    [MapDerivedType(typeof(CatDto), typeof(Cat))]
+    [MapDerivedType(typeof(BirdDto), typeof(Bird))]
+    public partial Animal Map(AnimalDto source);
+}

--- a/Mappa.Benchmark/Polymorphism/Models/PolymorphicModels.cs
+++ b/Mappa.Benchmark/Polymorphism/Models/PolymorphicModels.cs
@@ -1,0 +1,95 @@
+// <copyright file="PolymorphicModels.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+#pragma warning disable CA1002, CA1515, CA1724, CA1815, CA1819, CA2227, SA1201, SA1402, SA1649
+
+namespace Mappa.Benchmark.Polymorphism.Models;
+
+/// <summary>
+/// Polymorphic source base type.
+/// </summary>
+public abstract class AnimalDto
+{
+    /// <summary>
+    /// Gets or sets the name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Dog source type.
+/// </summary>
+public sealed class DogDto : AnimalDto
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the dog is trained.
+    /// </summary>
+    public bool Trained { get; set; }
+}
+
+/// <summary>
+/// Cat source type.
+/// </summary>
+public sealed class CatDto : AnimalDto
+{
+    /// <summary>
+    /// Gets or sets the number of lives.
+    /// </summary>
+    public int Lives { get; set; }
+}
+
+/// <summary>
+/// Bird source type.
+/// </summary>
+public sealed class BirdDto : AnimalDto
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the bird can fly.
+    /// </summary>
+    public bool CanFly { get; set; }
+}
+
+/// <summary>
+/// Polymorphic target base type.
+/// </summary>
+public abstract class Animal
+{
+    /// <summary>
+    /// Gets or sets the name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Dog target type.
+/// </summary>
+public sealed class Dog : Animal
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the dog is trained.
+    /// </summary>
+    public bool Trained { get; set; }
+}
+
+/// <summary>
+/// Cat target type.
+/// </summary>
+public sealed class Cat : Animal
+{
+    /// <summary>
+    /// Gets or sets the number of lives.
+    /// </summary>
+    public int Lives { get; set; }
+}
+
+/// <summary>
+/// Bird target type.
+/// </summary>
+public sealed class Bird : Animal
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the bird can fly.
+    /// </summary>
+    public bool CanFly { get; set; }
+}

--- a/Mappa.Benchmark/Polymorphism/PolymorphicBenchmark.cs
+++ b/Mappa.Benchmark/Polymorphism/PolymorphicBenchmark.cs
@@ -1,0 +1,79 @@
+// <copyright file="PolymorphicBenchmark.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using BenchmarkDotNet.Attributes;
+
+using Mappa.Benchmark.Polymorphism.Mappers;
+using Mappa.Benchmark.Polymorphism.Models;
+
+using Mapster;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Mappa.Benchmark.Polymorphism;
+
+/// <summary>
+/// Benchmark polymorphic mapping across three derived types.
+/// </summary>
+[MemoryDiagnoser]
+#pragma warning disable CA1515
+public class PolymorphicBenchmark
+#pragma warning restore CA1515
+{
+    private readonly AnimalDto input;
+    private readonly AutoMapper.IMapper automapperMapper;
+    private readonly MapperlyMapper mapperlyMapper;
+    private readonly MappaMapper mappaMapper;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PolymorphicBenchmark"/> class.
+    /// </summary>
+    public PolymorphicBenchmark()
+    {
+        this.automapperMapper = new AutoMapper.MapperConfiguration(
+            cfg => cfg.AddMaps(typeof(AutomapperMapperProfile)),
+#pragma warning disable CA2000
+            new NullLoggerFactory()).CreateMapper();
+#pragma warning restore CA2000
+        this.mapperlyMapper = new();
+        this.mappaMapper = new();
+        this.input = new DogDto { Name = "Rex", Trained = true };
+        TypeAdapterConfig<AnimalDto, Animal>.NewConfig()
+            .Include<DogDto, Dog>()
+            .Include<CatDto, Cat>()
+            .Include<BirdDto, Bird>();
+    }
+
+    /// <summary>
+    /// Map using AutoMapper.
+    /// </summary>
+    /// <returns>The mapped animal.</returns>
+    [Benchmark(Baseline = true)]
+    public Animal Automapper()
+        => this.automapperMapper.Map<Animal>(this.input);
+
+    /// <summary>
+    /// Map using Mapperly.
+    /// </summary>
+    /// <returns>The mapped animal.</returns>
+    [Benchmark]
+    public Animal Mapperly()
+        => this.mapperlyMapper.Map(this.input);
+
+    /// <summary>
+    /// Map using Mapster.
+    /// </summary>
+    /// <returns>The mapped animal.</returns>
+    [Benchmark]
+    public Animal Mapster()
+        => this.input.Adapt<Animal>();
+
+    /// <summary>
+    /// Map using Mappa.
+    /// </summary>
+    /// <returns>The mapped animal.</returns>
+    [Benchmark]
+    public Animal Mappa()
+        => this.mappaMapper.Map(this.input);
+}

--- a/Mappa.Benchmark/Polymorphism/PolymorphicBenchmark.cs
+++ b/Mappa.Benchmark/Polymorphism/PolymorphicBenchmark.cs
@@ -32,7 +32,7 @@ public class PolymorphicBenchmark
     public PolymorphicBenchmark()
     {
         this.automapperMapper = new AutoMapper.MapperConfiguration(
-            cfg => cfg.AddMaps(typeof(AutomapperMapperProfile)),
+            cfg => cfg.AddProfile(new AutomapperMapperProfile()),
 #pragma warning disable CA2000
             new NullLoggerFactory()).CreateMapper();
 #pragma warning restore CA2000

--- a/Mappa.Benchmark/Queryable/IQueryableProjectionBenchmark.cs
+++ b/Mappa.Benchmark/Queryable/IQueryableProjectionBenchmark.cs
@@ -38,7 +38,7 @@ public class IQueryableProjectionBenchmark
     public IQueryableProjectionBenchmark()
     {
         this.automapperMapper = new AutoMapper.MapperConfiguration(
-            cfg => cfg.AddMaps(typeof(AutomapperMapperProfile)),
+            cfg => cfg.AddProfile(new AutomapperMapperProfile()),
 #pragma warning disable CA2000
             new NullLoggerFactory()).CreateMapper();
 #pragma warning restore CA2000

--- a/Mappa.Benchmark/Queryable/IQueryableProjectionBenchmark.cs
+++ b/Mappa.Benchmark/Queryable/IQueryableProjectionBenchmark.cs
@@ -1,0 +1,95 @@
+// <copyright file="IQueryableProjectionBenchmark.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using AutoMapper.QueryableExtensions;
+
+using BenchmarkDotNet.Attributes;
+
+using Mappa.Benchmark.Common;
+using Mappa.Benchmark.Queryable.Mappers;
+using Mappa.Benchmark.Queryable.Models;
+
+using Mapster;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Mappa.Benchmark.Queryable;
+
+/// <summary>
+/// Benchmark IQueryable projection with forced enumeration.
+/// </summary>
+[MemoryDiagnoser]
+#pragma warning disable CA1002
+#pragma warning disable CA1515
+#pragma warning disable S101
+public class IQueryableProjectionBenchmark
+#pragma warning restore S101
+#pragma warning restore CA1515
+{
+    private readonly IQueryable<ProjectionOrder> input;
+    private readonly AutoMapper.IMapper automapperMapper;
+    private readonly MapperlyMapper mapperlyMapper;
+    private readonly MappaMapper mappaMapper;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IQueryableProjectionBenchmark"/> class.
+    /// </summary>
+    public IQueryableProjectionBenchmark()
+    {
+        this.automapperMapper = new AutoMapper.MapperConfiguration(
+            cfg => cfg.AddMaps(typeof(AutomapperMapperProfile)),
+#pragma warning disable CA2000
+            new NullLoggerFactory()).CreateMapper();
+#pragma warning restore CA2000
+        this.mapperlyMapper = new();
+        this.mappaMapper = new();
+
+        var orders = new List<ProjectionOrder>(BenchmarkConstants.CollectionSize);
+        for (var index = 0; index < BenchmarkConstants.CollectionSize; index++)
+        {
+            orders.Add(new ProjectionOrder
+            {
+                Id = index,
+                Name = $"Order-{index}",
+                CustomerName = $"Customer-{index}",
+            });
+        }
+
+        this.input = orders.AsQueryable();
+        TypeAdapterConfig<ProjectionOrder, ProjectionOrderDto>.NewConfig()
+            .Map(destination => destination.Title, source => source.Name);
+    }
+
+    /// <summary>
+    /// Map using AutoMapper ProjectTo.
+    /// </summary>
+    /// <returns>The projected list.</returns>
+    [Benchmark(Baseline = true)]
+    public List<ProjectionOrderDto> Automapper()
+        => this.input.ProjectTo<ProjectionOrderDto>(this.automapperMapper.ConfigurationProvider).ToList();
+
+    /// <summary>
+    /// Map using Mapperly projection.
+    /// </summary>
+    /// <returns>The projected list.</returns>
+    [Benchmark]
+    public List<ProjectionOrderDto> Mapperly()
+        => this.mapperlyMapper.Project(this.input).ToList();
+
+    /// <summary>
+    /// Map using Mapster ProjectToType.
+    /// </summary>
+    /// <returns>The projected list.</returns>
+    [Benchmark]
+    public List<ProjectionOrderDto> Mapster()
+        => this.input.ProjectToType<ProjectionOrderDto>().ToList();
+
+    /// <summary>
+    /// Map using Mappa projection.
+    /// </summary>
+    /// <returns>The projected list.</returns>
+    [Benchmark]
+    public List<ProjectionOrderDto> Mappa()
+        => this.mappaMapper.Project(this.input).ToList();
+}

--- a/Mappa.Benchmark/Queryable/Mappers/AutomapperMapperProfile.cs
+++ b/Mappa.Benchmark/Queryable/Mappers/AutomapperMapperProfile.cs
@@ -4,12 +4,12 @@
 
 using AutoMapper;
 
-using Mappa.Benchmark.Enums.Models;
+using Mappa.Benchmark.Queryable.Models;
 
-namespace Mappa.Benchmark.Enums.Mappers;
+namespace Mappa.Benchmark.Queryable.Mappers;
 
 /// <summary>
-/// The mapper profile for <see cref="AutoMapper"/>.
+/// AutoMapper profile for IQueryable projection benchmarks.
 /// </summary>
 internal sealed class AutomapperMapperProfile
     : Profile
@@ -19,12 +19,7 @@ internal sealed class AutomapperMapperProfile
     /// </summary>
     public AutomapperMapperProfile()
     {
-        this.CreateMap<StringComparison, string>();
-        this.CreateMap<string, StringComparison>();
-
-        this.CreateMap<StringComparison, int>();
-        this.CreateMap<int, StringComparison>();
-
-        this.CreateMap<SourceStatus, TargetStatus>();
+        this.CreateMap<ProjectionOrder, ProjectionOrderDto>()
+            .ForMember(destination => destination.Title, options => options.MapFrom(source => source.Name));
     }
 }

--- a/Mappa.Benchmark/Queryable/Mappers/MappaMapper.cs
+++ b/Mappa.Benchmark/Queryable/Mappers/MappaMapper.cs
@@ -1,0 +1,31 @@
+// <copyright file="MappaMapper.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using Mappa.Attributes;
+using Mappa.Benchmark.Queryable.Models;
+
+namespace Mappa.Benchmark.Queryable.Mappers;
+
+/// <summary>
+/// Mappa mapper for IQueryable projection benchmarks.
+/// </summary>
+[Mappa]
+internal sealed partial class MappaMapper
+{
+    /// <summary>
+    /// Projects orders to DTOs.
+    /// </summary>
+    /// <param name="query">The source queryable.</param>
+    /// <returns>The projected queryable.</returns>
+    [MappaUseProperty(nameof(ProjectionOrderDto.Title), nameof(ProjectionOrder.Name))]
+    public partial IQueryable<ProjectionOrderDto> Project(IQueryable<ProjectionOrder> query);
+
+    /// <summary>
+    /// Companion element map for projection.
+    /// </summary>
+    /// <param name="order">The source order.</param>
+    /// <returns>The mapped DTO.</returns>
+    [MappaUseProperty(nameof(ProjectionOrderDto.Title), nameof(ProjectionOrder.Name))]
+    private partial ProjectionOrderDto MapOrder(ProjectionOrder order);
+}

--- a/Mappa.Benchmark/Queryable/Mappers/MapperlyMapper.cs
+++ b/Mappa.Benchmark/Queryable/Mappers/MapperlyMapper.cs
@@ -1,0 +1,31 @@
+// <copyright file="MapperlyMapper.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using Mappa.Benchmark.Queryable.Models;
+
+using Riok.Mapperly.Abstractions;
+
+namespace Mappa.Benchmark.Queryable.Mappers;
+
+/// <summary>
+/// Mapperly mapper for IQueryable projection benchmarks.
+/// </summary>
+[Mapper]
+internal sealed partial class MapperlyMapper
+{
+    /// <summary>
+    /// Projects orders to DTOs.
+    /// </summary>
+    /// <param name="query">The source queryable.</param>
+    /// <returns>The projected queryable.</returns>
+    public partial IQueryable<ProjectionOrderDto> Project(IQueryable<ProjectionOrder> query);
+
+    /// <summary>
+    /// Companion element map for projection.
+    /// </summary>
+    /// <param name="order">The source order.</param>
+    /// <returns>The mapped DTO.</returns>
+    [MapProperty(nameof(ProjectionOrder.Name), nameof(ProjectionOrderDto.Title))]
+    private partial ProjectionOrderDto MapOrder(ProjectionOrder order);
+}

--- a/Mappa.Benchmark/Queryable/Models/ProjectionModels.cs
+++ b/Mappa.Benchmark/Queryable/Models/ProjectionModels.cs
@@ -1,0 +1,49 @@
+// <copyright file="ProjectionModels.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+#pragma warning disable CA1002, CA1515, CA1724, CA1815, CA1819, CA2227, SA1201, SA1402, SA1649
+
+namespace Mappa.Benchmark.Queryable.Models;
+
+/// <summary>
+/// Source entity for IQueryable projection benchmarks.
+/// </summary>
+public sealed class ProjectionOrder
+{
+    /// <summary>
+    /// Gets or sets the identifier.
+    /// </summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the customer name.
+    /// </summary>
+    public string CustomerName { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Target DTO for IQueryable projection benchmarks.
+/// </summary>
+public sealed class ProjectionOrderDto
+{
+    /// <summary>
+    /// Gets or sets the identifier.
+    /// </summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the title.
+    /// </summary>
+    public string Title { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the customer name.
+    /// </summary>
+    public string CustomerName { get; set; } = string.Empty;
+}

--- a/Mappa.Benchmark/README.md
+++ b/Mappa.Benchmark/README.md
@@ -42,7 +42,7 @@ Outputs are written under `.mappa-benchmark/` (gitignored). See [Documentation/d
 
 ### Chart / CI subset
 
-`MAPPA-BENCHMARK-TIME.svg` and `MAPPA-BENCHMARK-MEMORY.svg` (and CI `-ChartBenchmarksOnly`) include:
+`MAPPA-BENCHMARK-TIME.svg`, `MAPPA-BENCHMARK-MEMORY.svg`, `MAPPA-BENCHMARK-TIME-PERCENTAGES.svg`, and `MAPPA-BENCHMARK-MEMORY-PERCENTAGES.svg` (and CI `-ChartBenchmarksOnly`) include:
 
 - `ArrayToListBenchmark`
 - `DictionaryBenchmark`

--- a/Mappa.Benchmark/README.md
+++ b/Mappa.Benchmark/README.md
@@ -1,0 +1,57 @@
+# Mappa.Benchmark
+
+BenchmarkDotNet suite comparing **Mappa**, **Mapperly**, **Mapster**, and **AutoMapper** on common mapping scenarios.
+
+## How to run
+
+From the repository root (PowerShell):
+
+```powershell
+.\Scripts\RunBenchmarks.ps1
+```
+
+CI uses the chart subset only:
+
+```powershell
+.\Scripts\RunBenchmarks.ps1 -ChartBenchmarksOnly
+```
+
+Jobs use BenchmarkDotNet **Short** run mode. Prefer a Release rebuild first (`.\Scripts\RebuildUponVersionChange.ps1`).
+
+Outputs are written under `.mappa-benchmark/` (gitignored). See [Documentation/development.md](../Documentation/development.md) for the full list of artifacts and gist publishing via `UpdateBenchmarkGists.ps1`.
+
+## Interpreting results
+
+- **AutoMapper is the ratio baseline** (`[Benchmark(Baseline = true)]`) on every scenario.
+- **Lower mean time and lower allocated bytes are better.**
+- Summary tables report nanoseconds and bytes; the TIME/MEMORY bar charts plot **microseconds** and **kilobytes** with a **50** unit Y-axis tick.
+
+## Scenario suite
+
+| Area | Benchmark | Notes |
+|------|-----------|--------|
+| Object graph | `SpotifyBenchmark` | Nested album/artist/tracks; fixed Bogus seed |
+| Objects | `ClassToClassBenchmark`, `RecordToRecordBenchmark`, `StructToStructBenchmark` | Same property shape across kinds |
+| Enums | `EnumToIntBenchmark`, `IntToEnumBenchmark`, `EnumToStringBenchmark`, `StringToEnumBenchmark`, `EnumToEnumBenchmark` | |
+| Collections | `ArrayToListBenchmark`, `ListToArrayBenchmark`, `ListToHashSetBenchmark`, `DictionaryBenchmark` | |
+| Fast collections | `FastListToArrayBenchmark` | Mappa with `FastCollections`; others use their default path |
+| Memory | `MemoryToArrayBenchmark`, `ArrayToMemoryBenchmark` | |
+| Polymorphism | `PolymorphicBenchmark` | Derived-type maps |
+| IQueryable | `IQueryableProjectionBenchmark` | In-memory `AsQueryable()` + `.ToList()` |
+| Nested DTO | `NestedDtoBenchmark` | Multi-level parent/child |
+
+### Chart / CI subset
+
+`MAPPA-BENCHMARK-TIME.svg` and `MAPPA-BENCHMARK-MEMORY.svg` (and CI `-ChartBenchmarksOnly`) include:
+
+- `ArrayToListBenchmark`
+- `DictionaryBenchmark`
+- `ListToArrayBenchmark`
+- `FastListToArrayBenchmark`
+- `IQueryableProjectionBenchmark`
+- `NestedDtoBenchmark`
+- `ListToHashSetBenchmark`
+
+## Spotify attribution
+
+The Spotify object-graph models are adapted from [mjebrahimi/Benchmark.netCoreMappers](https://github.com/mjebrahimi/Benchmark.netCoreMappers). See [`Spotify/README.md`](Spotify/README.md).

--- a/Mappa.Benchmark/Spotify/SpotifyBenchmark.cs
+++ b/Mappa.Benchmark/Spotify/SpotifyBenchmark.cs
@@ -41,7 +41,7 @@ public class SpotifyBenchmark
         this.automapperMapper = new AutoMapper.MapperConfiguration(
             cfg =>
                 {
-                    cfg.AddMaps(typeof(AutomapperMapperProfile));
+                    cfg.AddProfile(new AutomapperMapperProfile());
                 },
 #pragma warning disable CA2000
             new NullLoggerFactory()).CreateMapper();

--- a/Mappa.Benchmark/Spotify/SpotifyBenchmark.cs
+++ b/Mappa.Benchmark/Spotify/SpotifyBenchmark.cs
@@ -4,6 +4,9 @@
 
 using BenchmarkDotNet.Attributes;
 
+using Bogus;
+
+using Mappa.Benchmark.Common;
 using Mappa.Benchmark.Spotify.Mappers;
 using Mappa.Benchmark.Spotify.Models;
 
@@ -31,6 +34,10 @@ public class SpotifyBenchmark
     /// </summary>
     public SpotifyBenchmark()
     {
+#pragma warning disable S3010
+        Randomizer.Seed = new Random(BenchmarkConstants.RandomSeed);
+#pragma warning restore S3010
+
         this.automapperMapper = new AutoMapper.MapperConfiguration(
             cfg =>
                 {
@@ -46,7 +53,7 @@ public class SpotifyBenchmark
 
         this.spotifyAlbumDto = new AutoBogus
             .AutoFaker<SpotifyAlbumDto>()
-            .Configure(builder => builder.WithRepeatCount(300))
+            .Configure(builder => builder.WithRepeatCount(BenchmarkConstants.CollectionSize))
             .Generate();
     }
 
@@ -54,7 +61,7 @@ public class SpotifyBenchmark
     /// Map using <see cref="AutoMapper"/>.
     /// </summary>
     /// <returns>The mapper model.</returns>
-    [Benchmark]
+    [Benchmark(Baseline = true)]
     public SpotifyAlbum Automapper()
         => this.automapperMapper.Map<SpotifyAlbum>(this.spotifyAlbumDto);
 
@@ -78,7 +85,7 @@ public class SpotifyBenchmark
     /// Map using <see cref="Mappa.Attributes"/>.
     /// </summary>
     /// <returns>The mapper model.</returns>
-    [Benchmark(Baseline = true)]
+    [Benchmark]
     public SpotifyAlbum Mappa()
         => this.mappaMapper.Map(this.spotifyAlbumDto);
 }

--- a/MappaVersion.targets
+++ b/MappaVersion.targets
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <MappaVersion>10.2.0-alpha.24</MappaVersion>
+        <MappaVersion>10.2.0-alpha.25</MappaVersion>
     </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -120,3 +120,18 @@ You can also find many examples in the [Mappa.Samples](Mappa.Samples) project.
 - [Code Coverage history](https://gist.github.com/sanelli/7f4a85bc809328b4821b03125f9190cb#file-mappa-code-coverage-history-md)
 
 <img alt="Code coverage history" src="https://gist.githubusercontent.com/sanelli/7f4a85bc809328b4821b03125f9190cb/raw/MAPPA-CODE-COVERAGE-HISTORY.svg" width="800" height="500"/>
+
+# 🏎️ Benchmarks
+Mappa is compared with AutoMapper, Mapster, and Mapperly on a shared set of mapping scenarios (collections, nested DTOs, IQueryable projection, and related cases). AutoMapper is the ratio baseline; **lower time and lower memory are better**. Details live in [Mappa.Benchmark/README.md](Mappa.Benchmark/README.md).
+
+### Latest run — mean time
+<img alt="Benchmark mean time" src="https://gist.githubusercontent.com/sanelli/7f4a85bc809328b4821b03125f9190cb/raw/MAPPA-BENCHMARK-TIME.svg" width="800"/>
+
+### Latest run — allocated memory
+<img alt="Benchmark allocated memory" src="https://gist.githubusercontent.com/sanelli/7f4a85bc809328b4821b03125f9190cb/raw/MAPPA-BENCHMARK-MEMORY.svg" width="800"/>
+
+### History — mean time (Mappa)
+<img alt="Benchmark time history" src="https://gist.githubusercontent.com/sanelli/7f4a85bc809328b4821b03125f9190cb/raw/MAPPA-BENCHMARK-TIME-HISTORY.svg" width="800" height="500"/>
+
+### History — allocated memory (Mappa)
+<img alt="Benchmark memory history" src="https://gist.githubusercontent.com/sanelli/7f4a85bc809328b4821b03125f9190cb/raw/MAPPA-BENCHMARK-MEMORY-HISTORY.svg" width="800" height="500"/>

--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ Mappa is compared with AutoMapper, Mapster, and Mapperly on a shared set of mapp
 ### Latest run — allocated memory
 <img alt="Benchmark allocated memory" src="https://gist.githubusercontent.com/sanelli/7f4a85bc809328b4821b03125f9190cb/raw/MAPPA-BENCHMARK-MEMORY.svg" width="800"/>
 
+### Latest run — mean time vs Mappa (%)
+<img alt="Benchmark mean time percentages" src="https://gist.githubusercontent.com/sanelli/7f4a85bc809328b4821b03125f9190cb/raw/MAPPA-BENCHMARK-TIME-PERCENTAGES.svg" width="800"/>
+
+### Latest run — allocated memory vs Mappa (%)
+<img alt="Benchmark allocated memory percentages" src="https://gist.githubusercontent.com/sanelli/7f4a85bc809328b4821b03125f9190cb/raw/MAPPA-BENCHMARK-MEMORY-PERCENTAGES.svg" width="800"/>
+
 ### History — mean time (Mappa)
 <img alt="Benchmark time history" src="https://gist.githubusercontent.com/sanelli/7f4a85bc809328b4821b03125f9190cb/raw/MAPPA-BENCHMARK-TIME-HISTORY.svg" width="800" height="500"/>
 

--- a/Scripts/BenchmarkChartsSvg.ps1
+++ b/Scripts/BenchmarkChartsSvg.ps1
@@ -1,0 +1,260 @@
+# Shared helpers for Mappa benchmark grouped-bar SVG charts.
+
+$script:BenchmarkMapperOrder = @("Automapper", "Mapster", "Mapperly", "Mappa")
+$script:BenchmarkMapperColors = @{
+    Automapper = "#4E79A7"
+    Mapster    = "#E15759"
+    Mapperly   = "#F28E2B"
+    Mappa      = "#76B7B2"
+}
+
+function ConvertTo-InvariantDouble
+{
+    param([string]$Text)
+
+    if ([string]::IsNullOrWhiteSpace($Text))
+    {
+        return $null
+    }
+
+    $normalized = $Text.Trim() -replace ',', ''
+    if ($normalized -match '[-+]?\d+(\.\d+)?([eE][-+]?\d+)?')
+    {
+        return [double]::Parse($Matches[0], [System.Globalization.CultureInfo]::InvariantCulture)
+    }
+
+    return $null
+}
+
+function ConvertTo-Nanoseconds
+{
+    param([string]$Text)
+
+    $value = ConvertTo-InvariantDouble -Text $Text
+    if ($null -eq $value)
+    {
+        return $null
+    }
+
+    $lower = $Text.ToLowerInvariant()
+    if ($lower -match '\bms\b')
+    {
+        return $value * 1000000.0
+    }
+
+    if ($lower -match '\bus\b' -or $lower -match '\bμs\b')
+    {
+        return $value * 1000.0
+    }
+
+    if ($lower -match '\bs\b' -and $lower -notmatch '\bns\b' -and $lower -notmatch '\bms\b' -and $lower -notmatch '\bus\b')
+    {
+        return $value * 1000000000.0
+    }
+
+    return $value
+}
+
+function ConvertTo-AllocatedBytes
+{
+    param([string]$Text)
+
+    $value = ConvertTo-InvariantDouble -Text $Text
+    if ($null -eq $value)
+    {
+        return $null
+    }
+
+    $lower = $Text.ToLowerInvariant()
+    if ($lower -match '\bkb\b')
+    {
+        return $value * 1024.0
+    }
+
+    if ($lower -match '\bmb\b')
+    {
+        return $value * 1024.0 * 1024.0
+    }
+
+    if ($lower -match '\bgb\b')
+    {
+        return $value * 1024.0 * 1024.0 * 1024.0
+    }
+
+    return $value
+}
+
+function New-BenchmarkGroupedBarSvg
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [object[]]$Benchmarks,
+
+        [Parameter(Mandatory = $true)]
+        [string]$MetricProperty,
+
+        [Parameter(Mandatory = $true)]
+        [string]$YAxisLabel,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Title,
+
+        [Parameter(Mandatory = $true)]
+        [string]$OutputPath,
+
+        [Parameter(Mandatory = $true)]
+        [double]$YAxisTickStep,
+
+        [string]$ValueLabelFormat = "0.##"
+    )
+
+    if ($Benchmarks.Count -eq 0)
+    {
+        throw "No benchmark rows available to chart."
+    }
+
+    if ($YAxisTickStep -le 0)
+    {
+        throw "YAxisTickStep must be greater than zero."
+    }
+
+    $mappers = $script:BenchmarkMapperOrder
+    $groupCount = $Benchmarks.Count
+    $seriesCount = $mappers.Count
+
+    $leftMargin = 80.0
+    $rightMargin = 40.0
+    $topMargin = 60.0
+    $bottomMargin = 120.0
+    $groupGap = 24.0
+    $barWidth = 18.0
+    $groupWidth = ($seriesCount * $barWidth) + 8.0
+    $plotWidth = [Math]::Max(640.0, ($groupCount * ($groupWidth + $groupGap)) + $groupGap)
+    $plotHeight = 360.0
+    $svgWidth = [Math]::Round($leftMargin + $plotWidth + $rightMargin, 0)
+    $svgHeight = [Math]::Round($topMargin + $plotHeight + $bottomMargin, 0)
+
+    $maxValue = 0.0
+    foreach ($benchmark in $Benchmarks)
+    {
+        foreach ($mapper in $mappers)
+        {
+            $entry = $benchmark.Mappers[$mapper]
+            if ($null -eq $entry)
+            {
+                continue
+            }
+
+            $metric = [double]$entry.$MetricProperty
+            if ($metric -gt $maxValue)
+            {
+                $maxValue = $metric
+            }
+        }
+    }
+
+    $tickCount = [int][Math]::Ceiling($maxValue / $YAxisTickStep)
+    if ($tickCount -lt 1)
+    {
+        $tickCount = 1
+    }
+
+    $axisMax = $tickCount * $YAxisTickStep
+
+    $builder = New-Object System.Text.StringBuilder
+    [void]$builder.AppendLine('<?xml version="1.0" encoding="UTF-8" standalone="no"?>')
+    [void]$builder.AppendLine("<svg xmlns=`"http://www.w3.org/2000/svg`" width=`"$svgWidth`" height=`"$svgHeight`" viewBox=`"0 0 $svgWidth $svgHeight`">")
+    [void]$builder.AppendLine("  <rect width=`"100%`" height=`"100%`" fill=`"#ffffff`"/>")
+    [void]$builder.AppendLine("  <text x=`"$([Math]::Round($svgWidth / 2, 1))`" y=`"28`" text-anchor=`"middle`" font-family=`"Segoe UI, Arial, sans-serif`" font-size=`"18`" fill=`"#222222`">$Title</text>")
+    [void]$builder.AppendLine("  <text x=`"20`" y=`"$([Math]::Round($topMargin + ($plotHeight / 2), 1))`" text-anchor=`"middle`" transform=`"rotate(-90 20 $([Math]::Round($topMargin + ($plotHeight / 2), 1)))`" font-family=`"Segoe UI, Arial, sans-serif`" font-size=`"12`" fill=`"#444444`">$YAxisLabel</text>")
+
+    for ($tickIndex = 0; $tickIndex -le $tickCount; $tickIndex++)
+    {
+        $value = $tickIndex * $YAxisTickStep
+        $ratio = 1.0 - ($value / $axisMax)
+        $y = $topMargin + ($plotHeight * $ratio)
+        if ($YAxisTickStep -ge 1.0)
+        {
+            $label = "{0:0}" -f $value
+        }
+        else
+        {
+            $label = "{0:0.##}" -f $value
+        }
+
+        [void]$builder.AppendLine("  <line x1=`"$leftMargin`" y1=`"$([Math]::Round($y, 2))`" x2=`"$([Math]::Round($leftMargin + $plotWidth, 2))`" y2=`"$([Math]::Round($y, 2))`" stroke=`"#dddddd`" stroke-width=`"1`"/>")
+        [void]$builder.AppendLine("  <text x=`"$([Math]::Round($leftMargin - 8, 2))`" y=`"$([Math]::Round($y + 4, 2))`" text-anchor=`"end`" font-family=`"Segoe UI, Arial, sans-serif`" font-size=`"11`" fill=`"#555555`">$label</text>")
+    }
+
+    [void]$builder.AppendLine("  <line x1=`"$leftMargin`" y1=`"$topMargin`" x2=`"$leftMargin`" y2=`"$([Math]::Round($topMargin + $plotHeight, 2))`" stroke=`"#333333`" stroke-width=`"1.5`"/>")
+    [void]$builder.AppendLine("  <line x1=`"$leftMargin`" y1=`"$([Math]::Round($topMargin + $plotHeight, 2))`" x2=`"$([Math]::Round($leftMargin + $plotWidth, 2))`" y2=`"$([Math]::Round($topMargin + $plotHeight, 2))`" stroke=`"#333333`" stroke-width=`"1.5`"/>")
+
+    for ($groupIndex = 0; $groupIndex -lt $groupCount; $groupIndex++)
+    {
+        $benchmark = $Benchmarks[$groupIndex]
+        $groupStartX = $leftMargin + $groupGap + ($groupIndex * ($groupWidth + $groupGap))
+
+        for ($seriesIndex = 0; $seriesIndex -lt $seriesCount; $seriesIndex++)
+        {
+            $mapper = $mappers[$seriesIndex]
+            $entry = $benchmark.Mappers[$mapper]
+            if ($null -eq $entry)
+            {
+                continue
+            }
+
+            $metric = [double]$entry.$MetricProperty
+            $barHeight = ($metric / $axisMax) * $plotHeight
+            $x = $groupStartX + ($seriesIndex * $barWidth)
+            $y = $topMargin + $plotHeight - $barHeight
+            $color = $script:BenchmarkMapperColors[$mapper]
+            [void]$builder.AppendLine("  <rect x=`"$([Math]::Round($x, 2))`" y=`"$([Math]::Round($y, 2))`" width=`"$barWidth`" height=`"$([Math]::Round($barHeight, 2))`" fill=`"$color`"/>")
+
+            $valueText = $metric.ToString($ValueLabelFormat, [System.Globalization.CultureInfo]::InvariantCulture)
+            $textX = $x + ($barWidth / 2.0)
+            $textY = $y - 4.0
+            # Always place the value vertically above the bar, using the bar color.
+            [void]$builder.AppendLine("  <text x=`"$([Math]::Round($textX, 2))`" y=`"$([Math]::Round($textY, 2))`" text-anchor=`"start`" dominant-baseline=`"middle`" transform=`"rotate(-90 $([Math]::Round($textX, 2)) $([Math]::Round($textY, 2)))`" font-family=`"Segoe UI, Arial, sans-serif`" font-size=`"9`" fill=`"$color`">$valueText</text>")
+        }
+
+        $labelX = $groupStartX + ($groupWidth / 2.0)
+        $labelY = $topMargin + $plotHeight + 16
+        $escapedName = [System.Security.SecurityElement]::Escape($benchmark.Name)
+        [void]$builder.AppendLine("  <text x=`"$([Math]::Round($labelX, 2))`" y=`"$([Math]::Round($labelY, 2))`" text-anchor=`"end`" transform=`"rotate(-40 $([Math]::Round($labelX, 2)) $([Math]::Round($labelY, 2)))`" font-family=`"Segoe UI, Arial, sans-serif`" font-size=`"11`" fill=`"#333333`">$escapedName</text>")
+    }
+
+    # Legend drawn last so it sits over the graph (single column, top-right of plot).
+    $legendItemHeight = 18.0
+    $legendBoxPadding = 8.0
+    $legendBoxWidth = 110.0
+    $legendBoxHeight = ($seriesCount * $legendItemHeight) + ($legendBoxPadding * 2)
+    $legendBoxX = $leftMargin + $plotWidth - $legendBoxWidth - 12.0
+    $legendBoxY = $topMargin + 12.0
+    [void]$builder.AppendLine("  <rect x=`"$([Math]::Round($legendBoxX, 2))`" y=`"$([Math]::Round($legendBoxY, 2))`" width=`"$([Math]::Round($legendBoxWidth, 2))`" height=`"$([Math]::Round($legendBoxHeight, 2))`" fill=`"#ffffff`" fill-opacity=`"0.9`" stroke=`"#cccccc`" stroke-width=`"1`"/>")
+
+    for ($seriesIndex = 0; $seriesIndex -lt $seriesCount; $seriesIndex++)
+    {
+        $mapper = $mappers[$seriesIndex]
+        $color = $script:BenchmarkMapperColors[$mapper]
+        $itemY = $legendBoxY + $legendBoxPadding + ($seriesIndex * $legendItemHeight) + 12.0
+        $swatchX = $legendBoxX + $legendBoxPadding
+        [void]$builder.AppendLine("  <rect x=`"$([Math]::Round($swatchX, 2))`" y=`"$([Math]::Round($itemY - 10, 2))`" width=`"12`" height=`"12`" fill=`"$color`"/>")
+        [void]$builder.AppendLine("  <text x=`"$([Math]::Round($swatchX + 18, 2))`" y=`"$([Math]::Round($itemY, 2))`" font-family=`"Segoe UI, Arial, sans-serif`" font-size=`"12`" fill=`"#333333`">$mapper</text>")
+    }
+
+    [void]$builder.AppendLine("</svg>")
+
+    $directory = Split-Path -Parent $OutputPath
+    if (-not [string]::IsNullOrWhiteSpace($directory) -and -not (Test-Path -LiteralPath $directory))
+    {
+        New-Item -ItemType Directory -Path $directory | Out-Null
+    }
+
+    $fullOutputPath = $OutputPath
+    if (-not [System.IO.Path]::IsPathRooted($OutputPath))
+    {
+        $fullOutputPath = Join-Path (Get-Location).Path $OutputPath
+    }
+
+    [System.IO.File]::WriteAllText($fullOutputPath, $builder.ToString())
+}

--- a/Scripts/BenchmarkChartsSvg.ps1
+++ b/Scripts/BenchmarkChartsSvg.ps1
@@ -116,7 +116,11 @@ function New-BenchmarkGroupedBarSvg
         [Parameter(Mandatory = $true)]
         [double]$YAxisTickStep,
 
-        [string]$ValueLabelFormat = "0.##"
+        [string]$ValueLabelFormat = "0.##",
+
+        [string]$ValueLabelSuffix = "",
+
+        [string[]]$MapperNames = $script:BenchmarkMapperOrder
     )
 
     if ($Benchmarks.Count -eq 0)
@@ -129,7 +133,12 @@ function New-BenchmarkGroupedBarSvg
         throw "YAxisTickStep must be greater than zero."
     }
 
-    $mappers = $script:BenchmarkMapperOrder
+    $mappers = @($MapperNames)
+    if ($mappers.Count -lt 1)
+    {
+        throw "MapperNames must contain at least one mapper."
+    }
+
     $groupCount = $Benchmarks.Count
     $seriesCount = $mappers.Count
 
@@ -221,7 +230,7 @@ function New-BenchmarkGroupedBarSvg
             $color = $script:BenchmarkMapperColors[$mapper]
             [void]$builder.AppendLine("  <rect x=`"$([Math]::Round($x, 2))`" y=`"$([Math]::Round($y, 2))`" width=`"$barWidth`" height=`"$([Math]::Round($barHeight, 2))`" fill=`"$color`"/>")
 
-            $valueText = $metric.ToString($ValueLabelFormat, [System.Globalization.CultureInfo]::InvariantCulture)
+            $valueText = $metric.ToString($ValueLabelFormat, [System.Globalization.CultureInfo]::InvariantCulture) + $ValueLabelSuffix
             $textX = $x + ($barWidth / 2.0)
             $textY = $y - 4.0
             # Always place the value vertically above the bar, using the bar color.

--- a/Scripts/BenchmarkChartsSvg.ps1
+++ b/Scripts/BenchmarkChartsSvg.ps1
@@ -8,6 +8,17 @@ $script:BenchmarkMapperColors = @{
     Mappa      = "#76B7B2"
 }
 
+# Same subset used by MAPPA-BENCHMARK-TIME.svg / MAPPA-BENCHMARK-MEMORY.svg.
+$script:BenchmarkChartNames = @(
+    "ArrayToListBenchmark",
+    "DictionaryBenchmark",
+    "ListToArrayBenchmark",
+    "FastListToArrayBenchmark",
+    "IQueryableProjectionBenchmark",
+    "NestedDtoBenchmark",
+    "ListToHashSetBenchmark"
+)
+
 function ConvertTo-InvariantDouble
 {
     param([string]$Text)
@@ -257,4 +268,511 @@ function New-BenchmarkGroupedBarSvg
     }
 
     [System.IO.File]::WriteAllText($fullOutputPath, $builder.ToString())
+}
+
+$script:BenchmarkHistorySeriesColors = @(
+    "#e41a1c", "#377eb8", "#4daf4a", "#984ea3", "#ff7f00",
+    "#a65628", "#f781bf", "#66c2a5", "#fc8d62", "#8da0cb",
+    "#e78ac3", "#a6d854", "#ffd92f", "#e5c494", "#b3b3b3",
+    "#1b9e77", "#d95f02", "#7570b3", "#e7298a", "#66a61e"
+)
+
+function Test-BenchmarkHistoryMarkdownHeaderOrSeparator
+{
+    param([string[]]$Cells)
+
+    if ($Cells.Count -lt 5)
+    {
+        return $true
+    }
+
+    if ($Cells[0] -eq "Timestamp" -or $Cells[3] -eq "Measure" -or $Cells[4] -eq "Value")
+    {
+        return $true
+    }
+
+    foreach ($cell in $Cells)
+    {
+        if ($cell -notmatch '^-+$')
+        {
+            return $false
+        }
+    }
+
+    return $true
+}
+
+function ConvertFrom-BenchmarkHistoryMarkdown
+{
+    param([string]$Markdown)
+
+    $rows = @()
+    if ([string]::IsNullOrWhiteSpace($Markdown))
+    {
+        return $rows
+    }
+
+    foreach ($historyLine in ($Markdown -split "`r?`n"))
+    {
+        if ($historyLine -notmatch '^\|')
+        {
+            continue
+        }
+
+        $cells = @($historyLine.Split("|") | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" })
+        if (Test-BenchmarkHistoryMarkdownHeaderOrSeparator -Cells $cells)
+        {
+            continue
+        }
+
+        if ($cells.Count -lt 5)
+        {
+            continue
+        }
+
+        $value = $null
+        try
+        {
+            $value = [double]::Parse($cells[4], [System.Globalization.CultureInfo]::InvariantCulture)
+        }
+        catch
+        {
+            continue
+        }
+
+        $rows += [pscustomobject]@{
+            Timestamp = $cells[0]
+            Version   = $cells[1]
+            Benchmark = $cells[2]
+            Measure   = $cells[3]
+            Value     = $value
+        }
+    }
+
+    return $rows
+}
+
+function Get-BenchmarkHistoryTrendArrow
+{
+    param(
+        [double]$Current,
+        $Previous
+    )
+
+    if ($null -eq $Previous)
+    {
+        return ""
+    }
+
+    $previousValue = [double]$Previous
+    $delta = [Math]::Round($Current - $previousValue, 3)
+    if ($Current -lt $previousValue)
+    {
+        # Lower is better.
+        return " &#9650;{0}" -f (("{0:0.###}" -f $delta))
+    }
+
+    if ($Current -gt $previousValue)
+    {
+        $deltaText = if ($delta -gt 0) { "+{0:0.###}" -f $delta } else { "{0:0.###}" -f $delta }
+        return " &#9660;$deltaText"
+    }
+
+    return " &#61;"
+}
+
+function Get-BenchmarkHistoryNiceAxisMax
+{
+    param([double]$MaxValue)
+
+    if ($MaxValue -le 0)
+    {
+        return 1.0
+    }
+
+    $exp = [Math]::Floor([Math]::Log10($MaxValue))
+    $pow = [Math]::Pow(10.0, $exp)
+    $mantissa = $MaxValue / $pow
+    foreach ($step in @(1.0, 1.2, 1.5, 2.0, 2.5, 3.0, 4.0, 5.0, 6.0, 8.0, 10.0))
+    {
+        if ($mantissa -le $step)
+        {
+            return $step * $pow
+        }
+    }
+
+    return 10.0 * $pow
+}
+
+function Format-BenchmarkHistoryAxisValue
+{
+    param([double]$Value)
+
+    $abs = [Math]::Abs($Value)
+    if ($abs -ge 1000)
+    {
+        return "{0:0.#}" -f $Value
+    }
+
+    if ($abs -ge 10)
+    {
+        return "{0:0.#}" -f $Value
+    }
+
+    if ($abs -ge 1)
+    {
+        return "{0:0.##}" -f $Value
+    }
+
+    return "{0:0.###}" -f $Value
+}
+
+function Get-BenchmarkHistoryLinearTrend
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Collections.IList]$Values,
+
+        [double]$StartX,
+        [double]$EndX,
+        [double]$AxisMin,
+        [double]$AxisMax,
+        [double]$PanelTopY,
+        [double]$PanelBottomY
+    )
+
+    $n = $Values.Count
+    if ($n -lt 2)
+    {
+        return $null
+    }
+
+    $sumX = 0.0
+    $sumY = 0.0
+    $sumXY = 0.0
+    $sumXX = 0.0
+    for ($index = 0; $index -lt $n; $index++)
+    {
+        $x = [double]$index
+        $y = [double]$Values[$index]
+        $sumX += $x
+        $sumY += $y
+        $sumXY += $x * $y
+        $sumXX += $x * $x
+    }
+
+    $denominator = ($n * $sumXX) - ($sumX * $sumX)
+    $span = $AxisMax - $AxisMin
+    if ($span -le 0)
+    {
+        $span = 1.0
+    }
+
+    if ([Math]::Abs($denominator) -lt 1e-9)
+    {
+        $mean = $sumY / $n
+        $meanY = [Math]::Round($PanelBottomY - (($mean - $AxisMin) * ($PanelBottomY - $PanelTopY) / $span), 2)
+        return [pscustomobject]@{
+            X1 = [Math]::Round($StartX, 2)
+            Y1 = $meanY
+            X2 = [Math]::Round($EndX, 2)
+            Y2 = $meanY
+        }
+    }
+
+    $slope = (($n * $sumXY) - ($sumX * $sumY)) / $denominator
+    $intercept = ($sumY - ($slope * $sumX)) / $n
+    $startValue = $intercept
+    $endValue = $intercept + ($slope * ($n - 1))
+
+    return [pscustomobject]@{
+        X1 = [Math]::Round($StartX, 2)
+        Y1 = [Math]::Round($PanelBottomY - (($startValue - $AxisMin) * ($PanelBottomY - $PanelTopY) / $span), 2)
+        X2 = [Math]::Round($EndX, 2)
+        Y2 = [Math]::Round($PanelBottomY - (($endValue - $AxisMin) * ($PanelBottomY - $PanelTopY) / $span), 2)
+    }
+}
+
+function New-BenchmarkHistorySvg
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$HistoryMarkdownPath,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("TIME_NS", "ALLOC_B")]
+        [string]$Measure,
+
+        [Parameter(Mandatory = $true)]
+        [string]$OutputPath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Title,
+
+        [Parameter(Mandatory = $true)]
+        [string]$YAxisUnitLabel,
+
+        [string[]]$BenchmarkNames = $script:BenchmarkChartNames,
+
+        [double]$YAxisTickStep = 50.0
+    )
+
+    if (-not (Test-Path -LiteralPath $HistoryMarkdownPath))
+    {
+        throw "History markdown file not found: $HistoryMarkdownPath"
+    }
+
+    if ($YAxisTickStep -le 0)
+    {
+        throw "YAxisTickStep must be greater than zero."
+    }
+
+    $markdown = Get-Content -Raw -LiteralPath $HistoryMarkdownPath
+    $allRows = @(ConvertFrom-BenchmarkHistoryMarkdown -Markdown $markdown)
+    $measureRows = @($allRows | Where-Object { $_.Measure -eq $Measure })
+    if ($measureRows.Count -lt 1)
+    {
+        throw "No $Measure history rows found in $HistoryMarkdownPath"
+    }
+
+    $selectedNames = @($BenchmarkNames)
+    if ($selectedNames.Count -lt 1)
+    {
+        throw "BenchmarkNames must contain at least one benchmark."
+    }
+
+    $seriesByBenchmark = @{}
+    foreach ($name in $selectedNames)
+    {
+        $seriesByBenchmark[$name] = @()
+    }
+
+    $versions = @()
+    foreach ($row in $measureRows)
+    {
+        if (-not $seriesByBenchmark.ContainsKey($row.Benchmark))
+        {
+            continue
+        }
+
+        $displayValue = if ($Measure -eq "TIME_NS") {
+            [Math]::Round(([double]$row.Value) / 1000.0, 6)
+        } else {
+            [Math]::Round(([double]$row.Value) / 1024.0, 6)
+        }
+
+        $seriesByBenchmark[$row.Benchmark] += [pscustomobject]@{
+            Version = $row.Version
+            Value   = $displayValue
+        }
+
+        if ($versions -notcontains $row.Version)
+        {
+            $versions += $row.Version
+        }
+    }
+
+    $benchmarkOrder = @($selectedNames | Where-Object { $seriesByBenchmark[$_].Count -gt 0 })
+    if ($benchmarkOrder.Count -lt 1)
+    {
+        throw "No history rows matched the chart benchmark subset for $Measure."
+    }
+
+    $maxValue = 0.0
+    foreach ($name in $benchmarkOrder)
+    {
+        foreach ($point in $seriesByBenchmark[$name])
+        {
+            if ([double]$point.Value -gt $maxValue)
+            {
+                $maxValue = [double]$point.Value
+            }
+        }
+    }
+
+    $tickCount = [int][Math]::Ceiling($maxValue / $YAxisTickStep)
+    if ($tickCount -lt 1)
+    {
+        $tickCount = 1
+    }
+
+    $axisMin = 0.0
+    $axisMax = $tickCount * $YAxisTickStep
+    $span = $axisMax - $axisMin
+
+    $numberOfVersions = $versions.Count
+    $chartLeft = 90.0
+    $chartRight = 690.0
+    $plotTop = 50.0
+    $plotBottom = 375.0
+    $svgWidth = 800
+    $svgHeight = 500
+    $xSpacing = if ($numberOfVersions -le 1) { 0.0 } else { ($chartRight - $chartLeft) / ($numberOfVersions - 1) }
+    $chartEndX = if ($numberOfVersions -le 1) { $chartLeft } else { $chartRight }
+    $labelAllVersions = $numberOfVersions -le 8
+
+    $builder = New-Object System.Text.StringBuilder
+    [void]$builder.AppendLine('<svg version="1.2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="height: 500px; width: 800px;font-family:''Open Sans'', sans-serif;background:white" role="img">')
+    [void]$builder.AppendLine("    <title id=`"title`">$([System.Security.SecurityElement]::Escape($Title))</title>")
+    [void]$builder.AppendLine("    <text x=`"400`" y=`"24`" text-anchor=`"middle`" style=`"font-weight:bold;font-size:16px;fill:black`">$([System.Security.SecurityElement]::Escape($Title))</text>")
+
+    # Axes and guides (coverage-style).
+    [void]$builder.AppendLine("    <g style=`"stroke:#CCCCCC;stroke-width: 2;`"><line x1=`"$chartLeft`" x2=`"$chartLeft`" y1=`"35`" y2=`"$plotBottom`"></line></g>")
+    [void]$builder.AppendLine("    <g style=`"stroke:#CCCCCC;stroke-width: 2;`"><line x1=`"$chartLeft`" x2=`"705`" y1=`"$plotBottom`" y2=`"$plotBottom`"></line></g>")
+    [void]$builder.AppendLine("    <g style=`"stroke:#DDDDDD;stroke-width: 1;stroke-dasharray: 4 4;`" aria-label=`"Horizontal guides`">")
+
+    $yLabels = @()
+    for ($tickIndex = 0; $tickIndex -le $tickCount; $tickIndex++)
+    {
+        $tickValue = $tickIndex * $YAxisTickStep
+        $tickY = [Math]::Round($plotBottom - (($tickValue - $axisMin) * ($plotBottom - $plotTop) / $span), 2)
+        if ($tickIndex -gt 0)
+        {
+            [void]$builder.AppendLine("        <line x1=`"$chartLeft`" x2=`"705`" y1=`"$tickY`" y2=`"$tickY`"></line>")
+        }
+
+        $yLabels += "<text x=`"80`" y=`"$tickY`" dy=`"4`">$(Format-BenchmarkHistoryAxisValue -Value $tickValue)</text>"
+    }
+
+    [void]$builder.AppendLine("    </g>")
+
+    $yLabelMid = [Math]::Round(($plotTop + $plotBottom) / 2.0, 1)
+    [void]$builder.AppendLine("    <g style=`"text-anchor: end;font-size: 13px;`">")
+    [void]$builder.AppendLine("        $($yLabels -join '')")
+    [void]$builder.AppendLine("        <text x=`"50`" y=`"$yLabelMid`" style=`"font-weight: bold;text-transform: uppercase;font-size: 12px;fill: black;`">$YAxisUnitLabel</text>")
+    [void]$builder.AppendLine("    </g>")
+
+    $xLabels = @()
+    for ($versionIndex = 0; $versionIndex -lt $numberOfVersions; $versionIndex++)
+    {
+        $version = $versions[$versionIndex]
+        $isMainRelease = -not $version.Contains("-")
+        $isLast = $versionIndex -eq ($numberOfVersions - 1)
+        if (-not ($labelAllVersions -or $isMainRelease -or $isLast))
+        {
+            continue
+        }
+
+        $x = [Math]::Round($chartLeft + ($versionIndex * $xSpacing), 2)
+        $escapedVersion = [System.Security.SecurityElement]::Escape($version)
+        $xLabels += "<text x=`"$x`" y=`"400`">$escapedVersion</text>"
+    }
+
+    [void]$builder.AppendLine("    <g style=`"text-anchor: middle;font-size: 13px;`">")
+    [void]$builder.AppendLine("            $($xLabels -join '')")
+    [void]$builder.AppendLine("            <text x=`"400`" y=`"440`" style=`"font-weight: bold;text-transform: uppercase;font-size: 12px;fill: black;`">Versions</text>")
+    [void]$builder.AppendLine("    </g>")
+
+    # Series lines.
+    for ($seriesIndex = 0; $seriesIndex -lt $benchmarkOrder.Count; $seriesIndex++)
+    {
+        $benchmarkName = $benchmarkOrder[$seriesIndex]
+        $points = @($seriesByBenchmark[$benchmarkName])
+        $color = $script:BenchmarkHistorySeriesColors[$seriesIndex % $script:BenchmarkHistorySeriesColors.Count]
+        $escapedBenchmark = [System.Security.SecurityElement]::Escape($benchmarkName)
+
+        $valueByVersion = @{}
+        foreach ($point in $points)
+        {
+            $valueByVersion[$point.Version] = [double]$point.Value
+        }
+
+        $polylinePoints = @()
+        $circles = @()
+        $orderedValues = @()
+        for ($versionIndex = 0; $versionIndex -lt $numberOfVersions; $versionIndex++)
+        {
+            $version = $versions[$versionIndex]
+            if (-not $valueByVersion.ContainsKey($version))
+            {
+                continue
+            }
+
+            $value = [double]$valueByVersion[$version]
+            $orderedValues += $value
+            $x = [Math]::Round($chartLeft + ($versionIndex * $xSpacing), 2)
+            $y = [Math]::Round($plotBottom - (($value - $axisMin) * ($plotBottom - $plotTop) / $span), 2)
+            $polylinePoints += "$x,$y"
+
+            $isMainRelease = -not $version.Contains("-")
+            $isLast = $versionIndex -eq ($numberOfVersions - 1)
+            if ($labelAllVersions -or $isMainRelease -or $isLast)
+            {
+                $circles += "<circle cx=`"$x`" cy=`"$y`" r=`"4`"/>"
+            }
+        }
+
+        if ($polylinePoints.Count -lt 1)
+        {
+            continue
+        }
+
+        $trend = Get-BenchmarkHistoryLinearTrend `
+            -Values $orderedValues `
+            -StartX $chartLeft `
+            -EndX $chartEndX `
+            -AxisMin $axisMin `
+            -AxisMax $axisMax `
+            -PanelTopY $plotTop `
+            -PanelBottomY $plotBottom
+
+        $trendLine = ""
+        if ($null -ne $trend)
+        {
+            $trendLine = "<line x1=`"$($trend.X1)`" y1=`"$($trend.Y1)`" x2=`"$($trend.X2)`" y2=`"$($trend.Y2)`" style=`"fill:none;stroke-dasharray:6 4;stroke-width:1.5`" />"
+        }
+
+        $lastValue = [double]$orderedValues[$orderedValues.Count - 1]
+        $previousValue = if ($orderedValues.Count -gt 1) { [double]$orderedValues[$orderedValues.Count - 2] } else { $null }
+        $lastY = [Math]::Round($plotBottom - (($lastValue - $axisMin) * ($plotBottom - $plotTop) / $span), 2)
+        $arrow = Get-BenchmarkHistoryTrendArrow -Current $lastValue -Previous $previousValue
+        $lastLabel = (Format-BenchmarkHistoryAxisValue -Value $lastValue) + $arrow
+
+        [void]$builder.AppendLine("    <g style=`"stroke:$color; fill:$color`" data-setname=`"$escapedBenchmark`">")
+        [void]$builder.AppendLine("        $trendLine")
+        [void]$builder.AppendLine("        <polyline points=`"$($polylinePoints -join ' ')`" style=`"fill:none;stroke-width:2`" />")
+        [void]$builder.AppendLine("        $($circles -join '')")
+        [void]$builder.AppendLine("    </g>")
+        [void]$builder.AppendLine("    <g style=`"font-size: 12px; font-weight: bold;`">")
+        [void]$builder.AppendLine("        <text x=`"710`" y=`"$lastY`" dy=`"4`" style=`"fill:$color;text-anchor:start`">$lastLabel</text>")
+        [void]$builder.AppendLine("    </g>")
+    }
+
+    # Legend (top-right, over the plot).
+    $legendItemHeight = 18.0
+    $legendBoxPadding = 8.0
+    $legendBoxWidth = 210.0
+    $legendBoxHeight = ($benchmarkOrder.Count * $legendItemHeight) + ($legendBoxPadding * 2)
+    $legendBoxX = 470.0
+    $legendBoxY = 40.0
+    [void]$builder.AppendLine("    <g aria-label=`"Legend`">")
+    [void]$builder.AppendLine("        <rect x=`"$legendBoxX`" y=`"$legendBoxY`" width=`"$legendBoxWidth`" height=`"$([Math]::Round($legendBoxHeight, 2))`" fill=`"#ffffff`" fill-opacity=`"0.92`" stroke=`"#cccccc`" stroke-width=`"1`"/>")
+    for ($seriesIndex = 0; $seriesIndex -lt $benchmarkOrder.Count; $seriesIndex++)
+    {
+        $benchmarkName = $benchmarkOrder[$seriesIndex]
+        $color = $script:BenchmarkHistorySeriesColors[$seriesIndex % $script:BenchmarkHistorySeriesColors.Count]
+        $escapedBenchmark = [System.Security.SecurityElement]::Escape($benchmarkName)
+        $itemY = $legendBoxY + $legendBoxPadding + ($seriesIndex * $legendItemHeight) + 12.0
+        $lineY = [Math]::Round($itemY - 4, 2)
+        [void]$builder.AppendLine("        <line x1=`"$([Math]::Round($legendBoxX + 10, 2))`" y1=`"$lineY`" x2=`"$([Math]::Round($legendBoxX + 34, 2))`" y2=`"$lineY`" style=`"stroke:$color;stroke-width:2`" />")
+        [void]$builder.AppendLine("        <circle cx=`"$([Math]::Round($legendBoxX + 22, 2))`" cy=`"$lineY`" r=`"4`" style=`"fill:$color;stroke:$color`" />")
+        [void]$builder.AppendLine("        <text x=`"$([Math]::Round($legendBoxX + 42, 2))`" y=`"$([Math]::Round($itemY, 2))`" style=`"fill:black;font-size:12px`">$escapedBenchmark</text>")
+    }
+
+    [void]$builder.AppendLine("    </g>")
+    [void]$builder.AppendLine("</svg>")
+
+    $directory = Split-Path -Parent $OutputPath
+    if (-not [string]::IsNullOrWhiteSpace($directory) -and -not (Test-Path -LiteralPath $directory))
+    {
+        New-Item -ItemType Directory -Path $directory | Out-Null
+    }
+
+    $fullOutputPath = $OutputPath
+    if (-not [System.IO.Path]::IsPathRooted($OutputPath))
+    {
+        $fullOutputPath = Join-Path (Get-Location).Path $OutputPath
+    }
+
+    [System.IO.File]::WriteAllText($fullOutputPath, $builder.ToString().TrimEnd())
 }

--- a/Scripts/CommentPullRequestCoverage.ps1
+++ b/Scripts/CommentPullRequestCoverage.ps1
@@ -10,12 +10,10 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+. "$PSScriptRoot/BenchmarkChartsSvg.ps1"
 $CommentMarker = "<!-- mappa-pr-coverage -->"
-$BenchmarkTrendNames = @(
-    "SpotifyBenchmark",
-    "FastListToArrayBenchmark",
-    "IQueryableProjectionBenchmark"
-)
+# Same subset as MAPPA-BENCHMARK-TIME/MEMORY.svg and -ChartBenchmarksOnly.
+$BenchmarkTrendNames = $script:BenchmarkChartNames
 
 function Get-TrendSymbol
 {

--- a/Scripts/CommentPullRequestCoverage.ps1
+++ b/Scripts/CommentPullRequestCoverage.ps1
@@ -1,6 +1,9 @@
 param(
     [string]$SummaryXmlPath = "./.mappa-tests-and-coverage/Summary.xml",
     [string]$GistId = "7f4a85bc809328b4821b03125f9190cb",
+    [string]$BenchmarkSummaryPath = "./.mappa-benchmark/Benchmark.Summary.md",
+    [string]$BenchmarkHistoryTablePath = "./.mappa-benchmark/history-table.md",
+    [string]$BenchmarkHistoryFileName = "MAPPA-BENCHMARK-HISTORY.md",
     [double]$WarningDropPercent = 1.0,
     [double]$FailDropPercent = 5.0,
     [switch]$DryRun
@@ -8,6 +11,11 @@ param(
 
 $ErrorActionPreference = "Stop"
 $CommentMarker = "<!-- mappa-pr-coverage -->"
+$BenchmarkTrendNames = @(
+    "SpotifyBenchmark",
+    "FastListToArrayBenchmark",
+    "IQueryableProjectionBenchmark"
+)
 
 function Get-TrendSymbol
 {
@@ -22,6 +30,27 @@ function Get-TrendSymbol
     }
 
     if ($Current -lt $Baseline)
+    {
+        return "▼"
+    }
+
+    return "="
+}
+
+function Get-BenchmarkTrendSymbol
+{
+    param(
+        [double]$Current,
+        [double]$Baseline
+    )
+
+    # Lower time / allocation is better.
+    if ($Current -lt $Baseline)
+    {
+        return "▲"
+    }
+
+    if ($Current -gt $Baseline)
     {
         return "▼"
     }
@@ -113,6 +142,156 @@ function Get-BaselineCoverageFromGist
         Branch = $branch
         Method = $method
     }
+}
+
+function Test-BenchmarkHistoryHeaderOrSeparator
+{
+    param([string[]]$Cells)
+
+    if ($Cells.Count -lt 5)
+    {
+        return $true
+    }
+
+    if ($Cells[0] -eq "Timestamp" -or $Cells[3] -eq "Measure" -or $Cells[4] -eq "Value")
+    {
+        return $true
+    }
+
+    foreach ($cell in $Cells)
+    {
+        if ($cell -notmatch '^-+$')
+        {
+            return $false
+        }
+    }
+
+    return $true
+}
+
+function ConvertTo-BenchmarkHistoryRows
+{
+    param([string]$Markdown)
+
+    $rows = @{}
+    if ([string]::IsNullOrWhiteSpace($Markdown))
+    {
+        return $rows
+    }
+
+    foreach ($historyLine in ($Markdown -split "`r?`n"))
+    {
+        if ($historyLine -notmatch '^\|')
+        {
+            continue
+        }
+
+        $cells = @($historyLine.Split("|") | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" })
+        if (Test-BenchmarkHistoryHeaderOrSeparator -Cells $cells)
+        {
+            continue
+        }
+
+        if ($cells.Count -lt 5)
+        {
+            continue
+        }
+
+        $benchmark = $cells[2]
+        $measure = $cells[3]
+        $valueText = $cells[4]
+        $value = $null
+        try
+        {
+            $value = [double]::Parse($valueText, [System.Globalization.CultureInfo]::InvariantCulture)
+        }
+        catch
+        {
+            continue
+        }
+
+        $key = "$benchmark|$measure"
+        $rows[$key] = [pscustomobject]@{
+            Benchmark = $benchmark
+            Measure = $measure
+            Value = $value
+        }
+    }
+
+    return $rows
+}
+
+function Get-BaselineBenchmarkHistoryFromGist
+{
+    param(
+        [string]$GistId,
+        [string]$HistoryFileName
+    )
+
+    $previousToken = $env:GH_TOKEN
+    $previousEap = $ErrorActionPreference
+    try
+    {
+        if (-not [string]::IsNullOrWhiteSpace($env:GH_PAT))
+        {
+            $env:GH_TOKEN = $env:GH_PAT
+        }
+
+        $ErrorActionPreference = "Continue"
+        $raw = & gh gist view $GistId --raw -f $HistoryFileName 2>&1
+        $exitCode = $LASTEXITCODE
+        if ($exitCode -ne 0)
+        {
+            Write-Host "Benchmark history file '$HistoryFileName' was not found in gist $GistId (exit $exitCode); treating baseline as empty."
+            return @{}
+        }
+
+        $content = if ($null -eq $raw) { "" } elseif ($raw -is [array]) { ($raw | ForEach-Object { "$_" }) -join "`n" } else { [string]$raw }
+        if ([string]::IsNullOrWhiteSpace($content))
+        {
+            Write-Host "Benchmark history file '$HistoryFileName' in gist $GistId is empty; treating baseline as empty."
+            return @{}
+        }
+
+        return ConvertTo-BenchmarkHistoryRows -Markdown $content
+    }
+    finally
+    {
+        $ErrorActionPreference = $previousEap
+        $env:GH_TOKEN = $previousToken
+    }
+}
+
+function Format-BenchmarkMetric
+{
+    param([double]$Value)
+
+    return ("{0:0.###}" -f $Value)
+}
+
+function Format-BenchmarkTrendRow
+{
+    param(
+        [string]$Benchmark,
+        [string]$Measure,
+        $BaselineValue,
+        $CurrentValue
+    )
+
+    $baselineText = if ($null -eq $BaselineValue) { "n/a" } else { Format-BenchmarkMetric -Value ([double]$BaselineValue) }
+    $currentText = if ($null -eq $CurrentValue) { "n/a" } else { Format-BenchmarkMetric -Value ([double]$CurrentValue) }
+
+    if (($null -eq $BaselineValue) -or ($null -eq $CurrentValue))
+    {
+        return "| $Benchmark | $Measure | $baselineText | $currentText | n/a | = |"
+    }
+
+    $baseline = [Math]::Round([double]$BaselineValue, 3)
+    $current = [Math]::Round([double]$CurrentValue, 3)
+    $delta = [Math]::Round($current - $baseline, 3)
+    $deltaText = if ($delta -gt 0) { "+{0:0.###}" -f $delta } elseif ($delta -lt 0) { "{0:0.###}" -f $delta } else { "0" }
+    $trend = Get-BenchmarkTrendSymbol -Current $current -Baseline $baseline
+    return "| $Benchmark | $Measure | $baselineText | $currentText | $deltaText | $trend |"
 }
 
 function Format-CoverageRow
@@ -244,6 +423,54 @@ if ($failMetrics.Count -gt 0)
 if (($warningMetrics.Count -eq 0) -and ($failMetrics.Count -eq 0))
 {
     [void]$bodyBuilder.AppendLine("No coverage metric dropped by more than $WarningDropPercent percentage point(s) versus baseline.")
+}
+
+[void]$bodyBuilder.AppendLine()
+[void]$bodyBuilder.AppendLine("## Benchmarks")
+[void]$bodyBuilder.AppendLine()
+
+if (Test-Path -LiteralPath $BenchmarkSummaryPath)
+{
+    $summaryMarkdown = (Get-Content -Raw -LiteralPath $BenchmarkSummaryPath).Trim()
+    # Drop the leading H1 so the PR section heading remains ## Benchmarks.
+    $summaryMarkdown = $summaryMarkdown -replace '(?s)^#\s+Benchmark summary\s*', ""
+    [void]$bodyBuilder.AppendLine($summaryMarkdown.Trim())
+}
+else
+{
+    [void]$bodyBuilder.AppendLine("Benchmark summary not found. Run Scripts/RunBenchmarks.ps1 before commenting.")
+}
+
+[void]$bodyBuilder.AppendLine()
+[void]$bodyBuilder.AppendLine("## Benchmark trends (Mappa)")
+[void]$bodyBuilder.AppendLine()
+[void]$bodyBuilder.AppendLine("Lower is better. Compared against the latest published Mappa-only rows from [`MAPPA-BENCHMARK-HISTORY.md`](https://gist.github.com/sanelli/$GistId).")
+[void]$bodyBuilder.AppendLine()
+[void]$bodyBuilder.AppendLine("| Benchmark | Measure | Baseline | PR | Δ | Trend |")
+[void]$bodyBuilder.AppendLine("| --------- | ------- | -------- | -- | - | ----- |")
+
+$benchmarkBaselineRows = Get-BaselineBenchmarkHistoryFromGist -GistId $GistId -HistoryFileName $BenchmarkHistoryFileName
+$benchmarkCurrentRows = @{}
+if (Test-Path -LiteralPath $BenchmarkHistoryTablePath)
+{
+    $benchmarkCurrentRows = ConvertTo-BenchmarkHistoryRows -Markdown (Get-Content -Raw -LiteralPath $BenchmarkHistoryTablePath)
+}
+else
+{
+    Write-Host "Benchmark history table not found at $BenchmarkHistoryTablePath; PR benchmark values will be n/a."
+}
+
+foreach ($benchmarkName in $BenchmarkTrendNames)
+{
+    foreach ($measure in @("TIME_NS", "ALLOC_B"))
+    {
+        $key = "$benchmarkName|$measure"
+        $baselineEntry = $benchmarkBaselineRows[$key]
+        $currentEntry = $benchmarkCurrentRows[$key]
+        $baselineValue = if ($null -eq $baselineEntry) { $null } else { $baselineEntry.Value }
+        $currentValue = if ($null -eq $currentEntry) { $null } else { $currentEntry.Value }
+        [void]$bodyBuilder.AppendLine((Format-BenchmarkTrendRow -Benchmark $benchmarkName -Measure $measure -BaselineValue $baselineValue -CurrentValue $currentValue))
+    }
 }
 
 $commentBody = $bodyBuilder.ToString().TrimEnd() + "`n"

--- a/Scripts/RebuildUponVersionChange.ps1
+++ b/Scripts/RebuildUponVersionChange.ps1
@@ -5,7 +5,7 @@ foreach ($project in $(
     "Mappa.Dependency.Bson", "Mappa.Dependency.Bson.DependencyInjection", "Mappa.Dependency.Bson.Tests", "Mappa.Dependency.Bson.DependencyInjection.Tests",
     "Mappa.Samples", "Mappa.Samples.Tests", "Mappa.Samples.Aot", "Mappa.Benchmark"))
 {
-    dotnet build $project
+    dotnet build $project -c Release
     if (-not $?)
     {
         exit 1

--- a/Scripts/RunBenchmarks.ps1
+++ b/Scripts/RunBenchmarks.ps1
@@ -351,11 +351,15 @@ try
     $historyPath = Join-Path $MappaBenchmarkPath "history-table.md"
     $timeSvgPath = Join-Path $MappaBenchmarkPath "MAPPA-BENCHMARK-TIME.svg"
     $memorySvgPath = Join-Path $MappaBenchmarkPath "MAPPA-BENCHMARK-MEMORY.svg"
+    $timePercentSvgPath = Join-Path $MappaBenchmarkPath "MAPPA-BENCHMARK-TIME-PERCENTAGES.svg"
+    $memoryPercentSvgPath = Join-Path $MappaBenchmarkPath "MAPPA-BENCHMARK-MEMORY-PERCENTAGES.svg"
 
     Write-BenchmarkSummaryMarkdown -Benchmarks $benchmarks -OutputPath $summaryPath
     Write-BenchmarkHistoryTable -Benchmarks $benchmarks -MappaVersion $currentMappaVersion -OutputPath $historyPath
 
     $chartBenchmarks = [System.Collections.Generic.List[object]]::new()
+    $percentageChartBenchmarks = [System.Collections.Generic.List[object]]::new()
+    $percentageMappers = @("Automapper", "Mapster", "Mapperly")
     foreach ($name in $SvgBenchmarkNames)
     {
         $match = @($benchmarks | Where-Object { $_.Name -eq $name } | Select-Object -First 1)
@@ -385,6 +389,49 @@ try
                 Name = $source.Name
                 Mappers = $convertedMappers
             }) | Out-Null
+
+        $mappaEntry = $source.Mappers["Mappa"]
+        $percentageMappersMap = @{}
+        if ($null -ne $mappaEntry)
+        {
+            foreach ($mapper in $percentageMappers)
+            {
+                $entry = $source.Mappers[$mapper]
+                if ($null -eq $entry)
+                {
+                    continue
+                }
+
+                $timePercent = if ($mappaEntry.MeanNs -eq 0) {
+                    $null
+                } else {
+                    [Math]::Round(($entry.MeanNs / $mappaEntry.MeanNs) * 100.0, 3)
+                }
+                $allocPercent = if ($mappaEntry.AllocatedBytes -eq 0) {
+                    $null
+                } else {
+                    [Math]::Round(($entry.AllocatedBytes / $mappaEntry.AllocatedBytes) * 100.0, 3)
+                }
+
+                if (($null -eq $timePercent) -and ($null -eq $allocPercent))
+                {
+                    continue
+                }
+
+                $percentageMappersMap[$mapper] = [pscustomobject]@{
+                    TimePercent = $timePercent
+                    AllocPercent = $allocPercent
+                }
+            }
+        }
+
+        if ($percentageMappersMap.Count -gt 0)
+        {
+            $percentageChartBenchmarks.Add([pscustomobject]@{
+                    Name = $source.Name
+                    Mappers = $percentageMappersMap
+                }) | Out-Null
+        }
     }
 
     if ($chartBenchmarks.Count -eq 0)
@@ -410,11 +457,81 @@ try
         -YAxisTickStep 50 `
         -ValueLabelFormat "0.#"
 
+    if ($percentageChartBenchmarks.Count -gt 0)
+    {
+        # Filter out mappers with null for the selected metric so bars are skipped.
+        $timePercentBenchmarks = [System.Collections.Generic.List[object]]::new()
+        $allocPercentBenchmarks = [System.Collections.Generic.List[object]]::new()
+        foreach ($benchmark in $percentageChartBenchmarks)
+        {
+            $timeMappers = @{}
+            $allocMappers = @{}
+            foreach ($mapper in $percentageMappers)
+            {
+                $entry = $benchmark.Mappers[$mapper]
+                if ($null -eq $entry)
+                {
+                    continue
+                }
+
+                if ($null -ne $entry.TimePercent)
+                {
+                    $timeMappers[$mapper] = [pscustomobject]@{ TimePercent = [double]$entry.TimePercent }
+                }
+
+                if ($null -ne $entry.AllocPercent)
+                {
+                    $allocMappers[$mapper] = [pscustomobject]@{ AllocPercent = [double]$entry.AllocPercent }
+                }
+            }
+
+            if ($timeMappers.Count -gt 0)
+            {
+                $timePercentBenchmarks.Add([pscustomobject]@{ Name = $benchmark.Name; Mappers = $timeMappers }) | Out-Null
+            }
+
+            if ($allocMappers.Count -gt 0)
+            {
+                $allocPercentBenchmarks.Add([pscustomobject]@{ Name = $benchmark.Name; Mappers = $allocMappers }) | Out-Null
+            }
+        }
+
+        if ($timePercentBenchmarks.Count -gt 0)
+        {
+            New-BenchmarkGroupedBarSvg `
+                -Benchmarks $timePercentBenchmarks.ToArray() `
+                -MetricProperty "TimePercent" `
+                -YAxisLabel "Competitor / Mappa (%)" `
+                -Title "Benchmark mean time vs Mappa" `
+                -OutputPath $timePercentSvgPath `
+                -YAxisTickStep 100 `
+                -ValueLabelFormat "0.#" `
+                -ValueLabelSuffix "%" `
+                -MapperNames $percentageMappers
+        }
+
+        if ($allocPercentBenchmarks.Count -gt 0)
+        {
+            New-BenchmarkGroupedBarSvg `
+                -Benchmarks $allocPercentBenchmarks.ToArray() `
+                -MetricProperty "AllocPercent" `
+                -YAxisLabel "Competitor / Mappa (%)" `
+                -Title "Benchmark allocated memory vs Mappa" `
+                -OutputPath $memoryPercentSvgPath `
+                -YAxisTickStep 100 `
+                -ValueLabelFormat "0.#" `
+                -ValueLabelSuffix "%" `
+                -MapperNames $percentageMappers
+        }
+    }
+
     Write-Host "Wrote:"
     Write-Host " - $summaryPath"
     Write-Host " - $historyPath"
     Write-Host " - $timeSvgPath"
     Write-Host " - $memorySvgPath"
+    Write-Host " - $timePercentSvgPath"
+    Write-Host " - $memoryPercentSvgPath"
 }
 finally
 {

--- a/Scripts/RunBenchmarks.ps1
+++ b/Scripts/RunBenchmarks.ps1
@@ -164,6 +164,29 @@ function Format-Metric
     return ("{0:0.###}" -f $Value)
 }
 
+function Format-BenchmarkRatio
+{
+    param(
+        $NumeratorEntry,
+        $DenominatorEntry,
+        [string]$MetricProperty
+    )
+
+    if (($null -eq $NumeratorEntry) -or ($null -eq $DenominatorEntry))
+    {
+        return "n/a"
+    }
+
+    $numerator = [double]$NumeratorEntry.$MetricProperty
+    $denominator = [double]$DenominatorEntry.$MetricProperty
+    if ($denominator -eq 0)
+    {
+        return "n/a"
+    }
+
+    return ("{0:0.#}%" -f (($numerator / $denominator) * 100.0))
+}
+
 function Write-BenchmarkSummaryMarkdown
 {
     param(
@@ -172,10 +195,12 @@ function Write-BenchmarkSummaryMarkdown
         [string]$OutputPath
     )
 
+    $ratioCompetitors = @("Automapper", "Mapperly", "Mapster")
+
     $builder = New-Object System.Text.StringBuilder
     [void]$builder.AppendLine("# Benchmark summary")
     [void]$builder.AppendLine()
-    [void]$builder.AppendLine("AutoMapper is the ratio baseline. Values are mean time in nanoseconds and allocated bytes.")
+    [void]$builder.AppendLine("AutoMapper is the BenchmarkDotNet ratio baseline. Absolute values are mean time in nanoseconds and allocated bytes. Ratio columns are competitor / Mappa as a percentage (n/a when either side is missing or Mappa is zero).")
     [void]$builder.AppendLine()
     [void]$builder.Append("| Benchmark |")
     foreach ($mapper in $MapperOrder)
@@ -183,9 +208,19 @@ function Write-BenchmarkSummaryMarkdown
         [void]$builder.Append(" $mapper Mean (ns) | $mapper Allocated (B) |")
     }
 
+    foreach ($competitor in $ratioCompetitors)
+    {
+        [void]$builder.Append(" $competitor/Mappa Time | $competitor/Mappa Alloc |")
+    }
+
     [void]$builder.AppendLine()
     [void]$builder.Append("| --- |")
     foreach ($mapper in $MapperOrder)
+    {
+        [void]$builder.Append(" --- | --- |")
+    }
+
+    foreach ($competitor in $ratioCompetitors)
     {
         [void]$builder.Append(" --- | --- |")
     }
@@ -206,6 +241,15 @@ function Write-BenchmarkSummaryMarkdown
             {
                 [void]$builder.Append(" $(Format-Metric -Value $entry.MeanNs) | $(Format-Metric -Value $entry.AllocatedBytes) |")
             }
+        }
+
+        $mappaEntry = $benchmark.Mappers["Mappa"]
+        foreach ($competitor in $ratioCompetitors)
+        {
+            $competitorEntry = $benchmark.Mappers[$competitor]
+            $timeRatio = Format-BenchmarkRatio -NumeratorEntry $competitorEntry -DenominatorEntry $mappaEntry -MetricProperty "MeanNs"
+            $allocRatio = Format-BenchmarkRatio -NumeratorEntry $competitorEntry -DenominatorEntry $mappaEntry -MetricProperty "AllocatedBytes"
+            [void]$builder.Append(" $timeRatio | $allocRatio |")
         }
 
         [void]$builder.AppendLine()

--- a/Scripts/RunBenchmarks.ps1
+++ b/Scripts/RunBenchmarks.ps1
@@ -17,6 +17,7 @@ $MapperOrder = @("Automapper", "Mapster", "Mapperly", "Mappa")
 $SvgBenchmarkNames = @(
     "ArrayToListBenchmark",
     "DictionaryBenchmark",
+    "ListToArrayBenchmark",
     "FastListToArrayBenchmark",
     "IQueryableProjectionBenchmark",
     "NestedDtoBenchmark",
@@ -306,7 +307,7 @@ try
             }
 
             $convertedMappers[$mapper] = [pscustomobject]@{
-                MeanMs = [Math]::Round($entry.MeanNs / 1000000.0, 6)
+                MeanUs = [Math]::Round($entry.MeanNs / 1000.0, 6)
                 AllocatedKb = [Math]::Round($entry.AllocatedBytes / 1024.0, 6)
             }
         }
@@ -324,11 +325,11 @@ try
 
     New-BenchmarkGroupedBarSvg `
         -Benchmarks $chartBenchmarks.ToArray() `
-        -MetricProperty "MeanMs" `
-        -YAxisLabel "Mean time (ms)" `
+        -MetricProperty "MeanUs" `
+        -YAxisLabel "Mean time (us)" `
         -Title "Benchmark mean time" `
         -OutputPath $timeSvgPath `
-        -YAxisTickStep 0.05 `
+        -YAxisTickStep 50 `
         -ValueLabelFormat "0.###"
 
     New-BenchmarkGroupedBarSvg `

--- a/Scripts/RunBenchmarks.ps1
+++ b/Scripts/RunBenchmarks.ps1
@@ -1,6 +1,8 @@
 param(
     # Quoted when passed to dotnet so PowerShell does not glob-expand "*".
     [string]$Filter = "*",
+    # Run only the benchmarks used by MAPPA-BENCHMARK-TIME/MEMORY.svg charts.
+    [switch]$ChartBenchmarksOnly,
     [switch]$SkipRun,
     [switch]$ListAvailable
 )
@@ -15,6 +17,35 @@ $ArtifactsPath = "BenchmarkDotNet.Artifacts"
 $ResultsPath = Join-Path $ArtifactsPath "results"
 $MapperOrder = @("Automapper", "Mapster", "Mapperly", "Mappa")
 $SvgBenchmarkNames = $script:BenchmarkChartNames
+
+function Get-BenchmarkDotNetFilterArgs
+{
+    if ($ChartBenchmarksOnly)
+    {
+        # BenchmarkDotNet accepts multiple patterns after a single --filter:
+        #   --filter '*.ClassA.*' '*.ClassB.*'
+        # Repeating --filter is rejected ("Option 'filter' is defined multiple times").
+        $filterArgs = @("--filter")
+        foreach ($name in $script:BenchmarkChartNames)
+        {
+            $filterArgs += "*$name*"
+        }
+
+        return ,$filterArgs
+    }
+
+    return @("--filter", $Filter)
+}
+
+function Get-BenchmarkFilterDescription
+{
+    if ($ChartBenchmarksOnly)
+    {
+        return ("ChartBenchmarksOnly: " + ($script:BenchmarkChartNames -join ", "))
+    }
+
+    return $Filter
+}
 
 function Get-BenchmarkNameFromCsvPath
 {
@@ -218,8 +249,9 @@ try
     if ($ListAvailable)
     {
         Write-Host "Available benchmarks:"
-        # Quote the filter: an unquoted "*" is expanded by PowerShell.
-        dotnet run -c Release --project ./Mappa.Benchmark/ -- --list flat --filter "$Filter"
+        $filterArgs = Get-BenchmarkDotNetFilterArgs
+        # Quote each filter value: an unquoted "*" is expanded by PowerShell.
+        dotnet run -c Release --project ./Mappa.Benchmark/ -- --list flat @filterArgs
         if (-not $?)
         {
             $exitCode = 1
@@ -245,10 +277,11 @@ try
 
     if (-not $SkipRun)
     {
-        Write-Host "Running benchmarks (filter: $Filter)..."
-        # Quote the filter: an unquoted "*" is expanded by PowerShell to every
-        # file/folder in the repo root, which BDN then treats as invalid filters.
-        dotnet run -c Release --project ./Mappa.Benchmark/ -- -j Short -e "Csv" "Html" "GitHub" --filter "$Filter"
+        $filterDescription = Get-BenchmarkFilterDescription
+        $filterArgs = Get-BenchmarkDotNetFilterArgs
+        Write-Host "Running benchmarks (filter: $filterDescription)..."
+        # Pass filters as separate args so PowerShell does not glob-expand "*".
+        dotnet run -c Release --project ./Mappa.Benchmark/ -- -j Short -e "Csv" "Html" "GitHub" @filterArgs
         if (-not $?)
         {
             Write-Host "Benchmark run failed." -ForegroundColor Red

--- a/Scripts/RunBenchmarks.ps1
+++ b/Scripts/RunBenchmarks.ps1
@@ -14,15 +14,7 @@ $MappaBenchmarkPath = ".mappa-benchmark"
 $ArtifactsPath = "BenchmarkDotNet.Artifacts"
 $ResultsPath = Join-Path $ArtifactsPath "results"
 $MapperOrder = @("Automapper", "Mapster", "Mapperly", "Mappa")
-$SvgBenchmarkNames = @(
-    "ArrayToListBenchmark",
-    "DictionaryBenchmark",
-    "ListToArrayBenchmark",
-    "FastListToArrayBenchmark",
-    "IQueryableProjectionBenchmark",
-    "NestedDtoBenchmark",
-    "ListToHashSetBenchmark"
-)
+$SvgBenchmarkNames = $script:BenchmarkChartNames
 
 function Get-BenchmarkNameFromCsvPath
 {
@@ -280,8 +272,8 @@ try
 
     $summaryPath = Join-Path $MappaBenchmarkPath "Benchmark.Summary.md"
     $historyPath = Join-Path $MappaBenchmarkPath "history-table.md"
-    $timeSvgPath = Join-Path $MappaBenchmarkPath "Benchmark.Time.svg"
-    $memorySvgPath = Join-Path $MappaBenchmarkPath "Benchmark.Memory.svg"
+    $timeSvgPath = Join-Path $MappaBenchmarkPath "MAPPA-BENCHMARK-TIME.svg"
+    $memorySvgPath = Join-Path $MappaBenchmarkPath "MAPPA-BENCHMARK-MEMORY.svg"
 
     Write-BenchmarkSummaryMarkdown -Benchmarks $benchmarks -OutputPath $summaryPath
     Write-BenchmarkHistoryTable -Benchmarks $benchmarks -MappaVersion $currentMappaVersion -OutputPath $historyPath

--- a/Scripts/RunBenchmarks.ps1
+++ b/Scripts/RunBenchmarks.ps1
@@ -1,10 +1,354 @@
-if (Test-Path "BenchmarkDotNet.Artifacts")
+param(
+    # Quoted when passed to dotnet so PowerShell does not glob-expand "*".
+    [string]$Filter = "*",
+    [switch]$SkipRun,
+    [switch]$ListAvailable
+)
+
+$ErrorActionPreference = "Stop"
+
+. "$PSScriptRoot/BenchmarkChartsSvg.ps1"
+
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$MappaBenchmarkPath = ".mappa-benchmark"
+$ArtifactsPath = "BenchmarkDotNet.Artifacts"
+$ResultsPath = Join-Path $ArtifactsPath "results"
+$MapperOrder = @("Automapper", "Mapster", "Mapperly", "Mappa")
+$SvgBenchmarkNames = @(
+    "ArrayToListBenchmark",
+    "DictionaryBenchmark",
+    "FastListToArrayBenchmark",
+    "IQueryableProjectionBenchmark",
+    "NestedDtoBenchmark",
+    "ListToHashSetBenchmark"
+)
+
+function Get-BenchmarkNameFromCsvPath
 {
-    Remove-Item -Recurse -Force "BenchmarkDotNet.Artifacts" > $null
+    param([string]$CsvPath)
+
+    $fileName = [System.IO.Path]::GetFileNameWithoutExtension($CsvPath)
+    if ($fileName -match '^(?<type>.+)-report$')
+    {
+        $typeName = $Matches["type"]
+        $parts = $typeName.Split(".")
+        return $parts[$parts.Length - 1]
+    }
+
+    return $fileName
 }
 
-dotnet run -c Release --project ./Mappa.Benchmark/ -- -j Short -e "Html" "GitHub" "Csv" --filter "*SpotifyBenchmark*"
-dotnet run -c Release --project ./Mappa.Benchmark/ -- -j Short -e "Html" "GitHub" "Csv" --filter "*EnumToIntBenchmark*"
-dotnet run -c Release --project ./Mappa.Benchmark/ -- -j Short -e "Html" "GitHub" "Csv" --filter "*EnumToStringBenchmark*"
-dotnet run -c Release --project ./Mappa.Benchmark/ -- -j Short -e "Html" "GitHub" "Csv" --filter "*IntToEnumBenchmark*"
-dotnet run -c Release --project ./Mappa.Benchmark/ -- -j Short -e "Html" "GitHub" "Csv" --filter "*StringToEnumBenchmark*"
+function Get-CsvPropertyValue
+{
+    param(
+        $Row,
+        [string[]]$CandidateNames
+    )
+
+    foreach ($name in $CandidateNames)
+    {
+        $property = $Row.PSObject.Properties[$name]
+        if ($null -ne $property -and -not [string]::IsNullOrWhiteSpace([string]$property.Value))
+        {
+            return [string]$property.Value
+        }
+    }
+
+    return $null
+}
+
+function Read-BenchmarkResults
+{
+    param([string]$CsvResultsDirectory)
+
+    if (-not (Test-Path -LiteralPath $CsvResultsDirectory))
+    {
+        throw "Benchmark CSV results directory not found: $CsvResultsDirectory"
+    }
+
+    $csvFiles = @(Get-ChildItem -LiteralPath $CsvResultsDirectory -Filter "*-report.csv" -File)
+    if ($csvFiles.Count -eq 0)
+    {
+        throw "No *-report.csv files found under $CsvResultsDirectory."
+    }
+
+    $benchmarksByName = [ordered]@{}
+
+    foreach ($csvFile in $csvFiles)
+    {
+        $benchmarkName = Get-BenchmarkNameFromCsvPath -CsvPath $csvFile.FullName
+        $rows = Import-Csv -LiteralPath $csvFile.FullName
+        foreach ($row in $rows)
+        {
+            $method = Get-CsvPropertyValue -Row $row -CandidateNames @("Method", "method")
+            if ([string]::IsNullOrWhiteSpace($method))
+            {
+                continue
+            }
+
+            $mapperName = $null
+            foreach ($candidate in $MapperOrder)
+            {
+                if ($method -eq $candidate -or $method.EndsWith("." + $candidate) -or $method.EndsWith(" " + $candidate))
+                {
+                    $mapperName = $candidate
+                    break
+                }
+            }
+
+            if ($null -eq $mapperName)
+            {
+                continue
+            }
+
+            $meanText = Get-CsvPropertyValue -Row $row -CandidateNames @("Mean", "mean")
+            $allocatedText = Get-CsvPropertyValue -Row $row -CandidateNames @("Allocated", "allocated")
+            if ([string]::IsNullOrWhiteSpace($meanText) -or $meanText -eq "NA" -or $meanText -eq "?")
+            {
+                continue
+            }
+
+            $meanNs = ConvertTo-Nanoseconds -Text $meanText
+            $allocatedBytes = ConvertTo-AllocatedBytes -Text $allocatedText
+            if ($null -eq $meanNs)
+            {
+                continue
+            }
+
+            if (-not $benchmarksByName.Contains($benchmarkName))
+            {
+                $benchmarksByName[$benchmarkName] = [pscustomobject]@{
+                    Name = $benchmarkName
+                    Mappers = @{}
+                }
+            }
+
+            $benchmarksByName[$benchmarkName].Mappers[$mapperName] = [pscustomobject]@{
+                MeanNs = [Math]::Round($meanNs, 3)
+                AllocatedBytes = if ($null -eq $allocatedBytes) { 0.0 } else { [Math]::Round($allocatedBytes, 3) }
+            }
+        }
+    }
+
+    return @($benchmarksByName.Values)
+}
+
+function Format-Metric
+{
+    param([double]$Value)
+
+    return ("{0:0.###}" -f $Value)
+}
+
+function Write-BenchmarkSummaryMarkdown
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [object[]]$Benchmarks,
+        [string]$OutputPath
+    )
+
+    $builder = New-Object System.Text.StringBuilder
+    [void]$builder.AppendLine("# Benchmark summary")
+    [void]$builder.AppendLine()
+    [void]$builder.AppendLine("AutoMapper is the ratio baseline. Values are mean time in nanoseconds and allocated bytes.")
+    [void]$builder.AppendLine()
+    [void]$builder.Append("| Benchmark |")
+    foreach ($mapper in $MapperOrder)
+    {
+        [void]$builder.Append(" $mapper Mean (ns) | $mapper Allocated (B) |")
+    }
+
+    [void]$builder.AppendLine()
+    [void]$builder.Append("| --- |")
+    foreach ($mapper in $MapperOrder)
+    {
+        [void]$builder.Append(" --- | --- |")
+    }
+
+    [void]$builder.AppendLine()
+
+    foreach ($benchmark in ($Benchmarks | Sort-Object Name))
+    {
+        [void]$builder.Append("| $($benchmark.Name) |")
+        foreach ($mapper in $MapperOrder)
+        {
+            $entry = $benchmark.Mappers[$mapper]
+            if ($null -eq $entry)
+            {
+                [void]$builder.Append(" n/a | n/a |")
+            }
+            else
+            {
+                [void]$builder.Append(" $(Format-Metric -Value $entry.MeanNs) | $(Format-Metric -Value $entry.AllocatedBytes) |")
+            }
+        }
+
+        [void]$builder.AppendLine()
+    }
+
+    [System.IO.File]::WriteAllText($OutputPath, $builder.ToString().TrimEnd() + "`n")
+}
+
+function Write-BenchmarkHistoryTable
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [object[]]$Benchmarks,
+        [string]$MappaVersion,
+        [string]$OutputPath
+    )
+
+    $timestamp = Get-Date -Format "yyyy/MM/dd HH:mm:ss"
+    $builder = New-Object System.Text.StringBuilder
+
+    # Include ALL benchmarks (Mappa time + memory), not a subset.
+    foreach ($benchmark in ($Benchmarks | Sort-Object Name))
+    {
+        $mappa = $benchmark.Mappers["Mappa"]
+        if ($null -eq $mappa)
+        {
+            continue
+        }
+
+        [void]$builder.AppendLine("| $timestamp | $MappaVersion | $($benchmark.Name) | TIME_NS | $(Format-Metric -Value $mappa.MeanNs) |")
+        [void]$builder.AppendLine("| $timestamp | $MappaVersion | $($benchmark.Name) | ALLOC_B | $(Format-Metric -Value $mappa.AllocatedBytes) |")
+    }
+
+    [System.IO.File]::WriteAllText($OutputPath, $builder.ToString().TrimEnd() + "`n")
+}
+
+Push-Location $RepoRoot
+$exitCode = 0
+try
+{
+    if ($ListAvailable)
+    {
+        Write-Host "Available benchmarks:"
+        # Quote the filter: an unquoted "*" is expanded by PowerShell.
+        dotnet run -c Release --project ./Mappa.Benchmark/ -- --list flat --filter "$Filter"
+        if (-not $?)
+        {
+            $exitCode = 1
+        }
+
+        return
+    }
+
+    if (-not $SkipRun)
+    {
+        if (Test-Path -LiteralPath $ArtifactsPath)
+        {
+            Remove-Item -Recurse -Force -LiteralPath $ArtifactsPath
+        }
+    }
+
+    if (Test-Path -LiteralPath $MappaBenchmarkPath)
+    {
+        Remove-Item -Recurse -Force -LiteralPath $MappaBenchmarkPath
+    }
+
+    New-Item -ItemType Directory -Path $MappaBenchmarkPath | Out-Null
+
+    if (-not $SkipRun)
+    {
+        Write-Host "Running benchmarks (filter: $Filter)..."
+        # Quote the filter: an unquoted "*" is expanded by PowerShell to every
+        # file/folder in the repo root, which BDN then treats as invalid filters.
+        dotnet run -c Release --project ./Mappa.Benchmark/ -- -j Short -e "Csv" "Html" "GitHub" --filter "$Filter"
+        if (-not $?)
+        {
+            Write-Host "Benchmark run failed." -ForegroundColor Red
+            $exitCode = 1
+            return
+        }
+    }
+    elseif (-not (Test-Path -LiteralPath $ResultsPath))
+    {
+        throw "SkipRun was set but results were not found at $ResultsPath."
+    }
+
+    $benchmarks = @(Read-BenchmarkResults -CsvResultsDirectory $ResultsPath)
+    if ($benchmarks.Count -eq 0)
+    {
+        throw "No benchmark mapper rows were parsed from CSV results."
+    }
+
+    [xml]$currentVersionFile = Get-Content -LiteralPath ./MappaVersion.targets
+    $currentMappaVersion = $currentVersionFile.Project.PropertyGroup.MappaVersion
+
+    $summaryPath = Join-Path $MappaBenchmarkPath "Benchmark.Summary.md"
+    $historyPath = Join-Path $MappaBenchmarkPath "history-table.md"
+    $timeSvgPath = Join-Path $MappaBenchmarkPath "Benchmark.Time.svg"
+    $memorySvgPath = Join-Path $MappaBenchmarkPath "Benchmark.Memory.svg"
+
+    Write-BenchmarkSummaryMarkdown -Benchmarks $benchmarks -OutputPath $summaryPath
+    Write-BenchmarkHistoryTable -Benchmarks $benchmarks -MappaVersion $currentMappaVersion -OutputPath $historyPath
+
+    $chartBenchmarks = [System.Collections.Generic.List[object]]::new()
+    foreach ($name in $SvgBenchmarkNames)
+    {
+        $match = @($benchmarks | Where-Object { $_.Name -eq $name } | Select-Object -First 1)
+        if ($match.Count -eq 0 -or $null -eq $match[0])
+        {
+            Write-Host "Skipping SVG series '$name' (no CSV results)." -ForegroundColor Yellow
+            continue
+        }
+
+        $source = $match[0]
+        $convertedMappers = @{}
+        foreach ($mapper in $MapperOrder)
+        {
+            $entry = $source.Mappers[$mapper]
+            if ($null -eq $entry)
+            {
+                continue
+            }
+
+            $convertedMappers[$mapper] = [pscustomobject]@{
+                MeanMs = [Math]::Round($entry.MeanNs / 1000000.0, 6)
+                AllocatedKb = [Math]::Round($entry.AllocatedBytes / 1024.0, 6)
+            }
+        }
+
+        $chartBenchmarks.Add([pscustomobject]@{
+                Name = $source.Name
+                Mappers = $convertedMappers
+            }) | Out-Null
+    }
+
+    if ($chartBenchmarks.Count -eq 0)
+    {
+        throw "No SVG chart benchmarks were found in CSV results."
+    }
+
+    New-BenchmarkGroupedBarSvg `
+        -Benchmarks $chartBenchmarks.ToArray() `
+        -MetricProperty "MeanMs" `
+        -YAxisLabel "Mean time (ms)" `
+        -Title "Benchmark mean time" `
+        -OutputPath $timeSvgPath `
+        -YAxisTickStep 0.05 `
+        -ValueLabelFormat "0.###"
+
+    New-BenchmarkGroupedBarSvg `
+        -Benchmarks $chartBenchmarks.ToArray() `
+        -MetricProperty "AllocatedKb" `
+        -YAxisLabel "Allocated (KB)" `
+        -Title "Benchmark allocated memory" `
+        -OutputPath $memorySvgPath `
+        -YAxisTickStep 50 `
+        -ValueLabelFormat "0.#"
+
+    Write-Host "Wrote:"
+    Write-Host " - $summaryPath"
+    Write-Host " - $historyPath"
+    Write-Host " - $timeSvgPath"
+    Write-Host " - $memorySvgPath"
+}
+finally
+{
+    Pop-Location
+}
+
+exit $exitCode

--- a/Scripts/UpdateBenchmarkGists.ps1
+++ b/Scripts/UpdateBenchmarkGists.ps1
@@ -1,0 +1,124 @@
+param(
+    [string]$GistId = "7f4a85bc809328b4821b03125f9190cb",
+    [string]$HistoryFileName = "MAPPA-BENCHMARK-HISTORY.md",
+    [string]$MappaBenchmarkPath = ".mappa-benchmark",
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = "Stop"
+
+$HistoryTableHeader = @"
+| Timestamp | Version | Benchmark | Measure | Value |
+| --------- | ------- | ---- | ---------- | ------- |
+"@
+
+function Get-BenchmarkHistoryFromGist
+{
+    param(
+        [string]$GistId,
+        [string]$HistoryFileName
+    )
+
+    # Prefer GH_PAT for gist API access; GITHUB_TOKEN cannot read private/org-restricted gists.
+    $previousToken = $env:GH_TOKEN
+    $previousEap = $ErrorActionPreference
+    try
+    {
+        if (-not [string]::IsNullOrWhiteSpace($env:GH_PAT))
+        {
+            $env:GH_TOKEN = $env:GH_PAT
+        }
+
+        $ErrorActionPreference = "Continue"
+        $raw = & gh gist view $GistId --raw -f $HistoryFileName 2>&1
+        $exitCode = $LASTEXITCODE
+        if ($exitCode -ne 0)
+        {
+            # File missing from gist (first run) — treat as empty baseline.
+            Write-Host "Benchmark history file '$HistoryFileName' was not found in gist $GistId (exit $exitCode); seeding empty history."
+            return [pscustomobject]@{
+                Exists = $false
+                Content = $null
+            }
+        }
+
+        $content = if ($null -eq $raw) { "" } elseif ($raw -is [array]) { ($raw | ForEach-Object { "$_" }) -join "`n" } else { [string]$raw }
+        return [pscustomobject]@{
+            Exists = $true
+            Content = $content
+        }
+    }
+    finally
+    {
+        $ErrorActionPreference = $previousEap
+        $env:GH_TOKEN = $previousToken
+    }
+}
+
+$historyRowsPath = Join-Path $MappaBenchmarkPath "history-table.md"
+if (-not (Test-Path -LiteralPath $historyRowsPath))
+{
+    throw "Benchmark history rows not found: $historyRowsPath. Run Scripts/RunBenchmarks.ps1 first."
+}
+
+$newRows = (Get-Content -Raw -LiteralPath $historyRowsPath).Trim()
+if ([string]::IsNullOrWhiteSpace($newRows))
+{
+    throw "Benchmark history rows file is empty: $historyRowsPath."
+}
+
+$gistHistory = Get-BenchmarkHistoryFromGist -GistId $GistId -HistoryFileName $HistoryFileName
+$fileExists = [bool]$gistHistory.Exists
+$existingContent = $gistHistory.Content
+
+if ([string]::IsNullOrWhiteSpace($existingContent))
+{
+    $fullHistory = $HistoryTableHeader.TrimEnd() + "`n" + $newRows + "`n"
+}
+else
+{
+    $fullHistory = $existingContent.TrimEnd() + "`n" + $newRows + "`n"
+}
+
+$fullHistoryPath = Join-Path $MappaBenchmarkPath "full-history-table.md"
+[System.IO.File]::WriteAllText($fullHistoryPath, $fullHistory)
+
+Write-Host "Wrote $fullHistoryPath"
+Get-Content -Raw -LiteralPath $fullHistoryPath | Write-Host
+
+if ($DryRun)
+{
+    Write-Host "DryRun enabled; skipping gist update."
+    exit 0
+}
+
+$previousToken = $env:GH_TOKEN
+try
+{
+    if (-not [string]::IsNullOrWhiteSpace($env:GH_PAT))
+    {
+        $env:GH_TOKEN = $env:GH_PAT
+    }
+
+    if ($fileExists)
+    {
+        gh gist edit $GistId -f $HistoryFileName $fullHistoryPath
+    }
+    else
+    {
+        gh gist edit $GistId -a $HistoryFileName $fullHistoryPath
+    }
+
+    if (-not $?)
+    {
+        throw "Failed to update gist $GistId file $HistoryFileName."
+    }
+
+    Write-Host "Updated gist $GistId ($HistoryFileName)."
+}
+finally
+{
+    $env:GH_TOKEN = $previousToken
+}
+
+exit 0

--- a/Scripts/UpdateBenchmarkGists.ps1
+++ b/Scripts/UpdateBenchmarkGists.ps1
@@ -112,6 +112,8 @@ $timeHistorySvgPath = Join-Path $MappaBenchmarkPath "MAPPA-BENCHMARK-TIME-HISTOR
 $memoryHistorySvgPath = Join-Path $MappaBenchmarkPath "MAPPA-BENCHMARK-MEMORY-HISTORY.svg"
 $timeSummarySvgPath = Join-Path $MappaBenchmarkPath "MAPPA-BENCHMARK-TIME.svg"
 $memorySummarySvgPath = Join-Path $MappaBenchmarkPath "MAPPA-BENCHMARK-MEMORY.svg"
+$timePercentSvgPath = Join-Path $MappaBenchmarkPath "MAPPA-BENCHMARK-TIME-PERCENTAGES.svg"
+$memoryPercentSvgPath = Join-Path $MappaBenchmarkPath "MAPPA-BENCHMARK-MEMORY-PERCENTAGES.svg"
 
 New-BenchmarkHistorySvg `
     -HistoryMarkdownPath $fullHistoryPath `
@@ -181,6 +183,8 @@ try
 
     Publish-GistFile -GistId $GistId -RemoteFileName "MAPPA-BENCHMARK-TIME.svg" -LocalPath $timeSummarySvgPath
     Publish-GistFile -GistId $GistId -RemoteFileName "MAPPA-BENCHMARK-MEMORY.svg" -LocalPath $memorySummarySvgPath
+    Publish-GistFile -GistId $GistId -RemoteFileName "MAPPA-BENCHMARK-TIME-PERCENTAGES.svg" -LocalPath $timePercentSvgPath
+    Publish-GistFile -GistId $GistId -RemoteFileName "MAPPA-BENCHMARK-MEMORY-PERCENTAGES.svg" -LocalPath $memoryPercentSvgPath
     Publish-GistFile -GistId $GistId -RemoteFileName "MAPPA-BENCHMARK-TIME-HISTORY.svg" -LocalPath $timeHistorySvgPath
     Publish-GistFile -GistId $GistId -RemoteFileName "MAPPA-BENCHMARK-MEMORY-HISTORY.svg" -LocalPath $memoryHistorySvgPath
 }

--- a/Scripts/UpdateBenchmarkGists.ps1
+++ b/Scripts/UpdateBenchmarkGists.ps1
@@ -7,6 +7,8 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+. "$PSScriptRoot/BenchmarkChartsSvg.ps1"
+
 $HistoryTableHeader = @"
 | Timestamp | Version | Benchmark | Measure | Value |
 | --------- | ------- | ---- | ---------- | ------- |
@@ -55,6 +57,28 @@ function Get-BenchmarkHistoryFromGist
     }
 }
 
+function Publish-GistFile
+{
+    param(
+        [string]$GistId,
+        [string]$RemoteFileName,
+        [string]$LocalPath
+    )
+
+    if (-not (Test-Path -LiteralPath $LocalPath))
+    {
+        throw "Cannot publish missing local file: $LocalPath"
+    }
+
+    gh gist edit $GistId -f $RemoteFileName $LocalPath
+    if (-not $?)
+    {
+        throw "Failed to update gist $GistId file $RemoteFileName from $LocalPath."
+    }
+
+    Write-Host "Updated gist $GistId ($RemoteFileName)."
+}
+
 $historyRowsPath = Join-Path $MappaBenchmarkPath "history-table.md"
 if (-not (Test-Path -LiteralPath $historyRowsPath))
 {
@@ -82,9 +106,49 @@ else
 
 $fullHistoryPath = Join-Path $MappaBenchmarkPath "full-history-table.md"
 [System.IO.File]::WriteAllText($fullHistoryPath, $fullHistory)
-
 Write-Host "Wrote $fullHistoryPath"
-Get-Content -Raw -LiteralPath $fullHistoryPath | Write-Host
+
+$timeHistorySvgPath = Join-Path $MappaBenchmarkPath "MAPPA-BENCHMARK-TIME-HISTORY.svg"
+$memoryHistorySvgPath = Join-Path $MappaBenchmarkPath "MAPPA-BENCHMARK-MEMORY-HISTORY.svg"
+$timeSummarySvgPath = Join-Path $MappaBenchmarkPath "MAPPA-BENCHMARK-TIME.svg"
+$memorySummarySvgPath = Join-Path $MappaBenchmarkPath "MAPPA-BENCHMARK-MEMORY.svg"
+
+New-BenchmarkHistorySvg `
+    -HistoryMarkdownPath $fullHistoryPath `
+    -Measure "TIME_NS" `
+    -OutputPath $timeHistorySvgPath `
+    -Title "Mappa benchmark time history" `
+    -YAxisUnitLabel "us"
+
+New-BenchmarkHistorySvg `
+    -HistoryMarkdownPath $fullHistoryPath `
+    -Measure "ALLOC_B" `
+    -OutputPath $memoryHistorySvgPath `
+    -Title "Mappa benchmark memory history" `
+    -YAxisUnitLabel "KB"
+
+Write-Host "Wrote $timeHistorySvgPath"
+Write-Host "Wrote $memoryHistorySvgPath"
+
+if (-not (Test-Path -LiteralPath $timeSummarySvgPath))
+{
+    $legacyTime = Join-Path $MappaBenchmarkPath "Benchmark.Time.svg"
+    if (Test-Path -LiteralPath $legacyTime)
+    {
+        Copy-Item -LiteralPath $legacyTime -Destination $timeSummarySvgPath -Force
+        Write-Host "Copied $legacyTime -> $timeSummarySvgPath"
+    }
+}
+
+if (-not (Test-Path -LiteralPath $memorySummarySvgPath))
+{
+    $legacyMemory = Join-Path $MappaBenchmarkPath "Benchmark.Memory.svg"
+    if (Test-Path -LiteralPath $legacyMemory)
+    {
+        Copy-Item -LiteralPath $legacyMemory -Destination $memorySummarySvgPath -Force
+        Write-Host "Copied $legacyMemory -> $memorySummarySvgPath"
+    }
+}
 
 if ($DryRun)
 {
@@ -102,19 +166,23 @@ try
 
     if ($fileExists)
     {
-        gh gist edit $GistId -f $HistoryFileName $fullHistoryPath
+        Publish-GistFile -GistId $GistId -RemoteFileName $HistoryFileName -LocalPath $fullHistoryPath
     }
     else
     {
         gh gist edit $GistId -a $HistoryFileName $fullHistoryPath
+        if (-not $?)
+        {
+            throw "Failed to add gist $GistId file $HistoryFileName."
+        }
+
+        Write-Host "Added gist $GistId ($HistoryFileName)."
     }
 
-    if (-not $?)
-    {
-        throw "Failed to update gist $GistId file $HistoryFileName."
-    }
-
-    Write-Host "Updated gist $GistId ($HistoryFileName)."
+    Publish-GistFile -GistId $GistId -RemoteFileName "MAPPA-BENCHMARK-TIME.svg" -LocalPath $timeSummarySvgPath
+    Publish-GistFile -GistId $GistId -RemoteFileName "MAPPA-BENCHMARK-MEMORY.svg" -LocalPath $memorySummarySvgPath
+    Publish-GistFile -GistId $GistId -RemoteFileName "MAPPA-BENCHMARK-TIME-HISTORY.svg" -LocalPath $timeHistorySvgPath
+    Publish-GistFile -GistId $GistId -RemoteFileName "MAPPA-BENCHMARK-MEMORY-HISTORY.svg" -LocalPath $memoryHistorySvgPath
 }
 finally
 {


### PR DESCRIPTION
## Summary
- Expand `Mappa.Benchmark` into a broad AutoMapper / Mapster / Mapperly / Mappa suite (objects, enums, collections, memory, polymorphism, IQueryable, nested DTOs) with AutoMapper as the ratio baseline.
- Rework `RunBenchmarks.ps1` / SVG helpers to emit summary tables, TIME/MEMORY bar charts, and Mappa-only history rows; publish history + charts via `UpdateBenchmarkGists.ps1`.
- Wire chart-subset benchmarks into PR and main CI, extend the coverage PR comment with benchmark summary/trends, and document the suite (including root README gist SVGs).

## Test plan
- [ ] `.\Scripts\RunBenchmarks.ps1 -ChartBenchmarksOnly` completes and writes `.mappa-benchmark/` summary + SVG outputs
- [ ] `.\Scripts\UpdateBenchmarkGists.ps1 -DryRun` merges gist history and regenerates history SVGs without upload
- [ ] `.\Scripts\CommentPullRequestCoverage.ps1 -DryRun` includes Benchmarks + trends sections
- [ ] PR CI runs chart-only benchmarks before the coverage comment
- [ ] Confirm root README gist SVG links resolve once the gist files are populated on `main`