### PR TITLE
#308 Dump successfully generated sources from generator tests

### DIFF
--- a/.cursor/rules/mappa-development-workflow.mdc
+++ b/.cursor/rules/mappa-development-workflow.mdc
@@ -87,6 +87,7 @@ The development environment uses **PowerShell**. All commands run in the termina
 - When creating a pull request for a GitHub issue, **also upload the plan** used for that work to the **original GitHub issue** (not only the PR description).
 - Post the plan as an issue comment with `gh issue comment <number>` after the PR exists (so the comment can include the PR URL).
 - Include: a short heading (e.g. `## Implementation plan`), a link to the PR, and the full contents of the plan file under `.cursor/plans/` (e.g. `issue_<number>_*.plan.md`). Prefer `--body-file` with a temporary markdown file built in PowerShell rather than bash heredocs.
+- **Also upload the new generator tests report** from [`.mappa-generator-tests-dump/new-generator-tests-report.md`](.mappa-generator-tests-dump/new-generator-tests-report.md) to the same GitHub issue (same `gh issue comment` / `--body-file` PowerShell pattern). Include a heading such as `## New generator tests report` and the full report contents (or post it as a second comment). If the report file is missing, create an empty report first (see **Tests**), then upload it.
 - If no issue number is known when creating the PR, ask the user for one before posting the plan.
 - **Pre-PR dependency check:** before creating a pull request, run `dotnet package list --outdated` (from the repository root, or per project as needed) and **report every package whose Latest version is greater than the Requested/Resolved version**. Search open GitHub issues for an existing dependency-update task. Then ask the user whether they want to **create a new GitHub issue** (if none is open) or **update the existing open issue** (if one already tracks dependency updates) with the outdated packages found. Do **not** silently open or edit the issue.
 
