### PR TITLE
#293 Retry gist updates and make history merges idempotent

### DIFF
--- a/.cursor/rules/mappa-development-workflow.mdc
+++ b/.cursor/rules/mappa-development-workflow.mdc
@@ -18,19 +18,21 @@ The development environment uses **PowerShell**. All commands run in the termina
 - **Always** create a plan with numbered steps before starting implementation.
 - **Always** save the plan file under `.cursor/plans/` in the repository.
 - **Always** name the plan file `issue_<number>_<short-description>.plan.md` when the work is tied to a GitHub issue (e.g. `.cursor/plans/issue_214_datetimestyle_mappasettings.plan.md`). If no issue number is provided, ask the user for one before creating the plan.
-- **Step 1 must always compute the code coverage baseline** (see **Code Coverage** below): run `.\Scripts\RunTestsAndReportCoverage.ps1` and record **line**, **branch**, and **method** coverage from [`.mappa-tests-and-coverage/Summary.xml`](.mappa-tests-and-coverage/Summary.xml), plus coverage for any assembly expected to change. No code changes before step 1 is complete.
+- **Coverage baseline (when required):** if the issue changes **code** (C# in any project listed under **Code** below), step 1 must compute the code coverage baseline (see **Code Coverage** below): run `.\Scripts\RunTestsAndReportCoverage.ps1` and record **line**, **branch**, and **method** coverage from [`.mappa-tests-and-coverage/Summary.xml`](.mappa-tests-and-coverage/Summary.xml), plus coverage for any assembly expected to change. No code changes before that baseline step is complete.
+- **Coverage baseline (when omitted):** issues that touch **only** Scripts, Documentation, and/or `.cursor` rules (no C# project changes) may omit the coverage baseline and the final coverage non-decrease check. In that case plan steps start at `1` with the first real work item; TODOs remain 1:1 with plan steps. Version bump + `.\Scripts\RebuildUponVersionChange.ps1` remain required for every issue (see **Versioning**).
 - **TODOs MUST ALWAYS match plan steps 1:1.** Create exactly one numbered TODO for each numbered plan step, and exactly one numbered plan step for each TODO — no extras, no omissions, no combined or split items.
 - **Step numbers must match TODO numbers** (e.g. plan step `3.` ↔ TODO `3`); TODO content must describe the same work as its corresponding step.
 - **TODO content must be prefixed with the step number** (e.g. `1. Run .\Scripts\RunTestsAndReportCoverage.ps1 …`, `2. Mappa — …`, `3. Bump MappaVersion.targets …`). The `id` field and the leading number in `content` must both match the plan step number.
 - **Plan frontmatter format:** each TODO entry uses `id: "<n>"` and `content: <n>. <description>` where `<n>` is the same integer as the corresponding `### <n>.` heading in the plan body.
-- Plan steps **2 onward** must follow the **Code** project order below, but only include projects that require changes — do **not** add empty steps for unchanged projects.
-- Step numbers are **sequential** (1, 2, 3, …) across all steps; step `1` is always the coverage baseline. Project work starts at step `2` (e.g. if **Mappa** and **Mappa.Tests** need no changes, the first project step may be **Mappa.Generator** numbered as step `2`).
+- Plan steps after any coverage baseline must follow the **Code** project order below, but only include projects that require changes — do **not** add empty steps for unchanged projects.
+- Step numbers are **sequential** (1, 2, 3, …) across all steps. When a coverage baseline is required, it is step `1` and project work starts at step `2` (e.g. if **Mappa** and **Mappa.Tests** need no changes, the first project step may be **Mappa.Generator** numbered as step `2`). When the baseline is omitted, step `1` is the first real work item.
 - Generated code **must compile** and **all tests must pass** before finishing.
 
 ## Code Coverage
 
-- **Step 1 of every plan** runs `.\Scripts\RunTestsAndReportCoverage.ps1` and records the baseline from [`.mappa-tests-and-coverage/Summary.xml`](.mappa-tests-and-coverage/Summary.xml): **line**, **branch**, and **method** coverage. Also note coverage for any assembly expected to change (especially **Mappa.Generator**).
-- **Coverage must not decrease** relative to that baseline when the issue is finished. Compare the final run using the same metrics.
+- **When the issue changes code** (C# in any project listed under **Code**), step 1 of the plan runs `.\Scripts\RunTestsAndReportCoverage.ps1` and records the baseline from [`.mappa-tests-and-coverage/Summary.xml`](.mappa-tests-and-coverage/Summary.xml): **line**, **branch**, and **method** coverage. Also note coverage for any assembly expected to change (especially **Mappa.Generator**).
+- **When the issue does not change code** (Scripts, Documentation, and/or `.cursor` rules only), skip the coverage baseline and the final coverage comparison.
+- **Coverage must not decrease** relative to that baseline when the issue is finished (code-change issues only). Compare the final run using the same metrics.
 - If coverage decreases — including after adding new production code with uncovered paths — **add or extend tests** until coverage is restored. Prefer targeted unit and integration tests for new branches, edge cases, and negative paths.
 - When analyzing gaps, use [`.mappa-tests-and-coverage/Summary.xml`](.mappa-tests-and-coverage/Summary.xml) and the HTML report under [`.mappa-tests-and-coverage/`](.mappa-tests-and-coverage/) to find uncovered lines and branches.
 
@@ -110,7 +112,7 @@ A single feature may require **two** bumps (e.g. one after **Mappa**, one after 
 
 - Update tests after changing a project.
 - Cover **happy path and negative paths** where possible.
-- Maintain or improve **code coverage** relative to the baseline recorded in plan step 1 (see **Code Coverage**).
+- When a coverage baseline was recorded (code-change issues), maintain or improve **code coverage** relative to that baseline (see **Code Coverage**).
 - For **Mappa.Generator**, test error/warning messages and corner cases.
 - **`HaveGeneratedSourceCode()` is not validation:** it only asserts that generated sources exist (count). Any test that calls `HaveGeneratedSourceCode()` **must** continue with `WithCompilationUnit()` (or `WithCompilationUnits`) plus a map-method helper (`HaveDefaultMapMethod` / `HaveMapMethod` / `HaveDefaultMapMethodWithContext` / `HaveQueryableProjectionMapMethod`, etc.) and a full `HasNextSyntaxNode` walk. When generation must fail, use `NotHaveGeneratedAnySourceCode()` instead of claiming sources without validating them.
 - **Mappa.Generator.Tests integration tests — generated syntax (mandatory):** when asserting that generated mapping code is correct, **always** walk the syntax tree with the `HasNextSyntaxNode` pattern (typically after `HaveDefaultMapMethod` / `blockSyntaxAssertions`, using helpers such as `BeLocalDeclarationStatementSyntax`, `BeReturnStatement`, `BeObjectCreationExpressionSyntax`, nested `HasSyntaxNodesCount` / `HasNextSyntaxNode` chains, etc.). See existing tests such as [`InvokeConstructorMapStrategyIntegrationTests.cs`](Mappa.Generator.Tests/InvokeConstructorMapStrategyIntegrationTests.cs) for the required style.
@@ -142,10 +144,12 @@ A single feature may require **two** bumps (e.g. one after **Mappa**, one after 
 
 ## Final Step
 
-Always end with:
+**When the issue changes code**, end with:
 
 ```powershell
 .\Scripts\RunTestsAndReportCoverage.ps1
 ```
 
-Confirm that **line**, **branch**, and **method** coverage in [`.mappa-tests-and-coverage/Summary.xml`](.mappa-tests-and-coverage/Summary.xml) are **greater than or equal to** the baseline recorded in **step 1**. If any metric decreased, add tests and re-run until coverage is restored.
+Confirm that **line**, **branch**, and **method** coverage in [`.mappa-tests-and-coverage/Summary.xml`](.mappa-tests-and-coverage/Summary.xml) are **greater than or equal to** the baseline recorded in the coverage baseline step. If any metric decreased, add tests and re-run until coverage is restored.
+
+**When the issue does not change code** (Scripts, Documentation, and/or `.cursor` rules only), skip this coverage final step; still finish with the required version bump and `.\Scripts\RebuildUponVersionChange.ps1` (see **Versioning**).

--- a/Documentation/development.md
+++ b/Documentation/development.md
@@ -53,7 +53,7 @@ After a local run (or on `main` CI), publish history + SVGs to the shared gist w
 
 `./Scripts/UpdateBenchmarkGists.ps1`
 
-That script downloads `MAPPA-BENCHMARK-HISTORY.md` from gist [`7f4a85bc809328b4821b03125f9190cb`](https://gist.github.com/sanelli/7f4a85bc809328b4821b03125f9190cb), appends `history-table.md`, regenerates the TIME/MEMORY history SVGs, and uploads:
+That script downloads `MAPPA-BENCHMARK-HISTORY.md` from gist [`7f4a85bc809328b4821b03125f9190cb`](https://gist.github.com/sanelli/7f4a85bc809328b4821b03125f9190cb), merges `history-table.md` by **replacing any existing rows for the same Mappa version** (so re-running main-merge is idempotent), regenerates the TIME/MEMORY history SVGs, and uploads:
 
 - `MAPPA-BENCHMARK-HISTORY.md`
 - `MAPPA-BENCHMARK-TIME.svg`
@@ -62,6 +62,10 @@ That script downloads `MAPPA-BENCHMARK-HISTORY.md` from gist [`7f4a85bc809328b48
 - `MAPPA-BENCHMARK-MEMORY-PERCENTAGES.svg`
 - `MAPPA-BENCHMARK-TIME-HISTORY.svg`
 - `MAPPA-BENCHMARK-MEMORY-HISTORY.svg`
+
+Gist uploads (including coverage badges/history via `./Scripts/UpdateCodeCoverageGists.ps1`) retry up to **5** times with a random **2–10 second** delay between attempts on transient API errors (for example HTTP 409).
+
+Code coverage history uses the same version-override merge when publishing `MAPPA-CODE-COVERAGE-HISTORY.MD`.
 
 See [`Mappa.Benchmark/README.md`](../Mappa.Benchmark/README.md) for the scenario suite and how to read results.
 

--- a/MappaVersion.targets
+++ b/MappaVersion.targets
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <MappaVersion>10.2.0-alpha.29</MappaVersion>
+        <MappaVersion>10.2.0-alpha.30</MappaVersion>
     </PropertyGroup>
 </Project>

--- a/Scripts/GistHelpers.ps1
+++ b/Scripts/GistHelpers.ps1
@@ -1,0 +1,219 @@
+# Shared helpers for GitHub gist publish (retry) and markdown history merge (version override).
+
+function Test-MarkdownHistoryHeaderOrSeparatorLine
+{
+    param(
+        [string]$Line,
+        [int]$MinimumCellCount = 4
+    )
+
+    if ($Line -notmatch '^\|')
+    {
+        return $true
+    }
+
+    $cells = @($Line.Split("|") | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" })
+    if ($cells.Count -lt $MinimumCellCount)
+    {
+        return $true
+    }
+
+    if ($cells[0] -eq "Timestamp")
+    {
+        return $true
+    }
+
+    foreach ($cell in $cells)
+    {
+        if ($cell -notmatch '^-+$')
+        {
+            return $false
+        }
+    }
+
+    return $true
+}
+
+function Get-MarkdownHistoryVersions
+{
+    param(
+        [string]$Markdown,
+        [int]$VersionColumnIndex = 1,
+        [int]$MinimumCellCount = 4
+    )
+
+    $versions = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+    if ([string]::IsNullOrWhiteSpace($Markdown))
+    {
+        return $versions
+    }
+
+    foreach ($historyLine in ($Markdown -split "`r?`n"))
+    {
+        if (Test-MarkdownHistoryHeaderOrSeparatorLine -Line $historyLine -MinimumCellCount $MinimumCellCount)
+        {
+            continue
+        }
+
+        $cells = @($historyLine.Split("|") | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" })
+        if ($cells.Count -le $VersionColumnIndex)
+        {
+            continue
+        }
+
+        [void]$versions.Add($cells[$VersionColumnIndex])
+    }
+
+    return $versions
+}
+
+function Merge-MarkdownHistoryByVersion
+{
+    param(
+        [AllowNull()]
+        [string]$ExistingMarkdown,
+
+        [Parameter(Mandatory = $true)]
+        [string]$NewMarkdown,
+
+        [string]$DefaultHeader = $null,
+
+        [int]$VersionColumnIndex = 1,
+
+        [int]$MinimumCellCount = 4
+    )
+
+    $newRows = if ($null -eq $NewMarkdown) { "" } else { $NewMarkdown.Trim() }
+    if ([string]::IsNullOrWhiteSpace($newRows))
+    {
+        throw "Cannot merge history: new markdown rows are empty."
+    }
+
+    $versionsToOverride = Get-MarkdownHistoryVersions `
+        -Markdown $newRows `
+        -VersionColumnIndex $VersionColumnIndex `
+        -MinimumCellCount $MinimumCellCount
+
+    if ($versionsToOverride.Count -eq 0)
+    {
+        throw "Cannot merge history: no version values found in new markdown rows."
+    }
+
+    $builder = New-Object System.Text.StringBuilder
+
+    if ([string]::IsNullOrWhiteSpace($ExistingMarkdown))
+    {
+        if (-not [string]::IsNullOrWhiteSpace($DefaultHeader))
+        {
+            [void]$builder.AppendLine($DefaultHeader.TrimEnd())
+        }
+
+        [void]$builder.AppendLine($newRows)
+        return $builder.ToString()
+    }
+
+    foreach ($historyLine in ($ExistingMarkdown -split "`r?`n"))
+    {
+        if ([string]::IsNullOrWhiteSpace($historyLine))
+        {
+            continue
+        }
+
+        if (Test-MarkdownHistoryHeaderOrSeparatorLine -Line $historyLine -MinimumCellCount $MinimumCellCount)
+        {
+            [void]$builder.AppendLine($historyLine)
+            continue
+        }
+
+        $cells = @($historyLine.Split("|") | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" })
+        if ($cells.Count -le $VersionColumnIndex)
+        {
+            continue
+        }
+
+        if ($versionsToOverride.Contains($cells[$VersionColumnIndex]))
+        {
+            continue
+        }
+
+        [void]$builder.AppendLine($historyLine)
+    }
+
+    [void]$builder.AppendLine($newRows)
+    return $builder.ToString()
+}
+
+function Invoke-GhGistEdit
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$GistId,
+
+        [Parameter(Mandatory = $true)]
+        [string]$RemoteFileName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$LocalPath,
+
+        [ValidateSet("Update", "Add")]
+        [string]$Mode = "Update",
+
+        [int]$MaxAttempts = 5
+    )
+
+    if (-not (Test-Path -LiteralPath $LocalPath))
+    {
+        throw "Cannot publish missing local file: $LocalPath"
+    }
+
+    $actionVerb = if ($Mode -eq "Add") { "add" } else { "update" }
+    $lastExit = 1
+
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++)
+    {
+        Write-Host "Gist $actionVerb attempt $attempt/$MaxAttempts for $RemoteFileName..."
+
+        $previousEap = $ErrorActionPreference
+        try
+        {
+            $ErrorActionPreference = "Continue"
+            if ($Mode -eq "Add")
+            {
+                & gh gist edit $GistId -a $RemoteFileName $LocalPath
+            }
+            else
+            {
+                & gh gist edit $GistId -f $RemoteFileName $LocalPath
+            }
+
+            $lastExit = $LASTEXITCODE
+        }
+        finally
+        {
+            $ErrorActionPreference = $previousEap
+        }
+
+        if ($lastExit -eq 0)
+        {
+            if ($Mode -eq "Add")
+            {
+                Write-Host "Added gist $GistId ($RemoteFileName)."
+            }
+            else
+            {
+                Write-Host "Updated gist $GistId ($RemoteFileName)."
+            }
+
+            return
+        }
+
+        if ($attempt -lt $MaxAttempts)
+        {
+            $delaySeconds = Get-Random -Minimum 2 -Maximum 11
+            Write-Host "Gist $actionVerb failed for $RemoteFileName (exit $lastExit); retrying in $delaySeconds seconds..."
+            Start-Sleep -Seconds $delaySeconds
+        }
+    }
+
+    throw "Failed to $actionVerb gist $GistId file $RemoteFileName from $LocalPath."
+}

--- a/Scripts/UpdateBenchmarkGists.ps1
+++ b/Scripts/UpdateBenchmarkGists.ps1
@@ -7,6 +7,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+. "$PSScriptRoot/GistHelpers.ps1"
 . "$PSScriptRoot/BenchmarkChartsSvg.ps1"
 
 $HistoryTableHeader = @"
@@ -62,21 +63,12 @@ function Publish-GistFile
     param(
         [string]$GistId,
         [string]$RemoteFileName,
-        [string]$LocalPath
+        [string]$LocalPath,
+        [ValidateSet("Update", "Add")]
+        [string]$Mode = "Update"
     )
 
-    if (-not (Test-Path -LiteralPath $LocalPath))
-    {
-        throw "Cannot publish missing local file: $LocalPath"
-    }
-
-    gh gist edit $GistId -f $RemoteFileName $LocalPath
-    if (-not $?)
-    {
-        throw "Failed to update gist $GistId file $RemoteFileName from $LocalPath."
-    }
-
-    Write-Host "Updated gist $GistId ($RemoteFileName)."
+    Invoke-GhGistEdit -GistId $GistId -RemoteFileName $RemoteFileName -LocalPath $LocalPath -Mode $Mode
 }
 
 $historyRowsPath = Join-Path $MappaBenchmarkPath "history-table.md"
@@ -91,18 +83,29 @@ if ([string]::IsNullOrWhiteSpace($newRows))
     throw "Benchmark history rows file is empty: $historyRowsPath."
 }
 
-$gistHistory = Get-BenchmarkHistoryFromGist -GistId $GistId -HistoryFileName $HistoryFileName
-$fileExists = [bool]$gistHistory.Exists
-$existingContent = $gistHistory.Content
-
-if ([string]::IsNullOrWhiteSpace($existingContent))
+if ($DryRun)
 {
-    $fullHistory = $HistoryTableHeader.TrimEnd() + "`n" + $newRows + "`n"
+    $existingContent = $null
+    $fullHistoryLocalPath = Join-Path $MappaBenchmarkPath "full-history-table.md"
+    if (Test-Path -LiteralPath $fullHistoryLocalPath)
+    {
+        $existingContent = Get-Content -Raw -LiteralPath $fullHistoryLocalPath
+    }
+
+    $fileExists = -not [string]::IsNullOrWhiteSpace($existingContent)
 }
 else
 {
-    $fullHistory = $existingContent.TrimEnd() + "`n" + $newRows + "`n"
+    $gistHistory = Get-BenchmarkHistoryFromGist -GistId $GistId -HistoryFileName $HistoryFileName
+    $fileExists = [bool]$gistHistory.Exists
+    $existingContent = $gistHistory.Content
 }
+
+$fullHistory = Merge-MarkdownHistoryByVersion `
+    -ExistingMarkdown $existingContent `
+    -NewMarkdown $newRows `
+    -DefaultHeader $HistoryTableHeader `
+    -MinimumCellCount 5
 
 $fullHistoryPath = Join-Path $MappaBenchmarkPath "full-history-table.md"
 [System.IO.File]::WriteAllText($fullHistoryPath, $fullHistory)
@@ -168,17 +171,11 @@ try
 
     if ($fileExists)
     {
-        Publish-GistFile -GistId $GistId -RemoteFileName $HistoryFileName -LocalPath $fullHistoryPath
+        Publish-GistFile -GistId $GistId -RemoteFileName $HistoryFileName -LocalPath $fullHistoryPath -Mode Update
     }
     else
     {
-        gh gist edit $GistId -a $HistoryFileName $fullHistoryPath
-        if (-not $?)
-        {
-            throw "Failed to add gist $GistId file $HistoryFileName."
-        }
-
-        Write-Host "Added gist $GistId ($HistoryFileName)."
+        Publish-GistFile -GistId $GistId -RemoteFileName $HistoryFileName -LocalPath $fullHistoryPath -Mode Add
     }
 
     Publish-GistFile -GistId $GistId -RemoteFileName "MAPPA-BENCHMARK-TIME.svg" -LocalPath $timeSummarySvgPath

--- a/Scripts/UpdateCodeCoverageGists.ps1
+++ b/Scripts/UpdateCodeCoverageGists.ps1
@@ -1,58 +1,148 @@
-param([switch]$DryRun)
+param(
+    [string]$GistId = "7f4a85bc809328b4821b03125f9190cb",
+    [string]$HistoryFileName = "MAPPA-CODE-COVERAGE-HISTORY.MD",
+    [string]$MappaTestsAndCoveragePath = ".mappa-tests-and-coverage",
+    [switch]$DryRun
+)
 
-$MappaTestsAndCoveragePath = ".mappa-tests-and-coverage"
+$ErrorActionPreference = "Stop"
+
+. "$PSScriptRoot/GistHelpers.ps1"
 . "$PSScriptRoot/CodeCoverageHistorySvg.ps1"
 
-Get-Content -Raw "./$MappaTestsAndCoveragePath/line-coverage-badge.json"
-if (-not $DryRun)
-{
-    gh gist edit "7f4a85bc809328b4821b03125f9190cb" -f "MAPPA-BADGE-LINE-COVERAGE.json" "./$MappaTestsAndCoveragePath/line-coverage-badge.json"
-}
-Get-Content -Raw "./$MappaTestsAndCoveragePath/branch-coverage-badge.json"
-if (-not $DryRun)
-{
-    gh gist edit "7f4a85bc809328b4821b03125f9190cb" -f "MAPPA-BADGE-BRANCH-COVERAGE.json" "./$MappaTestsAndCoveragePath/branch-coverage-badge.json"
-}
+$CoverageHistoryHeader = @"
+| Timestamp | Version | Type | Percentage |
+| --------- | ------- | ---- | ---------- |
+"@
 
-Get-Content -Raw "./$MappaTestsAndCoveragePath/method-coverage-badge.json"
-if (-not $DryRun)
+function Get-CoverageHistoryFromGist
 {
-    gh gist edit "7f4a85bc809328b4821b03125f9190cb" -f "MAPPA-BADGE-METHOD-COVERAGE.json" "./$MappaTestsAndCoveragePath/method-coverage-badge.json"
-}
+    param(
+        [string]$GistId,
+        [string]$HistoryFileName
+    )
 
-if (-not $DryRun)
-{
-    if (Test-Path -Type Leaf "./$MappaTestsAndCoveragePath/full-history-table.md")
+    # Prefer GH_PAT for gist API access; GITHUB_TOKEN cannot read private/org-restricted gists.
+    $previousToken = $env:GH_TOKEN
+    $previousEap = $ErrorActionPreference
+    try
     {
-        Remove-Item "./$MappaTestsAndCoveragePath/full-history-table.md"
+        if (-not [string]::IsNullOrWhiteSpace($env:GH_PAT))
+        {
+            $env:GH_TOKEN = $env:GH_PAT
+        }
+
+        $ErrorActionPreference = "Continue"
+        $raw = & gh gist view $GistId --raw -f $HistoryFileName 2>&1
+        $exitCode = $LASTEXITCODE
+        if ($exitCode -ne 0)
+        {
+            Write-Host "Coverage history file '$HistoryFileName' was not found in gist $GistId (exit $exitCode); seeding empty history."
+            return [pscustomobject]@{
+                Exists = $false
+                Content = $null
+            }
+        }
+
+        $content = if ($null -eq $raw) { "" } elseif ($raw -is [array]) { ($raw | ForEach-Object { "$_" }) -join "`n" } else { [string]$raw }
+        return [pscustomobject]@{
+            Exists = $true
+            Content = $content
+        }
+    }
+    finally
+    {
+        $ErrorActionPreference = $previousEap
+        $env:GH_TOKEN = $previousToken
     }
 }
 
-if (-not $DryRun)
+$lineBadgePath = Join-Path $MappaTestsAndCoveragePath "line-coverage-badge.json"
+$branchBadgePath = Join-Path $MappaTestsAndCoveragePath "branch-coverage-badge.json"
+$methodBadgePath = Join-Path $MappaTestsAndCoveragePath "method-coverage-badge.json"
+$historyRowsPath = Join-Path $MappaTestsAndCoveragePath "history-table.md"
+$fullHistoryPath = Join-Path $MappaTestsAndCoveragePath "full-history-table.md"
+$historySvgPath = Join-Path $MappaTestsAndCoveragePath "history.svg"
+
+Get-Content -Raw -LiteralPath $lineBadgePath
+Get-Content -Raw -LiteralPath $branchBadgePath
+Get-Content -Raw -LiteralPath $methodBadgePath
+
+if (-not (Test-Path -LiteralPath $historyRowsPath))
 {
-    $currentHistory = $( gh gist view "7f4a85bc809328b4821b03125f9190cb" --raw -f "MAPPA-CODE-COVERAGE-HISTORY.MD" )
+    throw "Coverage history rows not found: $historyRowsPath. Run Scripts/RunTestsAndReportCoverage.ps1 first."
+}
+
+$newRows = (Get-Content -Raw -LiteralPath $historyRowsPath).Trim()
+if ([string]::IsNullOrWhiteSpace($newRows))
+{
+    throw "Coverage history rows file is empty: $historyRowsPath."
+}
+
+if ($DryRun)
+{
+    $existingContent = $null
+    if (Test-Path -LiteralPath $fullHistoryPath)
+    {
+        $existingContent = Get-Content -Raw -LiteralPath $fullHistoryPath
+    }
+
+    $fileExists = -not [string]::IsNullOrWhiteSpace($existingContent)
 }
 else
 {
-    $currentHistory = $( Get-Content -Raw "./$MappaTestsAndCoveragePath/full-history-table.md" )
+    $gistHistory = Get-CoverageHistoryFromGist -GistId $GistId -HistoryFileName $HistoryFileName
+    $fileExists = [bool]$gistHistory.Exists
+    $existingContent = $gistHistory.Content
 }
 
-$currentHistory = $currentHistory.Trim()
-$currentHistory | Out-File "./$MappaTestsAndCoveragePath/full-history-table.md"
-Get-Content -Raw "./$MappaTestsAndCoveragePath/history-table.md" | Out-File -Append -NoNewline "./$MappaTestsAndCoveragePath/full-history-table.md"
-Get-Content -Raw "./$MappaTestsAndCoveragePath/full-history-table.md"
+$fullHistory = Merge-MarkdownHistoryByVersion `
+    -ExistingMarkdown $existingContent `
+    -NewMarkdown $newRows `
+    -DefaultHeader $CoverageHistoryHeader `
+    -MinimumCellCount 4
 
-if (-not $DryRun)
-{
-    gh gist edit "7f4a85bc809328b4821b03125f9190cb" -a "MAPPA-CODE-COVERAGE-HISTORY.MD" "./$MappaTestsAndCoveragePath/full-history-table.md"
-}
+[System.IO.File]::WriteAllText($fullHistoryPath, $fullHistory)
+Write-Host "Wrote $fullHistoryPath"
+Get-Content -Raw -LiteralPath $fullHistoryPath
 
 New-CodeCoverageHistorySvg `
-    -HistoryMarkdownPath "./$MappaTestsAndCoveragePath/full-history-table.md" `
-    -OutputPath "./$MappaTestsAndCoveragePath/history.svg"
-Get-Content -Raw "./$MappaTestsAndCoveragePath/history.svg"
+    -HistoryMarkdownPath $fullHistoryPath `
+    -OutputPath $historySvgPath
+Get-Content -Raw -LiteralPath $historySvgPath
 
-if (-not $DryRun)
+if ($DryRun)
 {
-    gh gist edit "7f4a85bc809328b4821b03125f9190cb" -f "MAPPA-CODE-COVERAGE-HISTORY.svg" "./$MappaTestsAndCoveragePath/history.svg"
+    Write-Host "DryRun enabled; skipping gist update."
+    exit 0
 }
+
+$previousToken = $env:GH_TOKEN
+try
+{
+    if (-not [string]::IsNullOrWhiteSpace($env:GH_PAT))
+    {
+        $env:GH_TOKEN = $env:GH_PAT
+    }
+
+    Invoke-GhGistEdit -GistId $GistId -RemoteFileName "MAPPA-BADGE-LINE-COVERAGE.json" -LocalPath $lineBadgePath -Mode Update
+    Invoke-GhGistEdit -GistId $GistId -RemoteFileName "MAPPA-BADGE-BRANCH-COVERAGE.json" -LocalPath $branchBadgePath -Mode Update
+    Invoke-GhGistEdit -GistId $GistId -RemoteFileName "MAPPA-BADGE-METHOD-COVERAGE.json" -LocalPath $methodBadgePath -Mode Update
+
+    if ($fileExists)
+    {
+        Invoke-GhGistEdit -GistId $GistId -RemoteFileName $HistoryFileName -LocalPath $fullHistoryPath -Mode Update
+    }
+    else
+    {
+        Invoke-GhGistEdit -GistId $GistId -RemoteFileName $HistoryFileName -LocalPath $fullHistoryPath -Mode Add
+    }
+
+    Invoke-GhGistEdit -GistId $GistId -RemoteFileName "MAPPA-CODE-COVERAGE-HISTORY.svg" -LocalPath $historySvgPath -Mode Update
+}
+finally
+{
+    $env:GH_TOKEN = $previousToken
+}
+
+exit 0


### PR DESCRIPTION
## Summary
- Retry `gh gist edit` up to 5 times with a random 2–10s delay to handle intermittent HTTP 409 failures on main-merge.
- Make coverage and benchmark history merges idempotent by replacing rows for the same Mappa version before republishing.
- Allow omitting coverage baseline/final steps for Scripts/Documentation/cursor-rule-only work; bump to `10.2.0-alpha.30`.

## Test plan
- [ ] Review `Scripts/GistHelpers.ps1` retry and version-merge helpers
- [ ] Dry-run `UpdateCodeCoverageGists.ps1 -DryRun` / `UpdateBenchmarkGists.ps1 -DryRun` with local history tables if available
- [ ] Confirm CI version check passes (`CheckVersionIncrease.ps1`)
- [ ] After merge, re-run main-merge (or simulate) and confirm gist history does not duplicate the same version

Closes #293