@@ -134,6 +135,11 @@ A single feature may require **two** bumps (e.g. one after **Mappa**, one after 
 - When `blockSyntaxAssertions` (or nested block assertions) include `HasSyntaxNodesCount(X)`, there must be exactly **X** subsequent `HasNextSyntaxNode` entries chained after it.
 - Prefer `.HaveDiagnostics(n).HaveDiagnostic(MappaDiagnosticDescriptors.…, messageArgs)` (or `NotHaveDiagnostics()`) over asserting warning IDs alone. Do not reintroduce `HaveOnlyWarnings`.
 - When adding samples in **Mappa.Samples**, also update **Mappa.Samples.Aot**.
+- **New generator tests report:** after all **Mappa.Generator.Tests** work for an issue is complete (and dumps exist under [`.mappa-generator-tests-dump/`](.mappa-generator-tests-dump/) from successful generation), write [`.mappa-generator-tests-dump/new-generator-tests-report.md`](.mappa-generator-tests-dump/new-generator-tests-report.md) covering each **new** generator integration test with:
+  1. the purpose of the test (from the test XML documentation / summary);
+  2. the original input source from the integration test arrange;
+  3. the generated source (from the corresponding dump `.g.cs` / run output).
+  If there are no new generator integration tests, write an **empty** report file. Successful generation dumps use `{className}_{testMethodName}.g.cs` (or `{className}_{testMethodName}_{sanitizedTheoryParams}.g.cs` for theories); `.\Scripts\RunTestsAndReportCoverage.ps1` deletes and recreates `.mappa-generator-tests-dump/` before tests.
 
 ## Samples
 

--- a/.gitignore
+++ b/.gitignore
@@ -355,5 +355,6 @@ MigrationBackup/
 .package/
 nuget.config
 .mappa-tests-and-coverage
+.mappa-generator-tests-dump
 .idea
 .cursor/plans/*

--- a/Mappa.Generator.Tests/Abstractions/MappaGeneratorAbstractUnitTests.cs
+++ b/Mappa.Generator.Tests/Abstractions/MappaGeneratorAbstractUnitTests.cs
@@ -88,6 +88,7 @@ public abstract class MappaGeneratorAbstractUnitTests
             out var outputCompilation,
             out var diagnostics,
             cancellationToken);
+        GeneratedSourceDumpHelper.TryDumpGeneratedSources(driver);
         return Task.FromResult(new GeneratedResults(driver, outputCompilation, diagnostics.ToArray()));
     }
 

--- a/Mappa.Generator.Tests/GeneratedSourceDumpHelperTests.cs
+++ b/Mappa.Generator.Tests/GeneratedSourceDumpHelperTests.cs
@@ -1,0 +1,186 @@
+// <copyright file="GeneratedSourceDumpHelperTests.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using Mappa.Generator.Tests.Abstractions;
+using Mappa.Generator.Tests.Helpers;
+
+namespace Mappa.Generator.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="GeneratedSourceDumpHelper"/>.
+/// </summary>
+public sealed class GeneratedSourceDumpHelperTests
+    : MappaGeneratorAbstractUnitTests
+{
+    /// <summary>
+    /// Test <see cref="GeneratedSourceDumpHelper.SanitizeFileNameFragment"/> replaces invalid characters.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void SanitizeFileNameFragmentReplacesInvalidCharacters()
+    {
+        var sanitized = GeneratedSourceDumpHelper.SanitizeFileNameFragment(@"System.Span<byte> path/name");
+
+        sanitized.Should().Be("System.Span_byte__path_name");
+    }
+
+    /// <summary>
+    /// Test <see cref="GeneratedSourceDumpHelper.SanitizeFileNameFragment"/> returns a fallback for blank values.
+    /// </summary>
+    /// <param name="value">The blank value.</param>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [UnitTest]
+    public void SanitizeFileNameFragmentReturnsEmptyFallbackForBlankValues(string? value)
+    {
+        GeneratedSourceDumpHelper.SanitizeFileNameFragment(value).Should().Be("empty");
+    }
+
+    /// <summary>
+    /// Test <see cref="GeneratedSourceDumpHelper.FormatTheoryArgument"/> formats supported values.
+    /// </summary>
+    /// <param name="argument">The argument.</param>
+    /// <param name="expected">The expected formatted value.</param>
+    [Theory]
+    [InlineData(null, "null")]
+    [InlineData("byte[]", "byte[]")]
+    [InlineData(true, "True")]
+    [InlineData(false, "False")]
+    [InlineData(42, "42")]
+    [UnitTest]
+    public void FormatTheoryArgumentFormatsSupportedValues(object? argument, string expected)
+    {
+        GeneratedSourceDumpHelper.FormatTheoryArgument(argument).Should().Be(expected);
+    }
+
+    /// <summary>
+    /// Test <see cref="GeneratedSourceDumpHelper.BuildDumpFileName"/> for ordinary tests.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void BuildDumpFileNameForOrdinaryTest()
+    {
+        var fileName = GeneratedSourceDumpHelper.BuildDumpFileName(
+            "GuidStrategyIntegrationTests",
+            "CanMapFromGuid",
+            theoryArguments: null,
+            invocationIndex: 1);
+
+        fileName.Should().Be("GuidStrategyIntegrationTests_CanMapFromGuid.g.cs");
+    }
+
+    /// <summary>
+    /// Test <see cref="GeneratedSourceDumpHelper.BuildDumpFileName"/> includes sanitized theory parameters.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void BuildDumpFileNameForTheoryIncludesSanitizedParameters()
+    {
+        var fileName = GeneratedSourceDumpHelper.BuildDumpFileName(
+            "GuidStrategyIntegrationTests",
+            "CanMapFromGuid",
+            ["System.Span<byte>"],
+            invocationIndex: 1);
+
+        fileName.Should().Be("GuidStrategyIntegrationTests_CanMapFromGuid_System.Span_byte_.g.cs");
+    }
+
+    /// <summary>
+    /// Test <see cref="GeneratedSourceDumpHelper.BuildDumpFileName"/> appends the invocation index after the first dump.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void BuildDumpFileNameAppendsInvocationIndexAfterFirstDump()
+    {
+        var fileName = GeneratedSourceDumpHelper.BuildDumpFileName(
+            "SomeTests",
+            "SomeMethod",
+            theoryArguments: null,
+            invocationIndex: 2);
+
+        fileName.Should().Be("SomeTests_SomeMethod_2.g.cs");
+    }
+
+    /// <summary>
+    /// Test <see cref="GeneratedSourceDumpHelper.TryDumpGeneratedSources"/> writes a dump when generation succeeds.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    [UnitTest]
+    public async Task TryDumpGeneratedSourcesWritesFileWhenGenerationSucceeds()
+    {
+        var dumpDirectory = Path.Combine(Path.GetTempPath(), "mappa-dump-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dumpDirectory);
+
+        try
+        {
+            const string sourceCode = """
+                                      #nullable enable
+                                      using System;
+                                      using Mappa.Attributes;
+
+                                      namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                      [Mappa]
+                                      public sealed partial class Mapper
+                                      {
+                                          public partial int Map(int input);
+                                      }
+                                      """;
+
+            var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+            GeneratedSourceDumpHelper.TryDumpGeneratedSources(generatedResults.Driver, dumpDirectory);
+
+            var files = Directory.GetFiles(dumpDirectory, "*.g.cs");
+            files.Should().NotBeEmpty();
+            var content = await File.ReadAllTextAsync(files[0], CancellationToken.None).ConfigureAwait(true);
+            content.Should().NotBeNullOrWhiteSpace();
+        }
+        finally
+        {
+            if (Directory.Exists(dumpDirectory))
+            {
+                Directory.Delete(dumpDirectory, recursive: true);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Test <see cref="GeneratedSourceDumpHelper.TryDumpGeneratedSources"/> does not write when no sources are generated.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Fact]
+    [UnitTest]
+    public async Task TryDumpGeneratedSourcesDoesNotWriteWhenNoSourcesAreGenerated()
+    {
+        var dumpDirectory = Path.Combine(Path.GetTempPath(), "mappa-dump-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dumpDirectory);
+
+        try
+        {
+            const string sourceCode = """
+                                      #nullable enable
+                                      namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                      public sealed class NotAMapper
+                                      {
+                                      }
+                                      """;
+
+            var generatedResults = await RunMappaGeneratorAsync(sourceCode, CancellationToken.None).ConfigureAwait(true);
+            GeneratedSourceDumpHelper.TryDumpGeneratedSources(generatedResults.Driver, dumpDirectory);
+
+            Directory.GetFiles(dumpDirectory, "*.g.cs").Should().BeEmpty();
+        }
+        finally
+        {
+            if (Directory.Exists(dumpDirectory))
+            {
+                Directory.Delete(dumpDirectory, recursive: true);
+            }
+        }
+    }
+}

--- a/Mappa.Generator.Tests/Helpers/GeneratedSourceDumpHelper.cs
+++ b/Mappa.Generator.Tests/Helpers/GeneratedSourceDumpHelper.cs
@@ -1,0 +1,264 @@
+// <copyright file="GeneratedSourceDumpHelper.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using System.Globalization;
+using System.Text;
+
+using Xunit.v3;
+
+namespace Mappa.Generator.Tests.Helpers;
+
+/// <summary>
+/// Dumps successfully generated source from generator integration tests to disk.
+/// </summary>
+internal static class GeneratedSourceDumpHelper
+{
+    /// <summary>
+    /// The dump folder name under the repository root.
+    /// </summary>
+    internal const string DumpFolderName = ".mappa-generator-tests-dump";
+
+    private const string VersionTargetsFileName = "MappaVersion.targets";
+    private const string InvocationCounterKey = "Mappa.Generator.Tests.GeneratedSourceDump.InvocationCounter";
+    private const int MaxFileNameLength = 200;
+
+    /// <summary>
+    /// Attempts to dump generated sources when the generator produced at least one source.
+    /// </summary>
+    /// <param name="driver">The generator driver after a run.</param>
+    /// <param name="dumpDirectoryOverride">Optional dump directory (for unit tests).</param>
+    internal static void TryDumpGeneratedSources(GeneratorDriver driver, string? dumpDirectoryOverride = null)
+    {
+        try
+        {
+            var generatedSources = CollectGeneratedSources(driver);
+            if (generatedSources.Count == 0)
+            {
+                return;
+            }
+
+            var dumpDirectory = dumpDirectoryOverride ?? ResolveDumpDirectory();
+            if (string.IsNullOrWhiteSpace(dumpDirectory))
+            {
+                return;
+            }
+
+            Directory.CreateDirectory(dumpDirectory);
+
+            var (className, methodName, theoryArguments) = GetTestIdentity();
+            var fileName = BuildDumpFileName(className, methodName, theoryArguments, NextInvocationIndex());
+            var content = BuildDumpContent(generatedSources);
+            File.WriteAllText(Path.Combine(dumpDirectory, fileName), content);
+        }
+#pragma warning disable CA1031
+        catch (Exception exception)
+#pragma warning restore CA1031
+        {
+            TestContext.Current.SendDiagnosticMessage(
+                "Failed to dump generated Mappa sources: {0}",
+                exception.Message);
+        }
+    }
+
+    /// <summary>
+    /// Builds a filesystem-safe dump file name.
+    /// </summary>
+    /// <param name="className">The test class name.</param>
+    /// <param name="methodName">The test method name.</param>
+    /// <param name="theoryArguments">Optional theory arguments.</param>
+    /// <param name="invocationIndex">The 1-based dump invocation index within the test.</param>
+    /// <returns>The dump file name.</returns>
+    internal static string BuildDumpFileName(
+        string? className,
+        string? methodName,
+        object?[]? theoryArguments,
+        int invocationIndex)
+    {
+        var classPart = SanitizeFileNameFragment(
+            string.IsNullOrWhiteSpace(className) ? "UnknownClass" : className);
+        var methodPart = SanitizeFileNameFragment(
+            string.IsNullOrWhiteSpace(methodName) ? "UnknownMethod" : methodName);
+        var name = $"{classPart}_{methodPart}";
+
+        if (theoryArguments is { Length: > 0 })
+        {
+            var parametersPart = string.Join(
+                "_",
+                theoryArguments.Select(FormatTheoryArgument));
+            name = $"{name}_{SanitizeFileNameFragment(parametersPart)}";
+        }
+
+        if (invocationIndex > 1)
+        {
+            name = $"{name}_{invocationIndex.ToString(CultureInfo.InvariantCulture)}";
+        }
+
+        const string suffix = ".g.cs";
+        if (name.Length + suffix.Length > MaxFileNameLength)
+        {
+            name = name[..(MaxFileNameLength - suffix.Length)];
+        }
+
+        return name + suffix;
+    }
+
+    /// <summary>
+    /// Sanitizes a value for use as a file-name fragment.
+    /// </summary>
+    /// <param name="value">The value to sanitize.</param>
+    /// <returns>A filesystem-safe fragment.</returns>
+    internal static string SanitizeFileNameFragment(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "empty";
+        }
+
+        var builder = new StringBuilder(value.Length);
+        foreach (var character in value)
+        {
+            if (IsUnsafeFileNameCharacter(character))
+            {
+                builder.Append('_');
+            }
+            else
+            {
+                builder.Append(character);
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Formats a theory argument for inclusion in a dump file name.
+    /// </summary>
+    /// <param name="argument">The theory argument.</param>
+    /// <returns>A string representation of the argument.</returns>
+    internal static string FormatTheoryArgument(object? argument)
+    {
+        return argument switch
+        {
+            null => "null",
+            string text => text,
+            bool boolean => boolean ? "True" : "False",
+            IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture) ?? "null",
+            _ => argument.ToString() ?? "null",
+        };
+    }
+
+    /// <summary>
+    /// Resolves the dump directory under the repository root.
+    /// </summary>
+    /// <returns>The dump directory path, or <see langword="null"/> when the repository root cannot be found.</returns>
+    internal static string? ResolveDumpDirectory()
+    {
+        var repositoryRoot = ResolveRepositoryRoot();
+        return repositoryRoot is null
+            ? null
+            : Path.Combine(repositoryRoot, DumpFolderName);
+    }
+
+    private static bool IsUnsafeFileNameCharacter(char character)
+    {
+        if (character is ' ' or '<' or '>' or ':' or '"' or '/' or '\\' or '|' or '?' or '*')
+        {
+            return true;
+        }
+
+        return Path.GetInvalidFileNameChars().Contains(character);
+    }
+
+    private static string? ResolveRepositoryRoot()
+    {
+        foreach (var startPath in new[] { Directory.GetCurrentDirectory(), AppContext.BaseDirectory })
+        {
+            var directory = new DirectoryInfo(startPath);
+            while (directory is not null)
+            {
+                if (File.Exists(Path.Combine(directory.FullName, VersionTargetsFileName)))
+                {
+                    return directory.FullName;
+                }
+
+                directory = directory.Parent;
+            }
+        }
+
+        return null;
+    }
+
+    private static List<(string HintName, string Source)> CollectGeneratedSources(GeneratorDriver driver)
+    {
+        var sources = new List<(string HintName, string Source)>();
+        foreach (var result in driver.GetRunResult().Results)
+        {
+            foreach (var generatedSource in result.GeneratedSources)
+            {
+                sources.Add((generatedSource.HintName, generatedSource.SourceText.ToString()));
+            }
+        }
+
+        return sources;
+    }
+
+    private static string BuildDumpContent(List<(string HintName, string Source)> generatedSources)
+    {
+        if (generatedSources.Count == 1)
+        {
+            return generatedSources[0].Source;
+        }
+
+        var builder = new StringBuilder();
+        for (var index = 0; index < generatedSources.Count; index++)
+        {
+            if (index > 0)
+            {
+                builder.AppendLine();
+                builder.AppendLine();
+            }
+
+            var (hintName, source) = generatedSources[index];
+            builder.Append("// HintName: ");
+            builder.AppendLine(hintName);
+            builder.Append(source);
+        }
+
+        return builder.ToString();
+    }
+
+    private static (string ClassName, string MethodName, object?[]? TheoryArguments) GetTestIdentity()
+    {
+        var testCase = TestContext.Current.TestCase;
+        var className = testCase?.TestClassSimpleName ?? "UnknownClass";
+        var methodName = testCase?.TestMethodName ?? "UnknownMethod";
+        object?[]? theoryArguments = null;
+        if (TestContext.Current.Test is IXunitTest xunitTest)
+        {
+            theoryArguments = xunitTest.TestMethodArguments;
+        }
+
+        return (className, methodName, theoryArguments);
+    }
+
+    private static int NextInvocationIndex()
+    {
+        try
+        {
+            var storage = TestContext.Current.KeyValueStorage;
+            var next = 1;
+            if (storage.TryGetValue(InvocationCounterKey, out var existing) && existing is int current)
+            {
+                next = current + 1;
+            }
+
+            storage[InvocationCounterKey] = next;
+            return next;
+        }
+        catch (InvalidOperationException)
+        {
+            return 1;
+        }
+    }
+}

--- a/MappaVersion.targets
+++ b/MappaVersion.targets
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <MappaVersion>10.2.0-alpha.53</MappaVersion>
+        <MappaVersion>10.2.0-alpha.54</MappaVersion>
     </PropertyGroup>
 </Project>

--- a/Scripts/RunTestsAndReportCoverage.ps1
+++ b/Scripts/RunTestsAndReportCoverage.ps1
@@ -2,6 +2,7 @@ param([switch]$AlwaysSuccess);
 
 [double]$Threshold = 80.00
 $MappaTestsAndCoveragePath = ".mappa-tests-and-coverage"
+$MappaGeneratorTestsDumpPath = ".mappa-generator-tests-dump"
 
 function Get-CoverageColor
 {
@@ -31,6 +32,12 @@ if (Test-Path $MappaTestsAndCoveragePath)
 {
     Remove-Item -Recurse -Force $MappaTestsAndCoveragePath
 }
+
+if (Test-Path $MappaGeneratorTestsDumpPath)
+{
+    Remove-Item -Recurse -Force $MappaGeneratorTestsDumpPath
+}
+New-Item -ItemType Directory -Name $MappaGeneratorTestsDumpPath > $null
 
 dotnet publish -c Release --self-contained ./Mappa.Samples.Aot/
 if (-not $?)


### PR DESCRIPTION
## Summary
- Dump successfully generated sources from `Mappa.Generator.Tests` into `.mappa-generator-tests-dump/` via `RunMappaGeneratorAsync` (fact/theory-safe file names).
- Ignore the dump folder, recreate it from `RunTestsAndReportCoverage.ps1`, and extend the development workflow so new-generator-test reports are written and uploaded with PRs.
- Bump `MappaVersion` to `10.2.0-alpha.54`.

## Test plan
- [x] Unit tests for `GeneratedSourceDumpHelper` (sanitize, naming, write / no-write)
- [x] Full `RunTestsAndReportCoverage.ps1` (2888 tests passed)
- [ ] Confirm dump files appear under `.mappa-generator-tests-dump/` after a local generator test run
- [ ] Confirm coverage script recreates an empty dump folder before tests

Closes #308