### PR TITLE
#238 Reduce ReportGenerator CRAP and cyclomatic complexity in Mappa.Generator

### DIFF
--- a/Mappa.Generator.Tests/AttributeDataExtensionsGetMappaSettingsAttributeTests.cs
+++ b/Mappa.Generator.Tests/AttributeDataExtensionsGetMappaSettingsAttributeTests.cs
@@ -359,4 +359,86 @@ public sealed class AttributeDataExtensionsGetMappaSettingsAttributeTests
         settings.Should().NotBeNull();
         settings!.DictionaryAssignment.Should().Be(DictionaryAssignmentSetting.Add);
     }
+
+    /// <summary>
+    /// Test <see cref="AttributeDataExtensions.GetMappaSettingsAttribute"/> reads depth properties.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void GetMappaSettingsAttributeReadsDepthProperties()
+    {
+        const string source = """
+                              using Mappa.Attributes;
+
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              public class Source { }
+
+                              public class Target { }
+
+                              [Mappa]
+                              public sealed partial class TestMapper
+                              {
+                                  [MappaSettings(MaxRuntimeDepth = 7, MaxCompileTimeDepth = 3)]
+                                  public partial Target Map(Source input);
+                              }
+                              """;
+
+        var compilation = BuildCompilation(source);
+        var attributes = AttributeDataExtensionsTestHelper.GetMethodAttributes(
+            compilation,
+            AttributeDataExtensionsTestHelper.MapperMetadataName,
+            "Map");
+
+        var settings = attributes.GetMappaSettingsAttribute(compilation);
+
+        settings.Should().NotBeNull();
+        settings!.MaxRuntimeDepth.Should().Be((short)7);
+        settings.MaxCompileTimeDepth.Should().Be((short)3);
+    }
+
+    /// <summary>
+    /// Test <see cref="AttributeDataExtensions.GetMappaSettingsAttribute"/> reads typed style enums
+    /// and undefined depth sentinels.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void GetMappaSettingsAttributeReadsTypedStylesAndUndefinedDepth()
+    {
+        const string source = """
+                              using System.Globalization;
+                              using Mappa.Attributes;
+
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              public class Source { }
+
+                              public class Target { }
+
+                              [Mappa]
+                              public sealed partial class TestMapper
+                              {
+                                  [MappaSettings(
+                                      DateTimeStyle = DateTimeStyles.AdjustToUniversal,
+                                      IntStyle = NumberStyles.HexNumber,
+                                      MaxRuntimeDepth = MappaSettingsAttribute.UndefinedDepth,
+                                      MaxCompileTimeDepth = MappaSettingsAttribute.UndefinedDepth)]
+                                  public partial Target Map(Source input);
+                              }
+                              """;
+
+        var compilation = BuildCompilation(source);
+        var attributes = AttributeDataExtensionsTestHelper.GetMethodAttributes(
+            compilation,
+            AttributeDataExtensionsTestHelper.MapperMetadataName,
+            "Map");
+
+        var settings = attributes.GetMappaSettingsAttribute(compilation);
+
+        settings.Should().NotBeNull();
+        settings!.DateTimeStyle.Should().Be(DateTimeStyles.AdjustToUniversal);
+        settings.IntStyle.Should().Be(NumberStyles.HexNumber);
+        settings.MaxRuntimeDepth.Should().Be(MappaSettingsAttribute.UndefinedDepth);
+        settings.MaxCompileTimeDepth.Should().Be(MappaSettingsAttribute.UndefinedDepth);
+    }
 }

--- a/Mappa.Generator.Tests/AttributeDataExtensionsTests.cs
+++ b/Mappa.Generator.Tests/AttributeDataExtensionsTests.cs
@@ -573,4 +573,352 @@ public sealed class AttributeDataExtensionsTests
         attribute.InjectFromAssemblies[0].ToDisplayString().Should().Be(AttributeDataExtensionsTestHelper.NamespaceName + ".IIgnored");
         attribute.ResolveMethodName("TestRegistrar").Should().Be("RegisterFromProperty");
     }
+
+    /// <summary>
+    /// Test <see cref="AttributeDataExtensions.GetMappaAllowInaccessibleSourceMembersAttribute"/>
+    /// reads params member names as primitive constructor arguments.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void GetMappaAllowInaccessibleSourceMembersAttributeReadsPrimitiveParamsMemberNames()
+    {
+        const string source = """
+                              using Mappa.Attributes;
+
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              public class Source
+                              {
+                                  private int First { get; set; }
+
+                                  private int Second { get; set; }
+                              }
+
+                              public class Target
+                              {
+                                  public int First { get; set; }
+
+                                  public int Second { get; set; }
+                              }
+
+                              [Mappa]
+                              public sealed partial class TestMapper
+                              {
+                                  [MappaAllowInaccessibleSourceMembers("First", "", "Second")]
+                                  public partial Target Map(Source input);
+                              }
+                              """;
+
+        var compilation = BuildCompilation(source);
+        var attributes = AttributeDataExtensionsTestHelper.GetMethodAttributes(
+            compilation,
+            AttributeDataExtensionsTestHelper.MapperMetadataName,
+            "Map");
+
+        var attribute = attributes.GetMappaAllowInaccessibleSourceMembersAttribute(compilation);
+
+        attribute.Should().NotBeNull();
+        attribute!.MemberNames.Should().Equal("First", "Second");
+    }
+
+    /// <summary>
+    /// Test <see cref="AttributeDataExtensions.GetMappaAllowInaccessibleTargetMembersAttribute"/>
+    /// reads a single primitive params member name.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void GetMappaAllowInaccessibleTargetMembersAttributeReadsSinglePrimitiveParamsMemberName()
+    {
+        const string source = """
+                              using Mappa.Attributes;
+
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              public class Source
+                              {
+                                  public int Allowed { get; set; }
+                              }
+
+                              public class Target
+                              {
+                                  private int Allowed { get; set; }
+                              }
+
+                              [Mappa]
+                              public sealed partial class TestMapper
+                              {
+                                  [MappaAllowInaccessibleTargetMembers("Allowed")]
+                                  public partial Target Map(Source input);
+                              }
+                              """;
+
+        var compilation = BuildCompilation(source);
+        var attributes = AttributeDataExtensionsTestHelper.GetMethodAttributes(
+            compilation,
+            AttributeDataExtensionsTestHelper.MapperMetadataName,
+            "Map");
+
+        var attribute = attributes.GetMappaAllowInaccessibleTargetMembersAttribute(compilation);
+
+        attribute.Should().NotBeNull();
+        attribute!.MemberNames.Should().Equal("Allowed");
+    }
+
+    /// <summary>
+    /// Test <see cref="AttributeDataExtensions.GetMappaAllowInaccessibleSourceMembersAttribute"/>
+    /// with the parameterless constructor.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void GetMappaAllowInaccessibleSourceMembersAttributeReadsParameterlessConstructor()
+    {
+        const string source = """
+                              using Mappa.Attributes;
+
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              public class Source
+                              {
+                                  private int Value { get; set; }
+                              }
+
+                              public class Target
+                              {
+                                  public int Value { get; set; }
+                              }
+
+                              [Mappa]
+                              public sealed partial class TestMapper
+                              {
+                                  [MappaAllowInaccessibleSourceMembers]
+                                  public partial Target Map(Source input);
+                              }
+                              """;
+
+        var compilation = BuildCompilation(source);
+        var attributes = AttributeDataExtensionsTestHelper.GetMethodAttributes(
+            compilation,
+            AttributeDataExtensionsTestHelper.MapperMetadataName,
+            "Map");
+
+        var attribute = attributes.GetMappaAllowInaccessibleSourceMembersAttribute(compilation);
+
+        attribute.Should().NotBeNull();
+        attribute!.MemberNames.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Test <see cref="AttributeDataExtensions.GetMappaDependencyInjectionAttributeData"/>
+    /// when IgnoreType and InjectFromAssemblies are empty arrays.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void GetMappaDependencyInjectionAttributeDataReadsEmptyTypeArrays()
+    {
+        const string source = """
+                              using Mappa.Attributes;
+
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              [MappaDependencyInjection(
+                                  IgnoreType = new System.Type[0],
+                                  InjectFromAssemblies = new System.Type[0])]
+                              public static partial class TestRegistrar
+                              {
+                              }
+                              """;
+
+        var compilation = BuildCompilation(source);
+        var attributes = AttributeDataExtensionsTestHelper.GetTypeAttributes(
+            compilation,
+            AttributeDataExtensionsTestHelper.NamespaceName + ".TestRegistrar");
+
+        var attribute = attributes.GetMappaDependencyInjectionAttributeData(compilation);
+
+        attribute.Should().NotBeNull();
+        attribute!.IgnoreTypes.Should().BeEmpty();
+        attribute.InjectFromAssemblies.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Test <see cref="AttributeDataExtensions.GetMappaBeforeMapAttributes"/> reads valid constructors
+    /// and ignores invalid location argument types.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void GetMappaBeforeMapAttributesReadsValidConstructorsAndIgnoresInvalidLocation()
+    {
+        const string source = """
+                              using Mappa.Attributes;
+
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              public class Source { }
+
+                              public class Target { }
+
+                              public static class StaticHookHelpers
+                              {
+                                  public static void Before(Source source) { }
+                              }
+
+                              public class InstanceHookHelpers
+                              {
+                                  public void InstanceBefore(Source source) { }
+                              }
+
+                              [Mappa]
+                              public sealed partial class TestMapper
+                              {
+                                  private readonly InstanceHookHelpers helper = new();
+
+                                  [MappaBeforeMap(nameof(LocalBefore))]
+                                  [MappaBeforeMap(typeof(StaticHookHelpers), nameof(StaticHookHelpers.Before))]
+                                  [MappaBeforeMap(nameof(helper), "InstanceBefore")]
+                                  [MappaBeforeMap(42, "InvalidLocation")]
+                                  public partial Target Map(Source input);
+
+                                  private void LocalBefore(Source source) { }
+                              }
+                              """;
+
+        var compilation = BuildCompilation(source);
+        var attributes = AttributeDataExtensionsTestHelper.GetMethodAttributes(
+            compilation,
+            AttributeDataExtensionsTestHelper.MapperMetadataName,
+            "Map");
+
+        var beforeMaps = attributes.GetMappaBeforeMapAttributes(compilation);
+
+        beforeMaps.Should().HaveCount(3);
+        beforeMaps[0].MethodName.Should().Be("LocalBefore");
+        beforeMaps[0].ClassType.Should().BeNull();
+        beforeMaps[0].FieldName.Should().BeNull();
+        beforeMaps[1].ClassType.Should().NotBeNull();
+        beforeMaps[1].MethodName.Should().Be("Before");
+        beforeMaps[2].FieldName.Should().Be("helper");
+        beforeMaps[2].MethodName.Should().Be("InstanceBefore");
+    }
+
+    /// <summary>
+    /// Test <see cref="AttributeDataExtensions.GetInvokeMethodAttributes"/> ignores invalid constructors.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void GetInvokeMethodAttributesIgnoresInvalidConstructors()
+    {
+        const string source = """
+                              using Mappa.Attributes;
+
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              public class Source
+                              {
+                                  public int Property { get; set; }
+                              }
+
+                              public class Target
+                              {
+                                  public string Property { get; set; }
+                              }
+
+                              [Mappa]
+                              public sealed partial class TestMapper
+                              {
+                                  [MappaInvokeMethod(nameof(Target.Property), 42, "LocalMap")]
+                                  [MappaInvokeMethod(nameof(Target.Property), "LocalMap")]
+                                  public partial Target Map(Source input);
+
+                                  private string LocalMap(int value) => value.ToString();
+                              }
+                              """;
+
+        var compilation = BuildCompilation(source);
+        var attributes = AttributeDataExtensionsTestHelper.GetMethodAttributes(
+            compilation,
+            AttributeDataExtensionsTestHelper.MapperMetadataName,
+            "Map");
+
+        var invokeAttributes = attributes.GetInvokeMethodAttributes(compilation);
+
+        invokeAttributes.Should().HaveCount(1);
+        invokeAttributes[0].MethodName.Should().Be("LocalMap");
+        invokeAttributes[0].FieldName.Should().BeNull();
+        invokeAttributes[0].ClassType.Should().BeNull();
+    }
+
+    /// <summary>
+    /// Test <see cref="AttributeDataExtensions.GetMappaObjectFactoryAttributes"/> ignores invalid middle arguments.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void GetMappaObjectFactoryAttributesIgnoresInvalidMiddleArgument()
+    {
+        const string source = """
+                              using Mappa.Attributes;
+
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              public class Source { }
+
+                              public class Target { }
+
+                              [Mappa]
+                              public sealed partial class TestMapper
+                              {
+                                  [MappaObjectFactory(typeof(Target), 42, "CreateTarget")]
+                                  [MappaObjectFactory(typeof(Target), nameof(CreateTarget))]
+                                  public partial Target Map(Source input);
+
+                                  private Target CreateTarget() => new();
+                              }
+                              """;
+
+        var compilation = BuildCompilation(source);
+        var attributes = AttributeDataExtensionsTestHelper.GetMethodAttributes(
+            compilation,
+            AttributeDataExtensionsTestHelper.MapperMetadataName,
+            "Map");
+
+        var factories = attributes.GetMappaObjectFactoryAttributes(compilation);
+
+        factories.Should().HaveCount(1);
+        factories[0].MethodName.Should().Be("CreateTarget");
+        factories[0].FieldName.Should().BeNull();
+        factories[0].ClassType.Should().BeNull();
+    }
+
+    /// <summary>
+    /// Test <see cref="AttributeDataExtensions.GetMappaTypeMappingDefaultAttribute"/> returns <see langword="null"/>
+    /// when constructor arguments cannot be interpreted.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void GetMappaTypeMappingDefaultAttributeReturnsNullForUninterpretableConstructorArguments()
+    {
+        const string source = """
+                              using Mappa.Attributes;
+
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              public class Source { }
+
+                              public class Target { }
+
+                              [Mappa]
+                              public sealed partial class TestMapper
+                              {
+                                  [MappaTypeMappingDefault(42.5)]
+                                  public partial Target Map(Source input);
+                              }
+                              """;
+
+        var compilation = BuildCompilation(source);
+        var attributes = AttributeDataExtensionsTestHelper.GetMethodAttributes(
+            compilation,
+            AttributeDataExtensionsTestHelper.MapperMetadataName,
+            "Map");
+
+        attributes.GetMappaTypeMappingDefaultAttribute(compilation).Should().BeNull();
+    }
 }

--- a/Mappa.Generator.Tests/MappaGlobalOptionsTests.cs
+++ b/Mappa.Generator.Tests/MappaGlobalOptionsTests.cs
@@ -184,4 +184,122 @@ public sealed class MappaGlobalOptionsTests
         options.MaxCompileTimeDepth.Should().Be((short)50);
         options.BreakCompileTimeCycles.Should().Be(BooleanSetting.Undefined);
     }
+
+    /// <summary>
+    /// Test unrecognized and alternate enum values in <c>.editorconfig</c>.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void ParsesUnrecognizedAndAlternateEnumSettingsFromEditorConfig()
+    {
+        const string editorConfig = """
+                                    root = true
+
+                                    [*.cs]
+                                    mappa.cultureinfosettings = NotACulture
+                                    mappa.protobufoptional = NotABoolean
+                                    mappa.enumtoenummapsetting = Undefined
+                                    mappa.identitymapdeepcopy = NestedDeepCopy
+                                    mappa.enumerableconcretetype = Undefined
+                                    mappa.pragmawarning = Undefined
+                                    mappa.debug = true
+                                    mappa.debugcomments = FALSE
+                                    mappa.maxruntimedepth =
+                                    mappa.maxcompiletimedepth = not-a-number
+                                    """;
+
+        var compilation = BuildCompilation("namespace Mappa.Generator.Tests.UnitTests.SourceCode { internal class Placeholder { } }");
+        var options = new MappaGlobalOptions(
+            TestAnalyzerConfigOptionsProvider.FromEditorConfig(editorConfig),
+            compilation.SyntaxTrees[0]);
+
+        options.CultureInfoSetting.Should().Be(CultureInfoSetting.None);
+        options.ProtobufOptional.Should().Be(BooleanSetting.Undefined);
+        options.EnumToEnumMapSetting.Should().Be(EnumToEnumMapSetting.Undefined);
+        options.IdentityMapDeepCopy.Should().Be(IdentityMapDeepCopySetting.NestedDeepCopy);
+        options.EnumerableConcreteType.Should().Be(EnumerableConcreteTypeSetting.Undefined);
+        options.PragmaWarning.Should().Be(PragmaWarningSetting.Undefined);
+        options.MappaDebug.Should().BeTrue();
+        options.MappaDebugComments.Should().BeFalse();
+        options.MaxRuntimeDepth.Should().Be((short)0);
+        options.MaxCompileTimeDepth.Should().Be((short)50);
+    }
+
+    /// <summary>
+    /// Test remaining enum fallbacks and disable paths in <c>.editorconfig</c>.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void ParsesRemainingEnumFallbacksAndDisablePathsFromEditorConfig()
+    {
+        const string editorConfig = """
+                                    root = true
+
+                                    [*.cs]
+                                    mappa.cultureinfosettings = CurrentCulture
+                                    mappa.fastcollections = Disable
+                                    mappa.enumtoenummapsetting = NotAValidEnumToEnum
+                                    mappa.identitymapdeepcopy = DeepCopy
+                                    mappa.enumerableconcretetype = NotAValidEnumerable
+                                    mappa.pragmawarning = NoBlock
+                                    mappa.enumstringmapsetting = Description
+                                    """;
+
+        var compilation = BuildCompilation("namespace Mappa.Generator.Tests.UnitTests.SourceCode { internal class Placeholder { } }");
+        var options = new MappaGlobalOptions(
+            TestAnalyzerConfigOptionsProvider.FromEditorConfig(editorConfig),
+            compilation.SyntaxTrees[0]);
+
+        options.CultureInfoSetting.Should().Be(CultureInfoSetting.CurrentCulture);
+        options.FastCollections.Should().Be(BooleanSetting.Disable);
+        options.EnumToEnumMapSetting.Should().Be(EnumToEnumMapSetting.MemberName);
+        options.IdentityMapDeepCopy.Should().Be(IdentityMapDeepCopySetting.DeepCopy);
+        options.EnumerableConcreteType.Should().Be(EnumerableConcreteTypeSetting.List);
+        options.PragmaWarning.Should().Be(PragmaWarningSetting.NoBlock);
+        options.EnumStringMapSetting.Should().Be(EnumStringMapSetting.Description);
+    }
+
+    /// <summary>
+    /// Test identity deep-copy and pragma warning invalid fallbacks.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void ParsesIdentityDeepCopyAndPragmaWarningInvalidFallbacks()
+    {
+        const string editorConfig = """
+                                    root = true
+
+                                    [*.cs]
+                                    mappa.cultureinfosettings = InvariantCulture
+                                    mappa.identitymapdeepcopy = NotAValidDeepCopy
+                                    mappa.enumerableconcretetype = Array
+                                    mappa.pragmawarning = NotAValidPragma
+                                    mappa.enumstringmapsetting = Undefined
+                                    mappa.enumtoenummapsetting = Description
+                                    """;
+
+        var compilation = BuildCompilation("namespace Mappa.Generator.Tests.UnitTests.SourceCode { internal class Placeholder { } }");
+        var options = new MappaGlobalOptions(
+            TestAnalyzerConfigOptionsProvider.FromEditorConfig(editorConfig),
+            compilation.SyntaxTrees[0]);
+
+        options.CultureInfoSetting.Should().Be(CultureInfoSetting.InvariantCulture);
+        options.IdentityMapDeepCopy.Should().Be(IdentityMapDeepCopySetting.ShallowCopy);
+        options.EnumerableConcreteType.Should().Be(EnumerableConcreteTypeSetting.Array);
+        options.PragmaWarning.Should().Be(PragmaWarningSetting.Undefined);
+        options.EnumStringMapSetting.Should().Be(EnumStringMapSetting.Undefined);
+        options.EnumToEnumMapSetting.Should().Be(EnumToEnumMapSetting.Description);
+
+        const string undefinedIdentityEditorConfig = """
+                                                     root = true
+
+                                                     [*.cs]
+                                                     mappa.identitymapdeepcopy = Undefined
+                                                     """;
+
+        var undefinedIdentityOptions = new MappaGlobalOptions(
+            TestAnalyzerConfigOptionsProvider.FromEditorConfig(undefinedIdentityEditorConfig),
+            compilation.SyntaxTrees[0]);
+        undefinedIdentityOptions.IdentityMapDeepCopy.Should().Be(IdentityMapDeepCopySetting.Undefined);
+    }
 }

--- a/Mappa.Generator.Tests/MappaTypeMappingDefaultAttributeExtensionsTests.cs
+++ b/Mappa.Generator.Tests/MappaTypeMappingDefaultAttributeExtensionsTests.cs
@@ -1,0 +1,155 @@
+// <copyright file="MappaTypeMappingDefaultAttributeExtensionsTests.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using Mappa.Attributes;
+using Mappa.Generator.Exceptions;
+using Mappa.Generator.Extensions;
+using Mappa.Generator.Tests.Abstractions;
+
+using Microsoft.CodeAnalysis;
+
+namespace Mappa.Generator.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="MappaTypeMappingDefaultAttributeExtensions"/>.
+/// </summary>
+public sealed class MappaTypeMappingDefaultAttributeExtensionsTests
+    : MappaGeneratorAbstractUnitTests
+{
+    /// <summary>
+    /// Test <see cref="MappaTypeMappingDefaultAttributeExtensions.IsValid"/> throws when
+    /// <see cref="MappaTypeMappingDefaultBehavior.Throw"/> references a type missing from the compilation.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void IsValidThrowBehaviorThrowsWhenExceptionTypeCannotBeLoaded()
+    {
+        var (compilation, sourceType, targetType, parentClass) = CreateMinimalSymbols();
+        var attribute = new MappaTypeMappingDefaultAttribute(
+            MappaTypeMappingDefaultBehavior.Throw,
+            typeof(MappaTypeMappingDefaultAttributeExtensionsTests));
+
+        var act = () => attribute.IsValid(
+            targetType,
+            sourceType,
+            parentClass,
+            nullableEnabled: true,
+            mapMethodHasTwoParameters: false,
+            compilation,
+            location: null,
+            out _,
+            out _);
+
+        act.Should()
+            .Throw<MappaGeneratorException>()
+            .WithMessage($"Type '{typeof(MappaTypeMappingDefaultAttributeExtensionsTests).FullName}' cannot be loaded at compile time.");
+    }
+
+    /// <summary>
+    /// Test <see cref="MappaTypeMappingDefaultAttributeExtensions.IsValid"/> throws when
+    /// <see cref="MappaTypeMappingDefaultBehavior.MapSourceType"/> references a type missing from the compilation.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void IsValidMapSourceTypeBehaviorThrowsWhenTargetTypeCannotBeLoaded()
+    {
+        var (compilation, sourceType, targetType, parentClass) = CreateMinimalSymbols();
+        var attribute = new MappaTypeMappingDefaultAttribute(
+            MappaTypeMappingDefaultBehavior.MapSourceType,
+            typeof(MappaTypeMappingDefaultAttributeExtensionsTests));
+
+        var act = () => attribute.IsValid(
+            targetType,
+            sourceType,
+            parentClass,
+            nullableEnabled: true,
+            mapMethodHasTwoParameters: false,
+            compilation,
+            location: null,
+            out _,
+            out _);
+
+        act.Should()
+            .Throw<MappaGeneratorException>()
+            .WithMessage($"Type '{typeof(MappaTypeMappingDefaultAttributeExtensionsTests).FullName}' cannot be loaded at compile time.");
+    }
+
+    /// <summary>
+    /// Test <see cref="MappaTypeMappingDefaultAttributeExtensions.IsValid"/> throws when
+    /// <see cref="MappaTypeMappingDefaultBehavior.InvokeMethod"/> references a declaring type missing from the compilation.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void IsValidInvokeMethodBehaviorThrowsWhenDeclaringTypeCannotBeLoaded()
+    {
+        var (compilation, sourceType, targetType, parentClass) = CreateMinimalSymbols();
+        var attribute = new MappaTypeMappingDefaultAttribute(
+            typeof(MappaTypeMappingDefaultAttributeExtensionsTests),
+            "MapDefault");
+
+        var act = () => attribute.IsValid(
+            targetType,
+            sourceType,
+            parentClass,
+            nullableEnabled: true,
+            mapMethodHasTwoParameters: false,
+            compilation,
+            location: null,
+            out _,
+            out _);
+
+        act.Should()
+            .Throw<MappaGeneratorException>()
+            .WithMessage("Type that can be used to identify the method to invoke cannot be loaded.");
+    }
+
+    /// <summary>
+    /// Test <see cref="MappaTypeMappingDefaultAttributeExtensions.IsValid"/> throws for an unsupported behavior value.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void IsValidThrowsForUnsupportedBehavior()
+    {
+        var (compilation, sourceType, targetType, parentClass) = CreateMinimalSymbols();
+        var attribute = new MappaTypeMappingDefaultAttribute((MappaTypeMappingDefaultBehavior)999);
+
+        var act = () => attribute.IsValid(
+            targetType,
+            sourceType,
+            parentClass,
+            nullableEnabled: true,
+            mapMethodHasTwoParameters: false,
+            compilation,
+            location: null,
+            out _,
+            out _);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    private static (Compilation Compilation, ITypeSymbol SourceType, ITypeSymbol TargetType, ITypeSymbol ParentClass) CreateMinimalSymbols()
+    {
+        const string source = """
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              public sealed class Source
+                              {
+                              }
+
+                              public sealed class Target
+                              {
+                              }
+
+                              public sealed class Mapper
+                              {
+                              }
+                              """;
+
+        var compilation = BuildCompilation(source);
+        var sourceType = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.Source")!;
+        var targetType = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.Target")!;
+        var parentClass = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.Mapper")!;
+        return (compilation, sourceType, targetType, parentClass);
+    }
+}

--- a/Mappa.Generator.Tests/TypeSymbolExtensionsTests.cs
+++ b/Mappa.Generator.Tests/TypeSymbolExtensionsTests.cs
@@ -25,10 +25,23 @@ public sealed class TypeSymbolExtensionsTests
     /// <param name="alias">The type alias.</param>
     /// <param name="expected">The expected normalized name.</param>
     [Theory]
+    [InlineData("sbyte", "System.SByte")]
+    [InlineData("short", "System.Int16")]
     [InlineData("int", "System.Int32")]
+    [InlineData("long", "System.Int64")]
+    [InlineData("byte", "System.Byte")]
+    [InlineData("ushort", "System.UInt16")]
+    [InlineData("uint", "System.UInt32")]
+    [InlineData("ulong", "System.UInt64")]
+    [InlineData("float", "System.Single")]
+    [InlineData("double", "System.Double")]
     [InlineData("string", "System.String")]
-    [InlineData("bool", "System.Boolean")]
+    [InlineData("char", "System.Char")]
+    [InlineData("decimal", "System.Decimal")]
+    [InlineData("nint", "System.IntPtr")]
+    [InlineData("nuint", "System.UIntPtr")]
     [InlineData("void", "System.Void")]
+    [InlineData("bool", "System.Boolean")]
     [InlineData("System.DateTime", "System.DateTime")]
     [UnitTest]
     public void NormalizeTypeMapsAliasesToClrNames(string alias, string expected)
@@ -597,5 +610,67 @@ public sealed class TypeSymbolExtensionsTests
 
         success.Should().BeTrue();
         elementType.ToDisplayString().Should().Be("string");
+    }
+
+    /// <summary>
+    /// Test <see cref="TypeSymbolExtensions.TryGetQueryableElementType"/> resolves the element type
+    /// from <see cref="System.Linq.IQueryable{T}"/> via <c>AllInterfaces</c>.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void TryGetQueryableElementTypeReturnsElementTypeFromImplementedInterface()
+    {
+        const string source = """
+                              using System.Linq;
+
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              public interface IMyQueryable<T> : IQueryable<T>
+                              {
+                              }
+
+                              public sealed class Holder
+                              {
+                                  public IMyQueryable<int> Values { get; set; }
+                              }
+                              """;
+
+        var compilation = BuildCompilation(source);
+        var holder = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.Holder")!;
+        var property = holder.GetMembers("Values").OfType<IPropertySymbol>().Single();
+
+        var success = property.Type.TryGetQueryableElementType(compilation, out var elementType);
+
+        success.Should().BeTrue();
+        elementType.ToDisplayString().Should().Be("int");
+    }
+
+    /// <summary>
+    /// Test <see cref="TypeSymbolExtensions.TryGetQueryableElementType"/> returns <c>false</c>
+    /// when the type is not a queryable.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void TryGetQueryableElementTypeReturnsFalseForNonQueryableType()
+    {
+        const string source = """
+                              using System.Collections.Generic;
+
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              public sealed class Holder
+                              {
+                                  public List<string> Values { get; set; }
+                              }
+                              """;
+
+        var compilation = BuildCompilation(source);
+        var holder = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.Holder")!;
+        var property = holder.GetMembers("Values").OfType<IPropertySymbol>().Single();
+
+        var success = property.Type.TryGetQueryableElementType(compilation, out var elementType);
+
+        success.Should().BeFalse();
+        elementType.Should().BeNull();
     }
 }

--- a/Mappa.Generator/Algorithm/EnumMapConfigurationResolver.cs
+++ b/Mappa.Generator/Algorithm/EnumMapConfigurationResolver.cs
@@ -352,41 +352,65 @@ internal sealed class EnumMapConfigurationResolver
         {
             if (this.legKind is EnumMapLegKind.EnumToEnum)
             {
-                this.TryGetEnumToEnumPair(memberAttribute, out var sourceMemberName, out var targetMemberName);
-                if (this.sourceEnumType is { } activeSourceEnumType
-                    && ignoredSourceMemberNames.Contains(sourceMemberName))
-                {
-                    isValid = false;
-                    this.ReportIgnoreConflict(activeSourceEnumType, sourceMemberName);
-                }
-
-                if (this.targetEnumType is { } activeTargetEnumType
-                    && ignoredTargetMemberNames.Contains(targetMemberName))
-                {
-                    isValid = false;
-                    this.ReportIgnoreConflict(activeTargetEnumType, targetMemberName);
-                }
-
+                isValid &= this.ValidateEnumToEnumIgnoreConflict(
+                    memberAttribute,
+                    ignoredSourceMemberNames,
+                    ignoredTargetMemberNames);
                 continue;
             }
 
-            if (this.sourceEnumType is { } sourceOnlyEnumType
-                && (ignoredSourceMemberNames.Contains(memberAttribute.EnumMemberName)
-                    || ignoredTargetMemberNames.Contains(memberAttribute.EnumMemberName)))
-            {
-                isValid = false;
-                this.ReportIgnoreConflict(sourceOnlyEnumType, memberAttribute.EnumMemberName);
-            }
-            else if (this.targetEnumType is { } targetOnlyEnumType
-                     && (ignoredSourceMemberNames.Contains(memberAttribute.EnumMemberName)
-                         || ignoredTargetMemberNames.Contains(memberAttribute.EnumMemberName)))
-            {
-                isValid = false;
-                this.ReportIgnoreConflict(targetOnlyEnumType, memberAttribute.EnumMemberName);
-            }
+            isValid &= this.ValidateSingleEnumIgnoreConflict(memberAttribute, ignoredSourceMemberNames, ignoredTargetMemberNames);
         }
 
         return isValid;
+    }
+
+    private bool ValidateEnumToEnumIgnoreConflict(
+        EnumMapMemberInfoAttribute memberAttribute,
+        HashSet<string> ignoredSourceMemberNames,
+        HashSet<string> ignoredTargetMemberNames)
+    {
+        var isValid = true;
+        this.TryGetEnumToEnumPair(memberAttribute, out var sourceMemberName, out var targetMemberName);
+        if (this.sourceEnumType is { } activeSourceEnumType
+            && ignoredSourceMemberNames.Contains(sourceMemberName))
+        {
+            isValid = false;
+            this.ReportIgnoreConflict(activeSourceEnumType, sourceMemberName);
+        }
+
+        if (this.targetEnumType is { } activeTargetEnumType
+            && ignoredTargetMemberNames.Contains(targetMemberName))
+        {
+            isValid = false;
+            this.ReportIgnoreConflict(activeTargetEnumType, targetMemberName);
+        }
+
+        return isValid;
+    }
+
+    private bool ValidateSingleEnumIgnoreConflict(
+        EnumMapMemberInfoAttribute memberAttribute,
+        HashSet<string> ignoredSourceMemberNames,
+        HashSet<string> ignoredTargetMemberNames)
+    {
+        if (this.sourceEnumType is { } sourceOnlyEnumType
+            && (ignoredSourceMemberNames.Contains(memberAttribute.EnumMemberName)
+                || ignoredTargetMemberNames.Contains(memberAttribute.EnumMemberName)))
+        {
+            this.ReportIgnoreConflict(sourceOnlyEnumType, memberAttribute.EnumMemberName);
+            return false;
+        }
+
+        if (this.targetEnumType is { } targetOnlyEnumType
+            && (ignoredSourceMemberNames.Contains(memberAttribute.EnumMemberName)
+                || ignoredTargetMemberNames.Contains(memberAttribute.EnumMemberName)))
+        {
+            this.ReportIgnoreConflict(targetOnlyEnumType, memberAttribute.EnumMemberName);
+            return false;
+        }
+
+        return true;
     }
 
     private bool TryResolveDefault(

--- a/Mappa.Generator/Algorithm/MappaDependencyInjectionGeneratorAlgorithm.cs
+++ b/Mappa.Generator/Algorithm/MappaDependencyInjectionGeneratorAlgorithm.cs
@@ -145,52 +145,76 @@ internal sealed class MappaDependencyInjectionGeneratorAlgorithm
         {
             foreach (var type in assembly.GetAllNamedTypes())
             {
-                if (SymbolEqualityComparer.Default.Equals(type, registrarClass))
-                {
-                    continue;
-                }
-
-                if (attributeData.IsIgnored(type))
-                {
-                    continue;
-                }
-
-                if (!type.GetAttributes().HasMappaAttribute(this.Compilation))
-                {
-                    continue;
-                }
-
-                // Static mapper classes cannot be registered with Microsoft.Extensions.DependencyInjection.
-                if (type.IsStatic)
-                {
-                    this.Context.ReportDiagnostic(
-                        MappaDiagnostics.MappaDependencyInjectionStaticMapperSkipped(
-                            classDeclarationSyntax,
-                            type.ToDisplayString()));
-                    continue;
-                }
-
-                var interfaces = GetEligibleInterfaces(type, attributeData);
-                switch (attributeData.InjectInterfaces)
-                {
-                    case MappaDependencyInjectionInjectInterfaces.InterfaceOnly:
-                    case MappaDependencyInjectionInjectInterfaces.InterfaceAndClass:
-                        if (interfaces.IsDefaultOrEmpty)
-                        {
-                            this.Context.ReportDiagnostic(
-                                MappaDiagnostics.MappaDependencyInjectionMapperHasNoEligibleInterfaces(
-                                    classDeclarationSyntax,
-                                    type.ToDisplayString()));
-                            continue;
-                        }
-
-                        break;
-                }
-
-                results.Add((type, interfaces));
+                this.TryAddDiscoveredMapper(type, registrarClass, attributeData, classDeclarationSyntax, results);
             }
         }
 
         return [.. results];
+    }
+
+    private void TryAddDiscoveredMapper(
+        INamedTypeSymbol type,
+        INamedTypeSymbol registrarClass,
+        MappaDependencyInjectionAttributeData attributeData,
+        ClassDeclarationSyntax classDeclarationSyntax,
+        List<(INamedTypeSymbol Mapper, ImmutableArray<INamedTypeSymbol> Interfaces)> results)
+    {
+        if (SymbolEqualityComparer.Default.Equals(type, registrarClass))
+        {
+            return;
+        }
+
+        if (attributeData.IsIgnored(type))
+        {
+            return;
+        }
+
+        if (!type.GetAttributes().HasMappaAttribute(this.Compilation))
+        {
+            return;
+        }
+
+        // Static mapper classes cannot be registered with Microsoft.Extensions.DependencyInjection.
+        if (type.IsStatic)
+        {
+            this.Context.ReportDiagnostic(
+                MappaDiagnostics.MappaDependencyInjectionStaticMapperSkipped(
+                    classDeclarationSyntax,
+                    type.ToDisplayString()));
+            return;
+        }
+
+        var interfaces = GetEligibleInterfaces(type, attributeData);
+        if (!this.HasRequiredEligibleInterfaces(attributeData, type, interfaces, classDeclarationSyntax))
+        {
+            return;
+        }
+
+        results.Add((type, interfaces));
+    }
+
+    private bool HasRequiredEligibleInterfaces(
+        MappaDependencyInjectionAttributeData attributeData,
+        INamedTypeSymbol type,
+        ImmutableArray<INamedTypeSymbol> interfaces,
+        ClassDeclarationSyntax classDeclarationSyntax)
+    {
+        switch (attributeData.InjectInterfaces)
+        {
+            case MappaDependencyInjectionInjectInterfaces.InterfaceOnly:
+            case MappaDependencyInjectionInjectInterfaces.InterfaceAndClass:
+                if (interfaces.IsDefaultOrEmpty)
+                {
+                    this.Context.ReportDiagnostic(
+                        MappaDiagnostics.MappaDependencyInjectionMapperHasNoEligibleInterfaces(
+                            classDeclarationSyntax,
+                            type.ToDisplayString()));
+                    return false;
+                }
+
+                break;
+        }
+
+        return true;
     }
 }

--- a/Mappa.Generator/Algorithm/MappaGeneratorClassAlgorithm.cs
+++ b/Mappa.Generator/Algorithm/MappaGeneratorClassAlgorithm.cs
@@ -95,6 +95,23 @@ internal sealed class MappaGeneratorClassAlgorithm
         }
     }
 
+    private static bool IsMapMethodIgnored(
+        MethodDeclarationSyntax methodDeclarationSyntax,
+        MappaClassGeneratorContext classContext,
+        CancellationToken cancellationToken)
+        => methodDeclarationSyntax.AttributeLists
+            .GetMappaIgnoreAttributeSyntax(classContext.SemanticModel, cancellationToken) is not null;
+
+    private static MapMethod CreateMapMethodFromDeclaration(
+        MethodDeclarationSyntax methodDeclarationSyntax,
+        MappaClassGeneratorContext classContext,
+        CancellationToken cancellationToken)
+        => new(
+            methodDeclarationSyntax,
+            classContext.SemanticModel,
+            classContext.IsNullableEnabled(methodDeclarationSyntax),
+            cancellationToken);
+
     private void GenerateStrategyForEachMethod(
         MappaClassGeneratorContext classContext,
         MappaUserSettings mappaUserSettings,
@@ -191,7 +208,20 @@ internal sealed class MappaGeneratorClassAlgorithm
             return;
         }
 
-        // Gather all the methods that require a mapping.
+        this.CollectMapMethodsFromClassDeclarations(classDeclarationSyntax, classContext, mappaDebug, cancellationToken);
+        this.CollectMapMethodsFromTypeHierarchy(classDeclarationSyntax, classContext, cancellationToken);
+        this.CollectMapMethodsFromStaticDependencies(classContext);
+        this.CollectMapMethodsFromMappaDependencies(classDeclarationSyntax, classContext, cancellationToken);
+        this.IdentifyStrategiesAndGenerateSource(classContext, options, cancellationToken);
+        this.ReportAllDiagnostics(classContext);
+    }
+
+    private void CollectMapMethodsFromClassDeclarations(
+        ClassDeclarationSyntax classDeclarationSyntax,
+        MappaClassGeneratorContext classContext,
+        MappaDebug mappaDebug,
+        CancellationToken cancellationToken)
+    {
         foreach (var methodDeclarationSyntax in classDeclarationSyntax.ChildNodes().OfType<MethodDeclarationSyntax>())
         {
             mappaDebug.Debug(
@@ -207,8 +237,13 @@ internal sealed class MappaGeneratorClassAlgorithm
                 this.AcceptMapMethodAlreadyMapped(methodDeclarationSyntax, classContext, cancellationToken);
             }
         }
+    }
 
-        // List methods also from base classes of the mapper.
+    private void CollectMapMethodsFromTypeHierarchy(
+        ClassDeclarationSyntax classDeclarationSyntax,
+        MappaClassGeneratorContext classContext,
+        CancellationToken cancellationToken)
+    {
         foreach (var method in this.Compilation.GetMethodsInTypeHierarchyFromMetadata(classContext.ClassSymbol))
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -223,8 +258,10 @@ internal sealed class MappaGeneratorClassAlgorithm
                 canBeInvokedByStaticMethod: method.IsStatic,
                 classContext);
         }
+    }
 
-        // Get all the static types on the class listed as static dependencies
+    private void CollectMapMethodsFromStaticDependencies(MappaClassGeneratorContext classContext)
+    {
         foreach (var dependencyType in classContext
                      .ClassSymbol
                      .GetAttributes()
@@ -235,7 +272,6 @@ internal sealed class MappaGeneratorClassAlgorithm
             var accessFieldName = $"global::{dependencyType.ToDisplayString()}";
             foreach (var method in methods)
             {
-                // Skip non-static methods
                 if (!method.IsStatic)
                 {
                     continue;
@@ -256,34 +292,60 @@ internal sealed class MappaGeneratorClassAlgorithm
                 this.Context.ReportDiagnostic(MappaDiagnostics.DependencyDoesNotProvideAnyViableMethod(classContext.ClassDeclarationSyntax, dependencyType.ToDisplayString()));
             }
         }
+    }
 
-        // Get all accessible properties that:
-        // - have a getter method
-        // - have MappaDependency attribute
+    private void CollectMapMethodsFromMappaDependencies(
+        ClassDeclarationSyntax classDeclarationSyntax,
+        MappaClassGeneratorContext classContext,
+        CancellationToken cancellationToken)
+    {
         var processedDependencyMemberNames = new HashSet<string>(StringComparer.Ordinal);
+        this.CollectMapMethodsFromMappaDependencyProperties(
+            classDeclarationSyntax,
+            classContext,
+            processedDependencyMemberNames,
+            cancellationToken);
+        this.CollectMapMethodsFromMappaDependencyFields(
+            classDeclarationSyntax,
+            classContext,
+            processedDependencyMemberNames,
+            cancellationToken);
+    }
+
+    private void CollectMapMethodsFromMappaDependencyProperties(
+        ClassDeclarationSyntax classDeclarationSyntax,
+        MappaClassGeneratorContext classContext,
+        HashSet<string> processedDependencyMemberNames,
+        CancellationToken cancellationToken)
+    {
 #pragma warning disable S3267 // Loops should be simplified using the "Where" LINQ method
         foreach (var propertyDeclarationSyntax in classDeclarationSyntax.ChildNodes().OfType<PropertyDeclarationSyntax>())
 #pragma warning restore S3267 // Loops should be simplified using the "Where" LINQ method
         {
-            if (propertyDeclarationSyntax.AccessorList is not null && propertyDeclarationSyntax.AccessorList.Accessors.Any(accessor => accessor.Kind() == SyntaxKind.GetAccessorDeclaration))
+            if (propertyDeclarationSyntax.AccessorList is null
+                || !propertyDeclarationSyntax.AccessorList.Accessors.Any(accessor => accessor.Kind() == SyntaxKind.GetAccessorDeclaration))
             {
-                if (propertyDeclarationSyntax.AttributeLists.GetMappaDependencyAttributeSyntax(classContext.SemanticModel, cancellationToken) is null)
-                {
-                    continue;
-                }
-
-                var propertySymbol = classContext.SemanticModel.GetDeclaredSymbol(propertyDeclarationSyntax, cancellationToken);
-                if (propertySymbol is not null)
-                {
-                    var propertyIdentifier = propertyDeclarationSyntax.Identifier.ToString();
-                    processedDependencyMemberNames.Add(propertyIdentifier);
-                    this.ProcessMappaDependencyProperty(
-                        propertyDeclarationSyntax,
-                        propertySymbol,
-                        propertyIdentifier,
-                        classContext);
-                }
+                continue;
             }
+
+            if (propertyDeclarationSyntax.AttributeLists.GetMappaDependencyAttributeSyntax(classContext.SemanticModel, cancellationToken) is null)
+            {
+                continue;
+            }
+
+            var propertySymbol = classContext.SemanticModel.GetDeclaredSymbol(propertyDeclarationSyntax, cancellationToken);
+            if (propertySymbol is null)
+            {
+                continue;
+            }
+
+            var propertyIdentifier = propertyDeclarationSyntax.Identifier.ToString();
+            processedDependencyMemberNames.Add(propertyIdentifier);
+            this.ProcessMappaDependencyProperty(
+                propertyDeclarationSyntax,
+                propertySymbol,
+                propertyIdentifier,
+                classContext);
         }
 
         foreach (var propertySymbol in this.Compilation.GetMappaDependencyPropertiesInMapperBaseTypeHierarchy(classContext.ClassSymbol))
@@ -301,8 +363,14 @@ internal sealed class MappaGeneratorClassAlgorithm
                 propertySymbol.Name,
                 classContext);
         }
+    }
 
-        // Get all accessible fields that have MappaDependency attribute
+    private void CollectMapMethodsFromMappaDependencyFields(
+        ClassDeclarationSyntax classDeclarationSyntax,
+        MappaClassGeneratorContext classContext,
+        HashSet<string> processedDependencyMemberNames,
+        CancellationToken cancellationToken)
+    {
         foreach (var fieldDeclarationSyntax in classDeclarationSyntax.ChildNodes().OfType<FieldDeclarationSyntax>())
         {
             if (fieldDeclarationSyntax.AttributeLists.GetMappaDependencyAttributeSyntax(classContext.SemanticModel, cancellationToken) is null)
@@ -343,7 +411,13 @@ internal sealed class MappaGeneratorClassAlgorithm
                 fieldSymbol.Name,
                 classContext);
         }
+    }
 
+    private void IdentifyStrategiesAndGenerateSource(
+        MappaClassGeneratorContext classContext,
+        MappaGlobalOptions options,
+        CancellationToken cancellationToken)
+    {
         var classAttributes = classContext.ClassSymbol.GetAttributes();
         var classBeforeMapAttributes = classAttributes.GetMappaBeforeMapAttributes(this.Compilation);
         var classAfterMapAttributes = classAttributes.GetMappaAfterMapAttributes(this.Compilation);
@@ -369,9 +443,6 @@ internal sealed class MappaGeneratorClassAlgorithm
 
         // Build the source code (only if there is something to generate)
         this.GenerateSourceCode(classContext, options);
-
-        // Report the diagnostics.
-        this.ReportAllDiagnostics(classContext);
     }
 
     private void ReportAllDiagnostics(MappaClassGeneratorContext classContext)
@@ -404,8 +475,7 @@ internal sealed class MappaGeneratorClassAlgorithm
         MappaClassGeneratorContext classContext,
         CancellationToken cancellationToken)
     {
-        if (methodDeclarationSyntax.AttributeLists
-            .GetMappaIgnoreAttributeSyntax(classContext.SemanticModel, cancellationToken) is not null)
+        if (IsMapMethodIgnored(methodDeclarationSyntax, classContext, cancellationToken))
         {
             return false;
         }
@@ -421,38 +491,9 @@ internal sealed class MappaGeneratorClassAlgorithm
             return false;
         }
 
-        var mapMethod = new MapMethod(
-            methodDeclarationSyntax,
-            classContext.SemanticModel,
-            classContext.IsNullableEnabled(methodDeclarationSyntax),
-            cancellationToken);
-        var methodSymbol = mapMethod.MethodSymbol;
-        if (methodSymbol is null)
+        var mapMethod = CreateMapMethodFromDeclaration(methodDeclarationSyntax, classContext, cancellationToken);
+        if (!this.ValidateMapMethodSymbolForAccept(methodDeclarationSyntax, mapMethod, classContext, reportDiagnostics: true))
         {
-            throw new MappaGeneratorException($"Cannot obtain the method symbol for method \"{methodDeclarationSyntax.Identifier}\".", methodDeclarationSyntax.GetLocation());
-        }
-
-        if (methodDeclarationSyntax.HasArity(2)
-            && !methodSymbol.SecondParameterIsMappaContext(this.Compilation))
-        {
-            classContext.ReportDiagnostic(MappaDiagnostics.MethodHasInvalidMappaContextParameter(methodDeclarationSyntax));
-            return false;
-        }
-
-        if (!methodSymbol.AreParametersRefModifiersValid())
-        {
-            return false;
-        }
-
-        if (methodSymbol.IsVoid())
-        {
-            classContext.ReportDiagnostic(MappaDiagnostics.MethodIsVoid(methodDeclarationSyntax));
-            return false;
-        }
-
-        if (methodSymbol.ReturnsAnyTaskType(this.Compilation))
-        {
-            classContext.ReportDiagnostic(MappaDiagnostics.MethodReturnsTaskType(methodDeclarationSyntax));
             return false;
         }
 
@@ -540,45 +581,7 @@ internal sealed class MappaGeneratorClassAlgorithm
         bool canBeInvokedByStaticMethod,
         MappaClassGeneratorContext classContext)
     {
-        var methodAttributes = method.GetAttributes();
-        if (methodAttributes.GetMappaIgnoreAttribute(this.Compilation) is not null)
-        {
-            return false;
-        }
-
-        if (!this.Compilation.IsSymbolAccessibleWithin(method, classContext.ClassSymbol))
-        {
-            return false;
-        }
-
-        if (method.IsStatic != methodMustBeStatic)
-        {
-            return false;
-        }
-
-        if (method.Parameters.Length != 1
-            && method.Parameters.Length != 2)
-        {
-            return false;
-        }
-
-        if (method.Parameters.Length == 2
-            && !method.SecondParameterIsMappaContext(this.Compilation))
-        {
-            return false;
-        }
-
-        if (!method.AreParametersRefModifiersValid())
-        {
-            return false;
-        }
-
-        if (method.IsVoid())
-        {
-            return false;
-        }
-
-        if (method.ReturnsAnyTaskType(this.Compilation))
+        if (!this.IsViableDependencyMapMethod(method, classContext, methodMustBeStatic))
         {
             return false;
         }
@@ -604,8 +607,7 @@ internal sealed class MappaGeneratorClassAlgorithm
         MappaClassGeneratorContext classContext,
         CancellationToken cancellationToken)
     {
-        if (methodDeclarationSyntax.AttributeLists
-                .GetMappaIgnoreAttributeSyntax(classContext.SemanticModel, cancellationToken) is not null)
+        if (IsMapMethodIgnored(methodDeclarationSyntax, classContext, cancellationToken))
         {
             return;
         }
@@ -620,34 +622,8 @@ internal sealed class MappaGeneratorClassAlgorithm
             return;
         }
 
-        var mapMethod = new MapMethod(
-            methodDeclarationSyntax,
-            classContext.SemanticModel,
-            classContext.IsNullableEnabled(methodDeclarationSyntax),
-            cancellationToken);
-        var methodSymbol = mapMethod.MethodSymbol;
-        if (methodSymbol is null)
-        {
-            throw new MappaGeneratorException($"Cannot obtain the method symbol for method \"{methodDeclarationSyntax.Identifier}\".", methodDeclarationSyntax.GetLocation());
-        }
-
-        if (methodDeclarationSyntax.HasArity(2)
-            && !methodSymbol.SecondParameterIsMappaContext(this.Compilation))
-        {
-            return;
-        }
-
-        if (!methodSymbol.AreParametersRefModifiersValid())
-        {
-            return;
-        }
-
-        if (methodSymbol.IsVoid())
-        {
-            return;
-        }
-
-        if (methodSymbol.ReturnsAnyTaskType(this.Compilation))
+        var mapMethod = CreateMapMethodFromDeclaration(methodDeclarationSyntax, classContext, cancellationToken);
+        if (!this.ValidateMapMethodSymbolForAccept(methodDeclarationSyntax, mapMethod, classContext, reportDiagnostics: false))
         {
             return;
         }
@@ -657,5 +633,141 @@ internal sealed class MappaGeneratorClassAlgorithm
         {
             mapMethod.MarkMapped();
         }
+    }
+
+    private bool ValidateMapMethodSymbolForAccept(
+        MethodDeclarationSyntax methodDeclarationSyntax,
+        MapMethod mapMethod,
+        MappaClassGeneratorContext classContext,
+        bool reportDiagnostics)
+    {
+        var methodSymbol = mapMethod.MethodSymbol;
+        if (methodSymbol is null)
+        {
+            throw new MappaGeneratorException($"Cannot obtain the method symbol for method \"{methodDeclarationSyntax.Identifier}\".", methodDeclarationSyntax.GetLocation());
+        }
+
+        if (!this.ValidateMapMethodMappaContextParameter(methodDeclarationSyntax, methodSymbol, classContext, reportDiagnostics))
+        {
+            return false;
+        }
+
+        if (!methodSymbol.AreParametersRefModifiersValid())
+        {
+            return false;
+        }
+
+        if (!this.ValidateMapMethodReturnType(methodDeclarationSyntax, methodSymbol, classContext, reportDiagnostics))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool ValidateMapMethodMappaContextParameter(
+        MethodDeclarationSyntax methodDeclarationSyntax,
+        IMethodSymbol methodSymbol,
+        MappaClassGeneratorContext classContext,
+        bool reportDiagnostics)
+    {
+        if (!methodDeclarationSyntax.HasArity(2)
+            || methodSymbol.SecondParameterIsMappaContext(this.Compilation))
+        {
+            return true;
+        }
+
+        if (reportDiagnostics)
+        {
+            classContext.ReportDiagnostic(MappaDiagnostics.MethodHasInvalidMappaContextParameter(methodDeclarationSyntax));
+        }
+
+        return false;
+    }
+
+    private bool ValidateMapMethodReturnType(
+        MethodDeclarationSyntax methodDeclarationSyntax,
+        IMethodSymbol methodSymbol,
+        MappaClassGeneratorContext classContext,
+        bool reportDiagnostics)
+    {
+        if (methodSymbol.IsVoid())
+        {
+            if (reportDiagnostics)
+            {
+                classContext.ReportDiagnostic(MappaDiagnostics.MethodIsVoid(methodDeclarationSyntax));
+            }
+
+            return false;
+        }
+
+        if (methodSymbol.ReturnsAnyTaskType(this.Compilation))
+        {
+            if (reportDiagnostics)
+            {
+                classContext.ReportDiagnostic(MappaDiagnostics.MethodReturnsTaskType(methodDeclarationSyntax));
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool IsViableDependencyMapMethod(
+        IMethodSymbol method,
+        MappaClassGeneratorContext classContext,
+        bool methodMustBeStatic)
+    {
+        if (!this.PassesDependencyMapMethodBasicChecks(method, classContext, methodMustBeStatic))
+        {
+            return false;
+        }
+
+        if (!method.AreParametersRefModifiersValid())
+        {
+            return false;
+        }
+
+        if (method.IsVoid())
+        {
+            return false;
+        }
+
+        return !method.ReturnsAnyTaskType(this.Compilation);
+    }
+
+    private bool PassesDependencyMapMethodBasicChecks(
+        IMethodSymbol method,
+        MappaClassGeneratorContext classContext,
+        bool methodMustBeStatic)
+    {
+        if (method.GetAttributes().GetMappaIgnoreAttribute(this.Compilation) is not null)
+        {
+            return false;
+        }
+
+        if (!this.Compilation.IsSymbolAccessibleWithin(method, classContext.ClassSymbol))
+        {
+            return false;
+        }
+
+        if (method.IsStatic != methodMustBeStatic)
+        {
+            return false;
+        }
+
+        if (method.Parameters.Length is not (1 or 2))
+        {
+            return false;
+        }
+
+        if (method.Parameters.Length == 2
+            && !method.SecondParameterIsMappaContext(this.Compilation))
+        {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/Mappa.Generator/Algorithm/ProjectionCapabilityAnalyzer.cs
+++ b/Mappa.Generator/Algorithm/ProjectionCapabilityAnalyzer.cs
@@ -17,6 +17,31 @@ namespace Mappa.Generator.Algorithm;
 /// </summary>
 internal static class ProjectionCapabilityAnalyzer
 {
+    private static readonly Type[] BuiltInTranslatableStrategyTypes =
+    [
+        typeof(EnumToIntegralMapStrategy),
+        typeof(IntegralToEnumMapStrategy),
+        typeof(InvokeParseMethodMapStrategy),
+        typeof(InvokeToStringMapStrategy),
+        typeof(InvokeParseStringWithFormatMapStrategy),
+        typeof(InvokeParseStringWithFormatForDateOnlyAndTimeOnlyMapStrategy),
+        typeof(StringToNumberMapStrategy),
+        typeof(StringToUriMapStrategy),
+        typeof(DateOnlyToDateTimeMapStrategy),
+        typeof(DateOnlyToLongMapStrategy),
+        typeof(DateTimeOffsetToDateOnlyMapStrategy),
+        typeof(DateTimeOffsetToDateTimeMapStrategy),
+        typeof(DateTimeOffsetToLongMapStrategy),
+        typeof(DateTimeOffsetToTimeOnlyMapStrategy),
+        typeof(DateTimeToDateOnlyMapStrategy),
+        typeof(DateTimeToTimeOnlyMapStrategy),
+        typeof(DateTimeToLongMapStrategy),
+        typeof(DoubleToTimeSpanMapStrategy),
+        typeof(LongToDateTimeMapStrategy),
+        typeof(LongToDateTimeOffsetMapStrategy),
+        typeof(TimeSpanToDoubleMapStrategy),
+    ];
+
     private enum AnalysisFailureKind
     {
         UnsupportedConstruct,
@@ -69,114 +94,259 @@ internal static class ProjectionCapabilityAnalyzer
         failureMember = null;
         normalizedStrategy = strategy;
 
-        if (analysisContext is not null
-            && ReferenceHandlingCodeGenerator.IsReferenceHandlingRequested(analysisContext.AlgorithmContext.MappaUserSettings))
+        if (!PassesReferenceHandlingGuard(analysisContext, out failureKind, out failureMember))
         {
-            failureKind = AnalysisFailureKind.UnsupportedConstruct;
-            failureMember = "reference handling";
             return false;
         }
 
-        switch (strategy)
+        return TryAnalyzeKnownStrategy(
+            strategy,
+            analysisContext,
+            out normalizedStrategy,
+            out failureKind,
+            out failureMember);
+    }
+
+    private static bool PassesReferenceHandlingGuard(
+        ProjectionCapabilityAnalysisContext? analysisContext,
+        out AnalysisFailureKind? failureKind,
+        out string? failureMember)
+    {
+        failureKind = null;
+        failureMember = null;
+        if (analysisContext is null
+            || !ReferenceHandlingCodeGenerator.IsReferenceHandlingRequested(analysisContext.AlgorithmContext.MappaUserSettings))
         {
-            case IdentityMapStrategy identityMapStrategy:
-                return IsIdentitySupported(identityMapStrategy);
-
-            case NullableStrategy nullableStrategy:
-                if (!TryAnalyzeCore(
-                        nullableStrategy.ElementStrategy,
-                        analysisContext,
-                        out var normalizedElementStrategy,
-                        out failureKind,
-                        out failureMember))
-                {
-                    return false;
-                }
-
-                normalizedStrategy = new NullableStrategy(
-                    nullableStrategy.TargetType,
-                    nullableStrategy.SourceType,
-                    normalizedElementStrategy);
-                return true;
-
-            case InvokeConstructorMapStrategy invokeConstructorMapStrategy:
-                return TryAnalyzeConstructor(invokeConstructorMapStrategy, analysisContext, out normalizedStrategy, out failureKind, out failureMember);
-
-            case InvokeObjectFactoryMapStrategy invokeObjectFactoryMapStrategy:
-                failureKind = AnalysisFailureKind.InvokeMethodNotInlinable;
-                failureMember = invokeObjectFactoryMapStrategy.ObjectFactory.Method.Name;
-                return false;
-
-            case ParameterMapStrategy parameterMapStrategy:
-                if (!TryAnalyzeCore(
-                        parameterMapStrategy.ParameterStrategy,
-                        analysisContext,
-                        out var normalizedParameterStrategy,
-                        out failureKind,
-                        out failureMember))
-                {
-                    return false;
-                }
-
-                normalizedStrategy = new ParameterMapStrategy(
-                    parameterMapStrategy.TargetParameter,
-                    parameterMapStrategy.SourceProperty,
-                    normalizedParameterStrategy,
-                    parameterMapStrategy.RequiresUnsafeAccessorOnSource);
-                return true;
-
-            case PropertyMapStrategy propertyMapStrategy:
-                return TryAnalyzeProperty(propertyMapStrategy, analysisContext, out normalizedStrategy, out failureKind, out failureMember);
-
-            case MethodMapStrategy methodMapStrategy:
-                return TryAnalyzeMethodMap(methodMapStrategy, analysisContext, out normalizedStrategy, out failureKind, out failureMember);
-
-            case MappaInvokeMethodAttributeStrategy mappaInvokeMethodAttributeStrategy:
-                return TryAnalyzeInvokeMethodAttribute(mappaInvokeMethodAttributeStrategy, analysisContext, out normalizedStrategy, out failureKind, out failureMember);
-
-            case EnumToEnumMapStrategy enumToEnumMapStrategy:
-                TryReportEnumWarning(enumToEnumMapStrategy.EnumToEnumMapSetting, enumToEnumMapStrategy.CaseInsensitiveEnumMap, analysisContext);
-                return true;
-
-            case EnumToStringMapStrategy enumToStringMapStrategy:
-                TryReportEnumStringWarning(
-                    enumToStringMapStrategy.EnumStringMapSetting,
-                    analysisContext?.AlgorithmContext.MappaUserSettings.CaseInsensitiveEnumMap ?? BooleanSetting.Undefined,
-                    analysisContext);
-                return true;
-
-            case StringToEnumMapStrategy stringToEnumMapStrategy:
-                TryReportEnumStringWarning(stringToEnumMapStrategy.EnumStringMapSetting, stringToEnumMapStrategy.CaseInsensitiveEnumMap, analysisContext);
-                return true;
-
-            default:
-                return IsBuiltInTranslatableStrategy(strategy)
-                    || TryAnalyzeUnsupported(strategy, out failureKind, out failureMember);
+            return true;
         }
+
+        failureKind = AnalysisFailureKind.UnsupportedConstruct;
+        failureMember = "reference handling";
+        return false;
+    }
+
+    private static bool TryAnalyzeKnownStrategy(
+        MapStrategy strategy,
+        ProjectionCapabilityAnalysisContext? analysisContext,
+        out MapStrategy normalizedStrategy,
+        out AnalysisFailureKind? failureKind,
+        out string? failureMember)
+    {
+        normalizedStrategy = strategy;
+        failureKind = null;
+        failureMember = null;
+
+        if (TryAnalyzeStructuralStrategies(
+                strategy,
+                analysisContext,
+                out normalizedStrategy,
+                out failureKind,
+                out failureMember,
+                out var handled))
+        {
+            return handled;
+        }
+
+        if (TryAnalyzeEnumStrategies(strategy, analysisContext))
+        {
+            return true;
+        }
+
+        return IsBuiltInTranslatableStrategy(strategy)
+            || TryAnalyzeUnsupported(strategy, out failureKind, out failureMember);
+    }
+
+    private static bool TryAnalyzeStructuralStrategies(
+        MapStrategy strategy,
+        ProjectionCapabilityAnalysisContext? analysisContext,
+        out MapStrategy normalizedStrategy,
+        out AnalysisFailureKind? failureKind,
+        out string? failureMember,
+        out bool handled)
+    {
+        if (TryAnalyzeConstructorLikeStrategies(
+                strategy,
+                analysisContext,
+                out normalizedStrategy,
+                out failureKind,
+                out failureMember,
+                out handled))
+        {
+            return true;
+        }
+
+        return TryAnalyzeMemberStrategies(
+            strategy,
+            analysisContext,
+            out normalizedStrategy,
+            out failureKind,
+            out failureMember,
+            out handled);
+    }
+
+    private static bool TryAnalyzeConstructorLikeStrategies(
+        MapStrategy strategy,
+        ProjectionCapabilityAnalysisContext? analysisContext,
+        out MapStrategy normalizedStrategy,
+        out AnalysisFailureKind? failureKind,
+        out string? failureMember,
+        out bool handled)
+    {
+        normalizedStrategy = strategy;
+        failureKind = null;
+        failureMember = null;
+        handled = false;
+
+        if (strategy is IdentityMapStrategy identityMapStrategy)
+        {
+            handled = IsIdentitySupported(identityMapStrategy);
+            return true;
+        }
+
+        if (strategy is NullableStrategy nullableStrategy)
+        {
+            handled = TryAnalyzeNullableStrategy(nullableStrategy, analysisContext, out normalizedStrategy, out failureKind, out failureMember);
+            return true;
+        }
+
+        if (strategy is InvokeConstructorMapStrategy invokeConstructorMapStrategy)
+        {
+            handled = TryAnalyzeConstructor(invokeConstructorMapStrategy, analysisContext, out normalizedStrategy, out failureKind, out failureMember);
+            return true;
+        }
+
+        if (strategy is InvokeObjectFactoryMapStrategy invokeObjectFactoryMapStrategy)
+        {
+            failureKind = AnalysisFailureKind.InvokeMethodNotInlinable;
+            failureMember = invokeObjectFactoryMapStrategy.ObjectFactory.Method.Name;
+            handled = false;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryAnalyzeMemberStrategies(
+        MapStrategy strategy,
+        ProjectionCapabilityAnalysisContext? analysisContext,
+        out MapStrategy normalizedStrategy,
+        out AnalysisFailureKind? failureKind,
+        out string? failureMember,
+        out bool handled)
+    {
+        normalizedStrategy = strategy;
+        failureKind = null;
+        failureMember = null;
+        handled = false;
+
+        if (strategy is ParameterMapStrategy parameterMapStrategy)
+        {
+            handled = TryAnalyzeParameterStrategy(parameterMapStrategy, analysisContext, out normalizedStrategy, out failureKind, out failureMember);
+            return true;
+        }
+
+        if (strategy is PropertyMapStrategy propertyMapStrategy)
+        {
+            handled = TryAnalyzeProperty(propertyMapStrategy, analysisContext, out normalizedStrategy, out failureKind, out failureMember);
+            return true;
+        }
+
+        if (strategy is MethodMapStrategy methodMapStrategy)
+        {
+            handled = TryAnalyzeMethodMap(methodMapStrategy, analysisContext, out normalizedStrategy, out failureKind, out failureMember);
+            return true;
+        }
+
+        if (strategy is MappaInvokeMethodAttributeStrategy mappaInvokeMethodAttributeStrategy)
+        {
+            handled = TryAnalyzeInvokeMethodAttribute(mappaInvokeMethodAttributeStrategy, analysisContext, out normalizedStrategy, out failureKind, out failureMember);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryAnalyzeEnumStrategies(
+        MapStrategy strategy,
+        ProjectionCapabilityAnalysisContext? analysisContext)
+    {
+        if (strategy is EnumToEnumMapStrategy enumToEnumMapStrategy)
+        {
+            TryReportEnumWarning(enumToEnumMapStrategy.EnumToEnumMapSetting, enumToEnumMapStrategy.CaseInsensitiveEnumMap, analysisContext);
+            return true;
+        }
+
+        if (strategy is EnumToStringMapStrategy enumToStringMapStrategy)
+        {
+            TryReportEnumStringWarning(
+                enumToStringMapStrategy.EnumStringMapSetting,
+                analysisContext?.AlgorithmContext.MappaUserSettings.CaseInsensitiveEnumMap ?? BooleanSetting.Undefined,
+                analysisContext);
+            return true;
+        }
+
+        if (strategy is StringToEnumMapStrategy stringToEnumMapStrategy)
+        {
+            TryReportEnumStringWarning(stringToEnumMapStrategy.EnumStringMapSetting, stringToEnumMapStrategy.CaseInsensitiveEnumMap, analysisContext);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryAnalyzeNullableStrategy(
+        NullableStrategy nullableStrategy,
+        ProjectionCapabilityAnalysisContext? analysisContext,
+        out MapStrategy normalizedStrategy,
+        out AnalysisFailureKind? failureKind,
+        out string? failureMember)
+    {
+        if (!TryAnalyzeCore(
+                nullableStrategy.ElementStrategy,
+                analysisContext,
+                out var normalizedElementStrategy,
+                out failureKind,
+                out failureMember))
+        {
+            normalizedStrategy = nullableStrategy;
+            return false;
+        }
+
+        normalizedStrategy = new NullableStrategy(
+            nullableStrategy.TargetType,
+            nullableStrategy.SourceType,
+            normalizedElementStrategy);
+        return true;
+    }
+
+    private static bool TryAnalyzeParameterStrategy(
+        ParameterMapStrategy parameterMapStrategy,
+        ProjectionCapabilityAnalysisContext? analysisContext,
+        out MapStrategy normalizedStrategy,
+        out AnalysisFailureKind? failureKind,
+        out string? failureMember)
+    {
+        if (!TryAnalyzeCore(
+                parameterMapStrategy.ParameterStrategy,
+                analysisContext,
+                out var normalizedParameterStrategy,
+                out failureKind,
+                out failureMember))
+        {
+            normalizedStrategy = parameterMapStrategy;
+            return false;
+        }
+
+        normalizedStrategy = new ParameterMapStrategy(
+            parameterMapStrategy.TargetParameter,
+            parameterMapStrategy.SourceProperty,
+            normalizedParameterStrategy,
+            parameterMapStrategy.RequiresUnsafeAccessorOnSource);
+        return true;
     }
 
     private static bool IsBuiltInTranslatableStrategy(MapStrategy strategy)
-        => strategy is EnumToIntegralMapStrategy
-            or IntegralToEnumMapStrategy
-            or InvokeParseMethodMapStrategy
-            or InvokeToStringMapStrategy
-            or InvokeParseStringWithFormatMapStrategy
-            or InvokeParseStringWithFormatForDateOnlyAndTimeOnlyMapStrategy
-            or StringToNumberMapStrategy
-            or StringToUriMapStrategy
-            or DateOnlyToDateTimeMapStrategy
-            or DateOnlyToLongMapStrategy
-            or DateTimeOffsetToDateOnlyMapStrategy
-            or DateTimeOffsetToDateTimeMapStrategy
-            or DateTimeOffsetToLongMapStrategy
-            or DateTimeOffsetToTimeOnlyMapStrategy
-            or DateTimeToDateOnlyMapStrategy
-            or DateTimeToTimeOnlyMapStrategy
-            or DateTimeToLongMapStrategy
-            or DoubleToTimeSpanMapStrategy
-            or LongToDateTimeMapStrategy
-            or LongToDateTimeOffsetMapStrategy
-            or TimeSpanToDoubleMapStrategy;
+        => BuiltInTranslatableStrategyTypes.Any(strategyType => strategyType.IsInstanceOfType(strategy));
 
     private static bool TryAnalyzeUnsupported(
         MapStrategy strategy,

--- a/Mappa.Generator/Algorithm/StrategyDetectors/ConstructorMapStrategyDetector.AssignToContext.cs
+++ b/Mappa.Generator/Algorithm/StrategyDetectors/ConstructorMapStrategyDetector.AssignToContext.cs
@@ -1,0 +1,134 @@
+// <copyright file="ConstructorMapStrategyDetector.AssignToContext.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using Mappa.Attributes;
+using Mappa.Generator.Diagnostics;
+using Mappa.Generator.Exceptions;
+using Mappa.Generator.Models;
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Mappa.Generator.Algorithm.StrategyDetectors;
+
+/// <summary>
+/// MappaAssignToContext enrichment for <see cref="ConstructorMapStrategyDetector"/>.
+/// </summary>
+internal sealed partial class ConstructorMapStrategyDetector
+{
+    private static HashSet<string> GetDuplicateAssignToContextKeys(MappaAssignToContextAttribute[] attributes)
+        => new(
+            attributes
+                .GroupBy(attribute => attribute.ContextKey, StringComparer.Ordinal)
+                .Where(group => group.Count() > 1)
+                .Select(group => group.Key),
+            StringComparer.Ordinal);
+
+    private bool TryBuildAssignToContextEnrichment(
+        bool attributesEnabled,
+        out MappaAssignToContextEntry[] entries,
+        out string? contextParameterName)
+    {
+        entries = [];
+        contextParameterName = null;
+
+        if (!attributesEnabled || this.context.MapMethod is null)
+        {
+            return false;
+        }
+
+        var attributes = this.context.MapMethod.GetAttributes<MappaAssignToContextAttribute>();
+        if (attributes.Length == 0)
+        {
+            return false;
+        }
+
+        var methodDeclarationSyntax = this.context.MapMethod.MethodDeclarationSyntax
+            ?? throw new MappaGeneratorException("Method declaration syntax has not been defined.");
+        var rootMapMethod = this.context.GetRootMapMethod();
+        var methodName = rootMapMethod.MethodName;
+        var targetTypeName = this.context.TargetType.ToDisplayString();
+        var providesContext = rootMapMethod.ProvideMappaContextWhenInvoked();
+
+        var duplicateContextKeys = GetDuplicateAssignToContextKeys(attributes);
+        this.ReportDuplicateAssignToContextKeys(methodDeclarationSyntax, methodName, duplicateContextKeys);
+
+        List<MappaAssignToContextEntry> assignToContextEntries = new();
+
+        foreach (var attribute in attributes)
+        {
+            if (duplicateContextKeys.Contains(attribute.ContextKey))
+            {
+                continue;
+            }
+
+            if (!this.TryAppendValidAssignToContextEntry(
+                    attribute,
+                    providesContext,
+                    methodDeclarationSyntax,
+                    methodName,
+                    targetTypeName,
+                    assignToContextEntries,
+                    ref contextParameterName))
+            {
+                continue;
+            }
+        }
+
+        if (assignToContextEntries.Count == 0)
+        {
+            return false;
+        }
+
+        entries = [.. assignToContextEntries];
+        return true;
+    }
+
+    private void ReportDuplicateAssignToContextKeys(
+        MethodDeclarationSyntax methodDeclarationSyntax,
+        string methodName,
+        HashSet<string> duplicateContextKeys)
+    {
+        foreach (var duplicateContextKey in duplicateContextKeys)
+        {
+            this.context.ReportDiagnostic(MappaDiagnostics.MultipleMappaAssignToContextAttributesUseTheSameContextKey(
+                methodDeclarationSyntax,
+                methodName,
+                duplicateContextKey));
+        }
+    }
+
+    private bool TryAppendValidAssignToContextEntry(
+        MappaAssignToContextAttribute attribute,
+        bool providesContext,
+        MethodDeclarationSyntax methodDeclarationSyntax,
+        string methodName,
+        string targetTypeName,
+        List<MappaAssignToContextEntry> assignToContextEntries,
+        ref string? contextParameterName)
+    {
+        if (!providesContext)
+        {
+            this.context.ReportDiagnostic(MappaDiagnostics.CannotUseMappaAssignToContextAttributeWithoutContextParameter(
+                methodDeclarationSyntax,
+                methodName,
+                attribute.ContextKey));
+            return false;
+        }
+
+        if (!this.TryResolveAssignToContextTargetMember(attribute.TargetPropertyName))
+        {
+            this.context.ReportDiagnostic(MappaDiagnostics.MappaAssignToContextTargetMemberDoesNotExistOrIsNotAccessible(
+                methodDeclarationSyntax,
+                methodName,
+                attribute.ContextKey,
+                attribute.TargetPropertyName,
+                targetTypeName));
+            return false;
+        }
+
+        assignToContextEntries.Add(new MappaAssignToContextEntry(attribute.ContextKey, attribute.TargetPropertyName));
+        contextParameterName ??= this.context.GetRootMapMethod().GetMappaContextParameterName();
+        return true;
+    }
+}

--- a/Mappa.Generator/Algorithm/StrategyDetectors/ConstructorMapStrategyDetector.EmptyCtorInitializers.cs
+++ b/Mappa.Generator/Algorithm/StrategyDetectors/ConstructorMapStrategyDetector.EmptyCtorInitializers.cs
@@ -1,0 +1,675 @@
+// <copyright file="ConstructorMapStrategyDetector.EmptyCtorInitializers.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using Mappa.Attributes;
+using Mappa.Generator.Diagnostics;
+using Mappa.Generator.Extensions;
+using Mappa.Generator.Helpers;
+using Mappa.Generator.Models;
+using Mappa.Generator.Models.Strategies;
+
+using Microsoft.CodeAnalysis;
+
+namespace Mappa.Generator.Algorithm.StrategyDetectors;
+
+/// <summary>
+/// Empty-constructor property initializer mapping for <see cref="ConstructorMapStrategyDetector"/>.
+/// </summary>
+internal sealed partial class ConstructorMapStrategyDetector
+{
+    private static string GetExpectedSourcePropertyNameFromMultipleUsePropertyAttributes(
+        MappaUsePropertyAttribute[] usePropertyAttributes,
+        string targetPropertyName,
+        out bool useExactNameFromAttribute)
+    {
+        useExactNameFromAttribute = false;
+        var distinctSourceRoots = usePropertyAttributes
+            .Select(attribute => PropertyPath.Parse(attribute.SourcePropertyName).GetFirstSegment())
+            .Where(segment => segment is not null)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        if (distinctSourceRoots.Length != 1)
+        {
+            return targetPropertyName;
+        }
+
+        var sourceRoot = distinctSourceRoots[0];
+        if (sourceRoot is null)
+        {
+            return targetPropertyName;
+        }
+
+        useExactNameFromAttribute = true;
+        return sourceRoot;
+    }
+
+    private PropertyMapStrategy TryCreateEmptyCtorPropertyMapStrategy(
+        IPropertySymbol targetProperty,
+        IPropertySymbol[] allTargetProperties,
+        IPropertySymbol[] sourceProperties,
+        NoMapStrategy noMapStrategy)
+    {
+        var sourceResolution = this.ResolveEmptyCtorPropertySourceNaming(targetProperty, noMapStrategy);
+        if (sourceResolution.FailureStrategy is PropertyMapStrategy failureStrategy)
+        {
+            return failureStrategy;
+        }
+
+        var nestedPropertyPathContext = this.ApplyNestedPathContextForEmptyCtorTarget(
+            targetProperty.Name,
+            sourceResolution.NestedPropertyPathContext);
+
+        var sourceProperty = this.TryResolveEmptyCtorSourceProperty(
+            sourceProperties,
+            sourceResolution,
+            out var chainedSourcePropertyPath);
+
+        var attributeStrategy = this.TryCreateEmptyCtorPropertyMapStrategyFromAttributes(
+            targetProperty,
+            allTargetProperties,
+            sourceProperties,
+            noMapStrategy,
+            chainedSourcePropertyPath,
+            ref sourceProperty);
+        if (attributeStrategy is not null)
+        {
+            return attributeStrategy;
+        }
+
+        var chainedStrategy = this.TryCreateEmptyCtorPropertyMapStrategyFromChainedSource(
+            targetProperty,
+            allTargetProperties,
+            chainedSourcePropertyPath);
+        if (chainedStrategy is not null)
+        {
+            return chainedStrategy;
+        }
+
+        var canWriteTargetProperty = this.TryIsTargetPropertyWritable(targetProperty, out var requiresUnsafeAccessorOnTargetSetter);
+        var readonlyGetterStrategy = this.TryCreateReadonlyGetterBackedEmptyCtorPropertyMapStrategy(
+            targetProperty,
+            sourceProperty,
+            canWriteTargetProperty,
+            noMapStrategy);
+        if (readonlyGetterStrategy is not null)
+        {
+            return readonlyGetterStrategy;
+        }
+
+        return this.TryCreateWritableEmptyCtorPropertyMapStrategy(
+            targetProperty,
+            allTargetProperties,
+            sourceProperties,
+            sourceProperty,
+            nestedPropertyPathContext,
+            canWriteTargetProperty,
+            requiresUnsafeAccessorOnTargetSetter,
+            noMapStrategy);
+    }
+
+    private EmptyCtorPropertySourceResolution ResolveEmptyCtorPropertySourceNaming(
+        IPropertySymbol targetProperty,
+        NoMapStrategy noMapStrategy)
+    {
+        var usePropertyAttributes = this.GetMatchingUsePropertyAttributes(
+            targetProperty.Name,
+            StringComparison.Ordinal);
+
+        return usePropertyAttributes.Length switch
+        {
+            0 => new EmptyCtorPropertySourceResolution(
+                targetProperty.Name,
+                UseExactNameFromAttribute: false,
+                NestedPropertyPathContext: null,
+                ChainedSourcePropertyPath: null,
+                FailureStrategy: null),
+            1 => this.ResolveEmptyCtorPropertySourceNamingFromSingleUsePropertyAttribute(
+                targetProperty,
+                usePropertyAttributes[0]),
+            _ => this.ResolveEmptyCtorPropertySourceNamingFromMultipleUsePropertyAttributes(
+                targetProperty,
+                usePropertyAttributes,
+                noMapStrategy),
+        };
+    }
+
+    private EmptyCtorPropertySourceResolution ResolveEmptyCtorPropertySourceNamingFromSingleUsePropertyAttribute(
+        IPropertySymbol targetProperty,
+        MappaUsePropertyAttribute usePropertyAttribute)
+    {
+        var isLeafTargetMapping = this.IsLeafTargetMappingForAttribute(usePropertyAttribute.TargetPropertyName);
+        if (this.TryResolveExpectedSourcePropertyName(
+                usePropertyAttribute,
+                isLeafTargetMapping,
+                out var expectedSourcePropertyName,
+                out var useExactNameFromAttribute,
+                out var nestedPropertyPathContext,
+                out var chainedSourcePropertyPath))
+        {
+            return new EmptyCtorPropertySourceResolution(
+                expectedSourcePropertyName,
+                useExactNameFromAttribute,
+                nestedPropertyPathContext,
+                chainedSourcePropertyPath,
+                FailureStrategy: null);
+        }
+
+        return new EmptyCtorPropertySourceResolution(
+            targetProperty.Name,
+            UseExactNameFromAttribute: true,
+            nestedPropertyPathContext,
+            chainedSourcePropertyPath,
+            FailureStrategy: null);
+    }
+
+    private EmptyCtorPropertySourceResolution ResolveEmptyCtorPropertySourceNamingFromMultipleUsePropertyAttributes(
+        IPropertySymbol targetProperty,
+        MappaUsePropertyAttribute[] usePropertyAttributes,
+        NoMapStrategy noMapStrategy)
+    {
+        var distinctTargetPaths = usePropertyAttributes
+            .Select(attribute => attribute.TargetPropertyName)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        if (distinctTargetPaths.Length == 1)
+        {
+            this.context.ReportDiagnostic(MappaDiagnostics.TooManyUsePropertyAttributesForTheSameTargetProperty(
+                this.context.GetRootMapMethod().MethodDeclarationSyntax,
+                this.context.GetRootMapMethod().MethodName,
+                targetProperty.Name));
+            return new EmptyCtorPropertySourceResolution(
+                string.Empty,
+                false,
+                null,
+                null,
+                new PropertyMapStrategy(targetProperty, null, noMapStrategy, false));
+        }
+
+        var expectedSourcePropertyName = GetExpectedSourcePropertyNameFromMultipleUsePropertyAttributes(
+            usePropertyAttributes,
+            targetProperty.Name,
+            out var useExactNameFromAttribute);
+
+        return new EmptyCtorPropertySourceResolution(
+            expectedSourcePropertyName,
+            useExactNameFromAttribute,
+            PropertyPathContext.CreateNestedAttributeScope(targetProperty.Name),
+            null,
+            FailureStrategy: null);
+    }
+
+    private PropertyPathContext? ApplyNestedPathContextForEmptyCtorTarget(
+        string targetPropertyName,
+        PropertyPathContext? nestedPropertyPathContext)
+    {
+        if (this.context.PropertyPathContext is not null)
+        {
+            return nestedPropertyPathContext;
+        }
+
+        if (!this.HasNestedPathAttributesForTargetMember(targetPropertyName, StringComparison.Ordinal))
+        {
+            return nestedPropertyPathContext;
+        }
+
+        if (nestedPropertyPathContext is not null
+            && this.CountNestedPathAttributesForTargetMember(targetPropertyName, StringComparison.Ordinal) <= 1)
+        {
+            return nestedPropertyPathContext;
+        }
+
+        return PropertyPathContext.CreateNestedAttributeScope(targetPropertyName);
+    }
+
+    private IPropertySymbol? TryResolveEmptyCtorSourceProperty(
+        IPropertySymbol[] sourceProperties,
+        EmptyCtorPropertySourceResolution sourceResolution,
+        out ChainedSourcePropertyPathInfo? chainedSourcePropertyPath)
+    {
+        chainedSourcePropertyPath = sourceResolution.ChainedSourcePropertyPath;
+        if (chainedSourcePropertyPath is null)
+        {
+            PropertyMapNameMatcher.TryFindSourceProperty(
+                sourceProperties,
+                sourceResolution.ExpectedSourcePropertyName,
+                this.context.MappaUserSettings.CaseInsensitivePropertyMap,
+                this.context.MappaUserSettings.IgnoreUnderscoreForPropertyMap,
+                isConstructorParameterPath: false,
+                sourceResolution.UseExactNameFromAttribute,
+                out var sourceProperty);
+            return sourceProperty;
+        }
+
+        if (!this.TryResolveChainedSourceProperty(
+                chainedSourcePropertyPath,
+                out var resolvedSourceProperties,
+                out _))
+        {
+            return null;
+        }
+
+        return resolvedSourceProperties[0];
+    }
+
+    private PropertyMapStrategy? TryCreateEmptyCtorPropertyMapStrategyFromAttributes(
+        IPropertySymbol targetProperty,
+        IPropertySymbol[] allTargetProperties,
+        IPropertySymbol[] sourceProperties,
+        NoMapStrategy noMapStrategy,
+        ChainedSourcePropertyPathInfo? chainedSourcePropertyPath,
+        ref IPropertySymbol? sourceProperty)
+    {
+        if (this.context.MapMethod is null && this.context.PropertyPathContext is null)
+        {
+            return null;
+        }
+
+        if (!this.TryGetStrategyForPropertyOrArgumentUsingAttributesOnMethod(
+                targetProperty.Name,
+                targetProperty.Type,
+                this.context.SourceType,
+                ref sourceProperty,
+                StringComparison.Ordinal,
+                isConstructorParameterPath: false,
+                out var propertyStrategyFromAttribute))
+        {
+            return null;
+        }
+
+        if (!this.TryIsTargetPropertyWritable(targetProperty, out var requiresUnsafeAccessorOnTargetFromAttribute))
+        {
+            this.context.ReportDiagnostic(MappaDiagnostics.PropertySetterIsNotAccessible(
+                this.context.GetRootMapMethod().MethodDeclarationSyntax,
+                this.context.TargetType,
+                targetProperty));
+            return new PropertyMapStrategy(targetProperty, null, noMapStrategy, false);
+        }
+
+        propertyStrategyFromAttribute = this.EncapsulateMapStrategyForSourceOptional(
+            sourceProperty,
+            sourceProperties,
+            propertyStrategyFromAttribute);
+        propertyStrategyFromAttribute = this.EncapsulateMapStrategyForTargetOptional(
+            targetProperty,
+            allTargetProperties,
+            propertyStrategyFromAttribute,
+            out var postConstructorInitializer);
+        var requiresUnsafeAccessorOnSourceFromAttribute = sourceProperty is not null
+            && this.TryIsSourcePropertyReadable(sourceProperty, out var sourceRequiresUnsafeFromAttribute)
+            && sourceRequiresUnsafeFromAttribute;
+        return new PropertyMapStrategy(
+            targetProperty,
+            sourceProperty,
+            propertyStrategyFromAttribute,
+            postConstructorInitializer,
+            chainedSourcePropertyPath,
+            requiresUnsafeAccessorOnSourceFromAttribute,
+            requiresUnsafeAccessorOnTargetFromAttribute);
+    }
+
+    private PropertyMapStrategy? TryCreateEmptyCtorPropertyMapStrategyFromChainedSource(
+        IPropertySymbol targetProperty,
+        IPropertySymbol[] allTargetProperties,
+        ChainedSourcePropertyPathInfo? chainedSourcePropertyPath)
+    {
+        if (chainedSourcePropertyPath is null
+            || !this.TryResolveChainedSourceProperty(
+                chainedSourcePropertyPath,
+                out var chainedSourceProperties,
+                out _))
+        {
+            return null;
+        }
+
+        var innerSourceType = chainedSourceProperties[chainedSourceProperties.Length - 1].Type;
+        MapStrategy chainedPropertyStrategy = new IdentityMapStrategy(targetProperty.Type, innerSourceType);
+        chainedPropertyStrategy = this.EncapsulateMapStrategyForTargetOptional(
+            targetProperty,
+            allTargetProperties,
+            chainedPropertyStrategy,
+            out var chainedPostConstructorInitializer);
+        this.TryIsTargetPropertyWritable(targetProperty, out var requiresUnsafeAccessorOnTargetFromChain);
+        return new PropertyMapStrategy(
+            targetProperty,
+            null,
+            chainedPropertyStrategy,
+            chainedPostConstructorInitializer,
+            chainedSourcePropertyPath,
+            requiresUnsafeAccessorOnSource: false,
+            requiresUnsafeAccessorOnTarget: requiresUnsafeAccessorOnTargetFromChain);
+    }
+
+    private PropertyMapStrategy? TryCreateReadonlyGetterBackedEmptyCtorPropertyMapStrategy(
+        IPropertySymbol targetProperty,
+        IPropertySymbol? sourceProperty,
+        bool canWriteTargetProperty,
+        NoMapStrategy noMapStrategy)
+    {
+        if (sourceProperty is null
+            || canWriteTargetProperty
+            || !this.TryIsTargetPropertyGetterReadable(targetProperty, out var requiresUnsafeAccessorOnTargetGetter))
+        {
+            return null;
+        }
+
+        if (this.TryCreateReadonlyDictionaryEmptyCtorPropertyMapStrategy(
+                targetProperty,
+                sourceProperty,
+                requiresUnsafeAccessorOnTargetGetter,
+                out var dictionaryStrategy))
+        {
+            return dictionaryStrategy;
+        }
+
+        if (this.TryCreateReadonlyStackEmptyCtorPropertyMapStrategy(
+                targetProperty,
+                sourceProperty,
+                requiresUnsafeAccessorOnTargetGetter,
+                out var stackStrategy))
+        {
+            return stackStrategy;
+        }
+
+        if (this.TryCreateReadonlyQueueEmptyCtorPropertyMapStrategy(
+                targetProperty,
+                sourceProperty,
+                requiresUnsafeAccessorOnTargetGetter,
+                out var queueStrategy))
+        {
+            return queueStrategy;
+        }
+
+        if (this.TryCreateReadonlyAddCollectionEmptyCtorPropertyMapStrategy(
+                targetProperty,
+                sourceProperty,
+                requiresUnsafeAccessorOnTargetGetter,
+                out var addCollectionStrategy))
+        {
+            return addCollectionStrategy;
+        }
+
+        if (this.TryCreateReadonlyCollectionEmptyCtorPropertyMapStrategy(
+                targetProperty,
+                sourceProperty,
+                requiresUnsafeAccessorOnTargetGetter,
+                out var collectionStrategy))
+        {
+            return collectionStrategy;
+        }
+
+        return new PropertyMapStrategy(targetProperty, null, noMapStrategy, false);
+    }
+
+    private bool TryCreateReadonlyDictionaryEmptyCtorPropertyMapStrategy(
+        IPropertySymbol targetProperty,
+        IPropertySymbol sourceProperty,
+        bool requiresUnsafeAccessorOnTargetGetter,
+        out PropertyMapStrategy? propertyMapStrategy)
+    {
+        propertyMapStrategy = null;
+        if (!targetProperty.Type.IsOrImplementIDictionary(this.compilation)
+            || !sourceProperty.Type.IsOrImplementIDictionary(this.compilation)
+            || !this.context.TryGetKeyAndValueStrategy(
+                targetProperty.Type,
+                sourceProperty.Type,
+                this.compilation,
+                out var keyStrategy,
+                out var valueStrategy,
+                this.cancellationToken))
+        {
+            return false;
+        }
+
+        var dictionaryPropertyStrategy = new ReadonlyDictionaryPropertyMapStrategy(
+            targetProperty,
+            sourceProperty,
+            keyStrategy,
+            valueStrategy,
+            DictionaryAssignmentSettingHelper.GetEffective(this.context.MappaUserSettings.DictionaryAssignment));
+        this.TryIsSourcePropertyReadable(sourceProperty, out var requiresUnsafeAccessorOnSourceDictionary);
+        propertyMapStrategy = new PropertyMapStrategy(
+            targetProperty,
+            sourceProperty,
+            dictionaryPropertyStrategy,
+            true,
+            requiresUnsafeAccessorOnSource: requiresUnsafeAccessorOnSourceDictionary,
+            requiresUnsafeAccessorOnTarget: requiresUnsafeAccessorOnTargetGetter);
+        return true;
+    }
+
+    private bool TryCreateReadonlyStackEmptyCtorPropertyMapStrategy(
+        IPropertySymbol targetProperty,
+        IPropertySymbol sourceProperty,
+        bool requiresUnsafeAccessorOnTargetGetter,
+        out PropertyMapStrategy? propertyMapStrategy)
+    {
+        propertyMapStrategy = null;
+        if (!(targetProperty.Type.IsOrDerivedFromStack(this.compilation)
+              || targetProperty.Type.IsOrDerivedFromConcurrentStack(this.compilation))
+            || !(sourceProperty.Type.IsArray() || sourceProperty.Type.IsOrImplementIEnumerable())
+            || !this.context.TryGetElementStrategy(
+                targetProperty.Type,
+                sourceProperty.Type,
+                this.compilation,
+                out var stackElementStrategy,
+                this.cancellationToken))
+        {
+            return false;
+        }
+
+        var stackPropertyStrategy = new ReadonlyStackPropertyMapStrategy(targetProperty, sourceProperty, stackElementStrategy);
+        this.TryIsSourcePropertyReadable(sourceProperty, out var requiresUnsafeAccessorOnSourceStack);
+        propertyMapStrategy = new PropertyMapStrategy(
+            targetProperty,
+            sourceProperty,
+            stackPropertyStrategy,
+            true,
+            requiresUnsafeAccessorOnSource: requiresUnsafeAccessorOnSourceStack,
+            requiresUnsafeAccessorOnTarget: requiresUnsafeAccessorOnTargetGetter);
+        return true;
+    }
+
+    private bool TryCreateReadonlyQueueEmptyCtorPropertyMapStrategy(
+        IPropertySymbol targetProperty,
+        IPropertySymbol sourceProperty,
+        bool requiresUnsafeAccessorOnTargetGetter,
+        out PropertyMapStrategy? propertyMapStrategy)
+    {
+        propertyMapStrategy = null;
+        if (!(targetProperty.Type.IsOrDerivedFromQueue(this.compilation)
+              || targetProperty.Type.IsOrImplementConcurrentQueue(this.compilation))
+            || !(sourceProperty.Type.IsArray() || sourceProperty.Type.IsOrImplementIEnumerable())
+            || !this.context.TryGetElementStrategy(
+                targetProperty.Type,
+                sourceProperty.Type,
+                this.compilation,
+                out var queueElementStrategy,
+                this.cancellationToken))
+        {
+            return false;
+        }
+
+        var queuePropertyStrategy = new ReadonlyQueuePropertyMapStrategy(targetProperty, sourceProperty, queueElementStrategy);
+        this.TryIsSourcePropertyReadable(sourceProperty, out var requiresUnsafeAccessorOnSourceQueue);
+        propertyMapStrategy = new PropertyMapStrategy(
+            targetProperty,
+            sourceProperty,
+            queuePropertyStrategy,
+            true,
+            requiresUnsafeAccessorOnSource: requiresUnsafeAccessorOnSourceQueue,
+            requiresUnsafeAccessorOnTarget: requiresUnsafeAccessorOnTargetGetter);
+        return true;
+    }
+
+    private bool TryCreateReadonlyAddCollectionEmptyCtorPropertyMapStrategy(
+        IPropertySymbol targetProperty,
+        IPropertySymbol sourceProperty,
+        bool requiresUnsafeAccessorOnTargetGetter,
+        out PropertyMapStrategy? propertyMapStrategy)
+    {
+        propertyMapStrategy = null;
+        if (!(targetProperty.Type.IsOrDerivedFromConcurrentBag(this.compilation)
+              || targetProperty.Type.IsOrDerivedFromBlockingCollection(this.compilation))
+            || !(sourceProperty.Type.IsArray() || sourceProperty.Type.IsOrImplementIEnumerable())
+            || !this.context.TryGetElementStrategy(
+                targetProperty.Type,
+                sourceProperty.Type,
+                this.compilation,
+                out var addCollectionElementStrategy,
+                this.cancellationToken))
+        {
+            return false;
+        }
+
+        var addCollectionPropertyStrategy = new ReadonlyAddCollectionPropertyMapStrategy(
+            targetProperty,
+            sourceProperty,
+            addCollectionElementStrategy);
+        this.TryIsSourcePropertyReadable(sourceProperty, out var requiresUnsafeAccessorOnSourceAddCollection);
+        propertyMapStrategy = new PropertyMapStrategy(
+            targetProperty,
+            sourceProperty,
+            addCollectionPropertyStrategy,
+            true,
+            requiresUnsafeAccessorOnSource: requiresUnsafeAccessorOnSourceAddCollection,
+            requiresUnsafeAccessorOnTarget: requiresUnsafeAccessorOnTargetGetter);
+        return true;
+    }
+
+    private bool TryCreateReadonlyCollectionEmptyCtorPropertyMapStrategy(
+        IPropertySymbol targetProperty,
+        IPropertySymbol sourceProperty,
+        bool requiresUnsafeAccessorOnTargetGetter,
+        out PropertyMapStrategy? propertyMapStrategy)
+    {
+        propertyMapStrategy = null;
+        if (!targetProperty.Type.IsOrImplementICollection()
+            || !(sourceProperty.Type.IsArray() || sourceProperty.Type.IsOrImplementIEnumerable())
+            || !this.context.TryGetElementStrategy(
+                targetProperty.Type,
+                sourceProperty.Type,
+                this.compilation,
+                out var elementStrategy,
+                this.cancellationToken))
+        {
+            return false;
+        }
+
+        var collectionPropertyStrategy = new ReadonlyCollectionPropertyMapStrategy(
+            targetProperty,
+            sourceProperty,
+            elementStrategy);
+        this.TryIsSourcePropertyReadable(sourceProperty, out var requiresUnsafeAccessorOnSourceCollection);
+        propertyMapStrategy = new PropertyMapStrategy(
+            targetProperty,
+            sourceProperty,
+            collectionPropertyStrategy,
+            true,
+            requiresUnsafeAccessorOnSource: requiresUnsafeAccessorOnSourceCollection,
+            requiresUnsafeAccessorOnTarget: requiresUnsafeAccessorOnTargetGetter);
+        return true;
+    }
+
+    private PropertyMapStrategy TryCreateWritableEmptyCtorPropertyMapStrategy(
+        IPropertySymbol targetProperty,
+        IPropertySymbol[] allTargetProperties,
+        IPropertySymbol[] sourceProperties,
+        IPropertySymbol? sourceProperty,
+        PropertyPathContext? nestedPropertyPathContext,
+        bool canWriteTargetProperty,
+        bool requiresUnsafeAccessorOnTargetSetter,
+        NoMapStrategy noMapStrategy)
+    {
+        if (sourceProperty is null || !canWriteTargetProperty)
+        {
+            return new PropertyMapStrategy(targetProperty, sourceProperty, noMapStrategy, false);
+        }
+
+        if (!this.TryGetStrategyBetweenTypes(
+                targetProperty.Type,
+                sourceProperty.Type,
+                true,
+                ConstructorMapStrategyDetector.GetNestedTypeMappingPropertyPathContext(
+                    targetProperty.Name,
+                    nestedPropertyPathContext),
+                out var propertyStrategy))
+        {
+            return new PropertyMapStrategy(targetProperty, null, noMapStrategy, false);
+        }
+
+        propertyStrategy = this.EncapsulateMapStrategyForSourceOptional(sourceProperty, sourceProperties, propertyStrategy);
+        propertyStrategy = this.EncapsulateMapStrategyForTargetOptional(
+            targetProperty,
+            allTargetProperties,
+            propertyStrategy,
+            out var postConstructorInitializer);
+        this.TryIsSourcePropertyReadable(sourceProperty, out var requiresUnsafeAccessorOnSource);
+        return new PropertyMapStrategy(
+            targetProperty,
+            sourceProperty,
+            propertyStrategy,
+            postConstructorInitializer,
+            requiresUnsafeAccessorOnSource: requiresUnsafeAccessorOnSource,
+            requiresUnsafeAccessorOnTarget: requiresUnsafeAccessorOnTargetSetter);
+    }
+
+    private bool ReportEmptyCtorDiagnosticsForUnmappedProperties(
+        PropertyMapStrategy[] propertiesWithStrategies,
+        PropertyMapStrategy[] propertiesWithoutStrategy)
+    {
+        var mustMapAttribute = this.GetMustMapTargetPropertyAttribute();
+        var mustMapFailed = false;
+
+        foreach (var propertyWithoutStrategy in propertiesWithoutStrategy
+                     .Select(propertyStrategy => propertyStrategy.TargetProperty)
+                     .Where(this.IsReportableEmptyCtorUnmappedProperty))
+        {
+            mustMapFailed |= this.TryReportMustMapOrNonRequiredEmptyCtorDiagnostic(
+                propertyWithoutStrategy,
+                propertiesWithStrategies,
+                mustMapAttribute);
+        }
+
+        return mustMapFailed;
+    }
+
+    private bool TryReportMustMapOrNonRequiredEmptyCtorDiagnostic(
+        IPropertySymbol propertyWithoutStrategy,
+        PropertyMapStrategy[] propertiesWithStrategies,
+        MappaMustMapTargetPropertyAttribute? mustMapAttribute)
+    {
+        if (IsMustMapEmptyCtorUnmappedProperty(propertyWithoutStrategy, mustMapAttribute))
+        {
+            this.context.ReportDiagnostic(MappaDiagnostics.MustMapTargetPropertyWasNotMapped(
+                this.context.GetRootMapMethod().MethodDeclarationSyntax,
+                this.context.TargetType,
+                propertyWithoutStrategy));
+            return true;
+        }
+
+        if (propertiesWithStrategies.Length > 0)
+        {
+            this.context.ReportDiagnostic(MappaDiagnostics.CannotMapNonRequiredProperty(
+                this.context.GetRootMapMethod().MethodDeclarationSyntax,
+                this.context.TargetType,
+                propertyWithoutStrategy));
+        }
+
+        return false;
+    }
+
+    private bool IsReportableEmptyCtorUnmappedProperty(IPropertySymbol propertyWithoutStrategy)
+    {
+        var targetCollections = propertyWithoutStrategy.Type.IsPostInitializationCollectionType(this.compilation);
+        var hasSetter = this.TryIsTargetPropertyWritable(propertyWithoutStrategy, out _);
+        return hasSetter || targetCollections;
+    }
+
+    private readonly record struct EmptyCtorPropertySourceResolution(
+        string ExpectedSourcePropertyName,
+        bool UseExactNameFromAttribute,
+        PropertyPathContext? NestedPropertyPathContext,
+        ChainedSourcePropertyPathInfo? ChainedSourcePropertyPath,
+        PropertyMapStrategy? FailureStrategy);
+}

--- a/Mappa.Generator/Algorithm/StrategyDetectors/ConstructorMapStrategyDetector.InvokeMethodAttribute.cs
+++ b/Mappa.Generator/Algorithm/StrategyDetectors/ConstructorMapStrategyDetector.InvokeMethodAttribute.cs
@@ -1,0 +1,489 @@
+// <copyright file="ConstructorMapStrategyDetector.InvokeMethodAttribute.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using Mappa.Attributes;
+using Mappa.Generator.Diagnostics;
+using Mappa.Generator.Exceptions;
+using Mappa.Generator.Extensions;
+using Mappa.Generator.Helpers;
+using Mappa.Generator.Models;
+using Mappa.Generator.Models.Strategies;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Mappa.Generator.Algorithm.StrategyDetectors;
+
+/// <summary>
+/// MappaInvokeMethod attribute handling for <see cref="ConstructorMapStrategyDetector"/>.
+/// </summary>
+internal sealed partial class ConstructorMapStrategyDetector
+{
+    private static ITypeSymbol GetFieldOrPropertyType(ISymbol fieldOrProperty)
+        => fieldOrProperty switch
+        {
+            IFieldSymbol field => field.Type,
+            IPropertySymbol property => property.Type,
+            _ => throw new MappaGeneratorException($"Unexpected symbol kind '{fieldOrProperty.Kind}' for field or property '{fieldOrProperty.Name}'."),
+        };
+
+    private MapStrategy TryGetStrategyFromSingleTargetPropertyAttribute(
+        string targetName,
+        ITypeSymbol targetType,
+        ITypeSymbol sourceClassType,
+        ref IPropertySymbol? sourceProperty,
+        StringComparison stringComparison,
+        bool isConstructorParameterPath,
+        IMappaTargetPropertyNameAttribute attribute)
+    {
+        switch (attribute)
+        {
+            case MappaInvokeMethodAttribute mappaInvokeMethodAttribute:
+                return this.TryGetStrategyFromMappaInvokeMethodAttribute(
+                    targetName,
+                    targetType,
+                    sourceClassType,
+                    ref sourceProperty,
+                    mappaInvokeMethodAttribute,
+                    stringComparison,
+                    isConstructorParameterPath);
+            case MappaAssignFromContextAttribute mappaAssignFromContextAttribute:
+                return this.TryGetStrategyFromMappaAssignFromContextAttribute(
+                    targetName,
+                    targetType,
+                    mappaAssignFromContextAttribute,
+                    ref sourceProperty,
+                    stringComparison);
+            case MappaAssignFromConstantAttribute mappaAssignFromConstantAttribute:
+                return this.TryGetStrategyFromMappaAssignFromConstantAttribute(
+                    targetType,
+                    mappaAssignFromConstantAttribute,
+                    ref sourceProperty,
+                    targetName,
+                    stringComparison);
+            default:
+                return new NoMapStrategy(targetType, sourceClassType);
+        }
+    }
+
+    private MapStrategy TryGetStrategyFromMappaInvokeMethodAttribute(
+        string targetName,
+        ITypeSymbol targetType,
+        ITypeSymbol sourceClassType,
+        ref IPropertySymbol? sourceProperty,
+        MappaInvokeMethodAttribute mappaInvokeMethodAttribute,
+        StringComparison stringComparison,
+        bool isConstructorParameterPath)
+    {
+        if (!string.IsNullOrWhiteSpace(mappaInvokeMethodAttribute.SourcePropertyName))
+        {
+            this.ReportMappaUsePropertySourcePropertyWillNotBeUsedIfPresent(
+                targetName,
+                stringComparison,
+                nameof(MappaInvokeMethodAttribute));
+            this.TryResolveSourcePropertyForMappaInvokeMethodAttribute(
+                mappaInvokeMethodAttribute,
+                sourceClassType,
+                isConstructorParameterPath,
+                ref sourceProperty);
+        }
+
+        this.TryGetStrategyUsingMappaInvokeMethodAttribute(
+            targetName,
+            targetType,
+            sourceClassType,
+            sourceProperty,
+            mappaInvokeMethodAttribute,
+            stringComparison,
+            out var strategy);
+        return strategy;
+    }
+
+    private MapStrategy TryGetStrategyFromMappaAssignFromContextAttribute(
+        string targetName,
+        ITypeSymbol targetType,
+        MappaAssignFromContextAttribute mappaAssignFromContextAttribute,
+        ref IPropertySymbol? sourceProperty,
+        StringComparison stringComparison)
+    {
+        this.TryGetStrategyUsingMappaAssignFromContextAttribute(
+            targetName,
+            targetType,
+            mappaAssignFromContextAttribute,
+            ref sourceProperty,
+            out var strategy);
+        if (strategy is not NoMapStrategy)
+        {
+            this.ReportMappaUsePropertySourcePropertyWillNotBeUsedIfPresent(
+                targetName,
+                stringComparison,
+                nameof(MappaAssignFromContextAttribute));
+        }
+
+        return strategy;
+    }
+
+    private MapStrategy TryGetStrategyFromMappaAssignFromConstantAttribute(
+        ITypeSymbol targetType,
+        MappaAssignFromConstantAttribute mappaAssignFromConstantAttribute,
+        ref IPropertySymbol? sourceProperty,
+        string targetName,
+        StringComparison stringComparison)
+    {
+        TryGetStrategyUsingMappaAssignFromConstantAttribute(
+            targetType,
+            mappaAssignFromConstantAttribute,
+            out var strategy);
+        if (strategy is not NoMapStrategy)
+        {
+            sourceProperty = null;
+            this.ReportMappaUsePropertySourcePropertyWillNotBeUsedIfPresent(
+                targetName,
+                stringComparison,
+                nameof(MappaAssignFromConstantAttribute));
+        }
+
+        return strategy;
+    }
+
+    private void TryGetStrategyUsingMappaInvokeMethodAttribute(
+        string targetName,
+        ITypeSymbol targetType,
+        ITypeSymbol sourceClassType,
+        IPropertySymbol? sourceProperty,
+        MappaInvokeMethodAttribute mappaInvokeMethodAttribute,
+        StringComparison stringComparison,
+        out MapStrategy strategy)
+    {
+        strategy = new NoMapStrategy(targetType, sourceClassType);
+
+        var mapMethod = this.GetAttributeMapMethod();
+        var mapMethodMethodDeclarationSyntax = mapMethod.MethodDeclarationSyntax ?? throw new MappaGeneratorException("Method declaration syntax has not been defined.");
+        var mapMethodClass = mapMethod.ContainingType;
+        var rootMethod = this.context.GetRootMapMethod();
+
+        if (!this.TryResolveMappaInvokeMethodSymbol(
+                targetName,
+                mappaInvokeMethodAttribute,
+                mapMethodClass,
+                rootMethod,
+                mapMethodMethodDeclarationSyntax,
+                targetType,
+                sourceClassType,
+                sourceProperty,
+                out var fieldOrProperty,
+                out var method)
+            || method is null)
+        {
+            return;
+        }
+
+        var contextParameterName = method.MethodHasMappaContextParameter(this.compilation)
+            ? rootMethod.MaybeGetMappaContextParameterName()
+            : null;
+
+        strategy = new MappaInvokeMethodAttributeStrategy(
+            targetType,
+            sourceClassType,
+            mappaInvokeMethodAttribute,
+            fieldOrProperty,
+            method,
+            sourceProperty,
+            this.GetAttributeMapMethod().NullableEnabled,
+            contextParameterName);
+
+        this.ReportMappaUsePropertyNotUsedByInvokeMethodIfNeeded(
+            targetName,
+            sourceProperty,
+            sourceClassType,
+            mappaInvokeMethodAttribute,
+            method,
+            stringComparison,
+            mapMethodMethodDeclarationSyntax);
+    }
+
+    private bool TryResolveMappaInvokeMethodSymbol(
+        string targetName,
+        MappaInvokeMethodAttribute mappaInvokeMethodAttribute,
+        INamedTypeSymbol mapMethodClass,
+        MapMethod rootMethod,
+        MethodDeclarationSyntax mapMethodMethodDeclarationSyntax,
+        ITypeSymbol targetType,
+        ITypeSymbol sourceClassType,
+        IPropertySymbol? sourceProperty,
+        out ISymbol? fieldOrProperty,
+        out IMethodSymbol? method)
+    {
+        fieldOrProperty = null;
+
+        if (mappaInvokeMethodAttribute.FieldName is not null)
+        {
+            return this.TryResolveMappaInvokeMethodFromField(
+                targetName,
+                mappaInvokeMethodAttribute,
+                mapMethodClass,
+                rootMethod,
+                mapMethodMethodDeclarationSyntax,
+                targetType,
+                sourceClassType,
+                sourceProperty,
+                out fieldOrProperty,
+                out method);
+        }
+
+        if (mappaInvokeMethodAttribute.ClassType is not null)
+        {
+            return this.TryResolveMappaInvokeMethodFromClassType(
+                targetName,
+                mappaInvokeMethodAttribute,
+                mapMethodClass,
+                rootMethod,
+                mapMethodMethodDeclarationSyntax,
+                targetType,
+                sourceClassType,
+                sourceProperty,
+                out method);
+        }
+
+        return this.TryResolveMappaInvokeMethodFromMapMethodClass(
+            targetName,
+            mappaInvokeMethodAttribute,
+            mapMethodClass,
+            rootMethod,
+            mapMethodMethodDeclarationSyntax,
+            targetType,
+            sourceClassType,
+            sourceProperty,
+            out method);
+    }
+
+    private bool TryResolveMappaInvokeMethodFromField(
+        string targetName,
+        MappaInvokeMethodAttribute mappaInvokeMethodAttribute,
+        INamedTypeSymbol mapMethodClass,
+        MapMethod rootMethod,
+        MethodDeclarationSyntax mapMethodMethodDeclarationSyntax,
+        ITypeSymbol targetType,
+        ITypeSymbol sourceClassType,
+        IPropertySymbol? sourceProperty,
+        out ISymbol? fieldOrProperty,
+        out IMethodSymbol? method)
+    {
+        if (mappaInvokeMethodAttribute.FieldName is not { Length: > 0 } fieldName || string.IsNullOrWhiteSpace(fieldName))
+        {
+            fieldOrProperty = null;
+            method = null;
+            return false;
+        }
+
+        fieldOrProperty = this.compilation.LocateAccessibleFieldOrPropertyInTypeHierarchy(
+            mapMethodClass,
+            fieldName,
+            mapMethodClass);
+
+        if (fieldOrProperty is null)
+        {
+            this.context.ReportDiagnostic(MappaDiagnostics.CannotFindFieldOrProperty(
+                mapMethodMethodDeclarationSyntax,
+                fieldName));
+            method = null;
+            return false;
+        }
+
+        if (rootMethod.CanBeUsedByStaticMethod && !fieldOrProperty.IsStatic)
+        {
+            this.context.ReportDiagnostic(MappaDiagnostics.FieldOrPropertyMustBeStatic(
+                fieldOrProperty.Name,
+                rootMethod.Location));
+            method = null;
+            return false;
+        }
+
+        var fieldOrPropertyType = GetFieldOrPropertyType(fieldOrProperty);
+        var resolutionResult = this.TryResolveInvokeMethodForAttribute(
+            mapMethodClass,
+            fieldOrPropertyType.LocateMethods(mappaInvokeMethodAttribute.MethodName),
+            mappaInvokeMethodAttribute.MethodName,
+            targetType,
+            sourceClassType,
+            sourceProperty,
+            InvokeMethodStaticRequirement.NotStatic,
+            rootMethod,
+            mapMethodMethodDeclarationSyntax,
+            out var resolvedMethod);
+        method = resolvedMethod;
+
+        return this.IsSuccessfulMappaInvokeMethodResolution(
+            resolutionResult,
+            method,
+            mappaInvokeMethodAttribute,
+            mapMethodClass,
+            mapMethodMethodDeclarationSyntax,
+            targetName);
+    }
+
+    private bool TryResolveMappaInvokeMethodFromClassType(
+        string targetName,
+        MappaInvokeMethodAttribute mappaInvokeMethodAttribute,
+        INamedTypeSymbol mapMethodClass,
+        MapMethod rootMethod,
+        MethodDeclarationSyntax mapMethodMethodDeclarationSyntax,
+        ITypeSymbol targetType,
+        ITypeSymbol sourceClassType,
+        IPropertySymbol? sourceProperty,
+        out IMethodSymbol? method)
+    {
+        var classTypeFullName = mappaInvokeMethodAttribute.ClassType?.FullName
+            ?? throw new MappaGeneratorException("Cannot detect type full name");
+        var className = this.compilation.GetTypeByMetadataName(classTypeFullName);
+        if (className is null)
+        {
+            this.context.ReportDiagnostic(MappaDiagnostics.CannotDetectType(
+                mapMethodMethodDeclarationSyntax,
+                classTypeFullName));
+            method = null;
+            return false;
+        }
+
+        var resolutionResult = this.TryResolveInvokeMethodForAttribute(
+            mapMethodClass,
+            className.LocateMethods(mappaInvokeMethodAttribute.MethodName),
+            mappaInvokeMethodAttribute.MethodName,
+            targetType,
+            sourceClassType,
+            sourceProperty,
+            InvokeMethodStaticRequirement.Static,
+            rootMethod,
+            mapMethodMethodDeclarationSyntax,
+            out method);
+
+        return this.IsSuccessfulMappaInvokeMethodResolution(
+            resolutionResult,
+            method,
+            mappaInvokeMethodAttribute,
+            mapMethodClass,
+            mapMethodMethodDeclarationSyntax,
+            targetName);
+    }
+
+    private bool TryResolveMappaInvokeMethodFromMapMethodClass(
+        string targetName,
+        MappaInvokeMethodAttribute mappaInvokeMethodAttribute,
+        INamedTypeSymbol mapMethodClass,
+        MapMethod rootMethod,
+        MethodDeclarationSyntax mapMethodMethodDeclarationSyntax,
+        ITypeSymbol targetType,
+        ITypeSymbol sourceClassType,
+        IPropertySymbol? sourceProperty,
+        out IMethodSymbol? method)
+    {
+        var staticRequirement = rootMethod.CanBeUsedByStaticMethod
+            ? InvokeMethodStaticRequirement.Static
+            : InvokeMethodStaticRequirement.StaticOrNotStatic;
+
+        var resolutionResult = this.TryResolveInvokeMethodForAttribute(
+            mapMethodClass,
+            mapMethodClass.LocateMethods(mappaInvokeMethodAttribute.MethodName),
+            mappaInvokeMethodAttribute.MethodName,
+            targetType,
+            sourceClassType,
+            sourceProperty,
+            staticRequirement,
+            rootMethod,
+            mapMethodMethodDeclarationSyntax,
+            out method);
+
+        return this.IsSuccessfulMappaInvokeMethodResolution(
+            resolutionResult,
+            method,
+            mappaInvokeMethodAttribute,
+            mapMethodClass,
+            mapMethodMethodDeclarationSyntax,
+            targetName);
+    }
+
+    private bool IsSuccessfulMappaInvokeMethodResolution(
+        InvokeMethodResolutionResult resolutionResult,
+        IMethodSymbol? method,
+        MappaInvokeMethodAttribute mappaInvokeMethodAttribute,
+        INamedTypeSymbol mapMethodClass,
+        MethodDeclarationSyntax mapMethodMethodDeclarationSyntax,
+        string targetName)
+    {
+        if (resolutionResult is InvokeMethodResolutionResult.Ambiguous)
+        {
+            return false;
+        }
+
+        if (resolutionResult is InvokeMethodResolutionResult.Success && method is not null)
+        {
+            return true;
+        }
+
+        var displayClassName = mappaInvokeMethodAttribute.ClassType is not null
+            ? mappaInvokeMethodAttribute.ClassType.FullName ?? "unknown"
+            : mapMethodClass.ToDisplayString();
+        this.context.ReportDiagnostic(MappaDiagnostics.CannotDetectSuitableMethodToInvokeForParameter(
+            mapMethodMethodDeclarationSyntax,
+            targetName,
+            mappaInvokeMethodAttribute.MethodName,
+            displayClassName));
+        return false;
+    }
+
+    private void ReportMappaUsePropertyNotUsedByInvokeMethodIfNeeded(
+        string targetName,
+        IPropertySymbol? sourceProperty,
+        ITypeSymbol sourceClassType,
+        MappaInvokeMethodAttribute mappaInvokeMethodAttribute,
+        IMethodSymbol method,
+        StringComparison stringComparison,
+        MethodDeclarationSyntax mapMethodMethodDeclarationSyntax)
+    {
+        var explicitSourcePropertyName = this.GetExplicitSourcePropertyNameForInvokeMethod(
+            targetName,
+            mappaInvokeMethodAttribute,
+            stringComparison);
+        if (explicitSourcePropertyName is null)
+        {
+            return;
+        }
+
+        if (method.UsesSourceProperty(
+                this.compilation,
+                sourceProperty,
+                sourceClassType,
+                this.context.IsNullableEnabled()))
+        {
+            return;
+        }
+
+        this.context.ReportDiagnostic(MappaDiagnostics.MappaUsePropertyNotUsedByInvokeMethod(
+            mapMethodMethodDeclarationSyntax,
+            this.context.GetRootMapMethod().MethodName,
+            targetName,
+            explicitSourcePropertyName,
+            mappaInvokeMethodAttribute.MethodName));
+    }
+
+    private string? GetExplicitSourcePropertyNameForInvokeMethod(
+        string targetName,
+        MappaInvokeMethodAttribute mappaInvokeMethodAttribute,
+        StringComparison stringComparison)
+    {
+        if (!string.IsNullOrWhiteSpace(mappaInvokeMethodAttribute.SourcePropertyName))
+        {
+            return mappaInvokeMethodAttribute.SourcePropertyName;
+        }
+
+        var usePropertyAttributes = this.GetAttributeMapMethod()
+            .GetAttributes<MappaUsePropertyAttribute>()
+            .Where(attribute => this.AttributeTargetPathMatches(attribute.TargetPropertyName, targetName, stringComparison))
+            .ToArray();
+
+        return usePropertyAttributes.Length == 1
+            ? usePropertyAttributes[0].SourcePropertyName
+            : null;
+    }
+}

--- a/Mappa.Generator/Algorithm/StrategyDetectors/ConstructorMapStrategyDetector.ObjectFactory.cs
+++ b/Mappa.Generator/Algorithm/StrategyDetectors/ConstructorMapStrategyDetector.ObjectFactory.cs
@@ -46,34 +46,12 @@ internal sealed partial class ConstructorMapStrategyDetector
             return false;
         }
 
-        ParameterMapStrategy[] parametersMapStrategies = [];
-        PropertyMapStrategy[] initializerStrategies = [];
-
-        switch (objectFactory.InvocationKind)
+        if (!this.TryBuildObjectFactoryParameterAndInitializerStrategies(
+                objectFactory,
+                out var parametersMapStrategies,
+                out var initializerStrategies))
         {
-            case ObjectFactoryInvocationKind.FullyProduced:
-                break;
-
-            case ObjectFactoryInvocationKind.EmptyCtorLike:
-                if (!this.TryBuildEmptyCtorLikePropertyInitializers(
-                        requireAtLeastOneMappedProperty: false,
-                        out initializerStrategies))
-                {
-                    return false;
-                }
-
-                break;
-
-            case ObjectFactoryInvocationKind.ParameterizedLike:
-                if (!this.TryMapFactoryParameters(objectFactory.Method, out parametersMapStrategies))
-                {
-                    return false;
-                }
-
-                break;
-
-            default:
-                throw new MappaGeneratorException($"Unexpected object factory invocation kind '{objectFactory.InvocationKind}'.");
+            return false;
         }
 
         mapStrategy = new InvokeObjectFactoryMapStrategy(
@@ -193,75 +171,7 @@ internal sealed partial class ConstructorMapStrategyDetector
     private InvokeObjectFactoryMapStrategy EnrichInvokeObjectFactoryMapStrategyWithAssignToContext(
         InvokeObjectFactoryMapStrategy strategy)
     {
-        // Nested (derived) contexts do not expose a MapMethod; attribute enrichment is root-only.
-        if (this.context.MapMethod is null)
-        {
-            return strategy;
-        }
-
-        var attributes = this.context.MapMethod.GetAttributes<MappaAssignToContextAttribute>();
-        if (attributes.Length == 0)
-        {
-            return strategy;
-        }
-
-        var methodDeclarationSyntax = this.context.MapMethod.MethodDeclarationSyntax
-            ?? throw new MappaGeneratorException("Method declaration syntax has not been defined.");
-        var rootMapMethod = this.context.GetRootMapMethod();
-        var methodName = rootMapMethod.MethodName;
-        var targetTypeName = this.context.TargetType.ToDisplayString();
-        var providesContext = rootMapMethod.ProvideMappaContextWhenInvoked();
-
-        var duplicateContextKeys = new HashSet<string>(
-            attributes
-                .GroupBy(attribute => attribute.ContextKey, StringComparer.Ordinal)
-                .Where(group => group.Count() > 1)
-                .Select(group => group.Key),
-            StringComparer.Ordinal);
-
-        foreach (var duplicateContextKey in duplicateContextKeys)
-        {
-            this.context.ReportDiagnostic(MappaDiagnostics.MultipleMappaAssignToContextAttributesUseTheSameContextKey(
-                methodDeclarationSyntax,
-                methodName,
-                duplicateContextKey));
-        }
-
-        List<MappaAssignToContextEntry> assignToContextEntries = new();
-        string? contextParameterName = null;
-
-        foreach (var attribute in attributes)
-        {
-            if (duplicateContextKeys.Contains(attribute.ContextKey))
-            {
-                continue;
-            }
-
-            if (!providesContext)
-            {
-                this.context.ReportDiagnostic(MappaDiagnostics.CannotUseMappaAssignToContextAttributeWithoutContextParameter(
-                    methodDeclarationSyntax,
-                    methodName,
-                    attribute.ContextKey));
-                continue;
-            }
-
-            if (!this.TryResolveAssignToContextTargetMember(attribute.TargetPropertyName))
-            {
-                this.context.ReportDiagnostic(MappaDiagnostics.MappaAssignToContextTargetMemberDoesNotExistOrIsNotAccessible(
-                    methodDeclarationSyntax,
-                    methodName,
-                    attribute.ContextKey,
-                    attribute.TargetPropertyName,
-                    targetTypeName));
-                continue;
-            }
-
-            assignToContextEntries.Add(new MappaAssignToContextEntry(attribute.ContextKey, attribute.TargetPropertyName));
-            contextParameterName ??= rootMapMethod.GetMappaContextParameterName();
-        }
-
-        if (assignToContextEntries.Count == 0)
+        if (!this.TryBuildAssignToContextEnrichment(attributesEnabled: true, out var entries, out var contextParameterName))
         {
             return strategy;
         }
@@ -272,8 +182,34 @@ internal sealed partial class ConstructorMapStrategyDetector
             strategy.ObjectFactory,
             strategy.ParametersMapStrategies,
             strategy.InitializerStrategies,
-            [.. assignToContextEntries],
+            entries,
             contextParameterName);
+    }
+
+    private bool TryBuildObjectFactoryParameterAndInitializerStrategies(
+        ObjectFactory objectFactory,
+        out ParameterMapStrategy[] parametersMapStrategies,
+        out PropertyMapStrategy[] initializerStrategies)
+    {
+        parametersMapStrategies = [];
+        initializerStrategies = [];
+
+        switch (objectFactory.InvocationKind)
+        {
+            case ObjectFactoryInvocationKind.FullyProduced:
+                return true;
+
+            case ObjectFactoryInvocationKind.EmptyCtorLike:
+                return this.TryBuildEmptyCtorLikePropertyInitializers(
+                    requireAtLeastOneMappedProperty: false,
+                    out initializerStrategies);
+
+            case ObjectFactoryInvocationKind.ParameterizedLike:
+                return this.TryMapFactoryParameters(objectFactory.Method, out parametersMapStrategies);
+
+            default:
+                throw new MappaGeneratorException($"Unexpected object factory invocation kind '{objectFactory.InvocationKind}'.");
+        }
     }
 
     private bool TryBuildEmptyCtorLikePropertyInitializers(
@@ -302,308 +238,11 @@ internal sealed partial class ConstructorMapStrategyDetector
         var mappedInitializerStrategies = targetProperties
             .Where(targetProperty => this.context.MappaUserSettings.ProtobufOptional is not BooleanSetting.Enable
                                      || allTargetProperties.All(otherProperty => !targetProperty.Name.Equals($"Has{otherProperty.Name}", StringComparison.Ordinal)))
-            .Select(
-                targetProperty =>
-                {
-                    var usePropertyAttributes = this.GetMatchingUsePropertyAttributes(
-                        targetProperty.Name,
-                        StringComparison.Ordinal);
-
-                    string expectedSourcePropertyName;
-                    var useExactNameFromAttribute = false;
-                    PropertyPathContext? nestedPropertyPathContext = null;
-                    ChainedSourcePropertyPathInfo? chainedSourcePropertyPath = null;
-                    switch (usePropertyAttributes.Length)
-                    {
-                        case 0:
-                            expectedSourcePropertyName = targetProperty.Name;
-                            break;
-                        case 1:
-                        {
-                            var usePropertyAttribute = usePropertyAttributes[0];
-                            var isLeafTargetMapping = this.IsLeafTargetMappingForAttribute(usePropertyAttribute.TargetPropertyName);
-                            if (this.TryResolveExpectedSourcePropertyName(
-                                    usePropertyAttribute,
-                                    isLeafTargetMapping,
-                                    out expectedSourcePropertyName,
-                                    out useExactNameFromAttribute,
-                                    out nestedPropertyPathContext,
-                                    out chainedSourcePropertyPath))
-                            {
-                                break;
-                            }
-
-                            useExactNameFromAttribute = true;
-                            expectedSourcePropertyName = targetProperty.Name;
-                            break;
-                        }
-
-                        default:
-                        {
-                            var distinctTargetPaths = usePropertyAttributes
-                                .Select(attribute => attribute.TargetPropertyName)
-                                .Distinct(StringComparer.Ordinal)
-                                .ToArray();
-                            if (distinctTargetPaths.Length == 1)
-                            {
-                                this.context.ReportDiagnostic(MappaDiagnostics.TooManyUsePropertyAttributesForTheSameTargetProperty(this.context.GetRootMapMethod().MethodDeclarationSyntax, this.context.GetRootMapMethod().MethodName, targetProperty.Name));
-                                return new PropertyMapStrategy(targetProperty, null, noMapStrategy, false);
-                            }
-
-                            var distinctSourceRoots = usePropertyAttributes
-                                .Select(attribute => PropertyPath.Parse(attribute.SourcePropertyName).GetFirstSegment())
-                                .Where(segment => segment is not null)
-                                .Distinct(StringComparer.Ordinal)
-                                .ToArray();
-                            if (distinctSourceRoots.Length == 1)
-                            {
-                                var sourceRoot = distinctSourceRoots[0];
-                                if (sourceRoot is not null)
-                                {
-                                    expectedSourcePropertyName = sourceRoot;
-                                    useExactNameFromAttribute = true;
-                                }
-                                else
-                                {
-                                    expectedSourcePropertyName = targetProperty.Name;
-                                }
-                            }
-                            else
-                            {
-                                expectedSourcePropertyName = targetProperty.Name;
-                            }
-
-                            nestedPropertyPathContext = PropertyPathContext.CreateNestedAttributeScope(targetProperty.Name);
-                            break;
-                        }
-                    }
-
-                    if (this.context.PropertyPathContext is null
-                        && this.HasNestedPathAttributesForTargetMember(targetProperty.Name, StringComparison.Ordinal)
-                        && (nestedPropertyPathContext is null
-                            || this.CountNestedPathAttributesForTargetMember(targetProperty.Name, StringComparison.Ordinal) > 1))
-                    {
-                        nestedPropertyPathContext = PropertyPathContext.CreateNestedAttributeScope(targetProperty.Name);
-                    }
-
-                    IPropertySymbol? sourceProperty = null;
-                    if (chainedSourcePropertyPath is null)
-                    {
-                        PropertyMapNameMatcher.TryFindSourceProperty(
-                            sourceProperties,
-                            expectedSourcePropertyName,
-                            this.context.MappaUserSettings.CaseInsensitivePropertyMap,
-                            this.context.MappaUserSettings.IgnoreUnderscoreForPropertyMap,
-                            isConstructorParameterPath: false,
-                            useExactNameFromAttribute,
-                            out sourceProperty);
-                    }
-                    else if (this.TryResolveChainedSourceProperty(
-                                 chainedSourcePropertyPath,
-                                 out var resolvedSourceProperties,
-                                 out _))
-                    {
-                        sourceProperty = resolvedSourceProperties[0];
-                    }
-
-                    if ((this.context.MapMethod is not null || this.context.PropertyPathContext is not null)
-                        && this.TryGetStrategyForPropertyOrArgumentUsingAttributesOnMethod(
-                            targetProperty.Name,
-                            targetProperty.Type,
-                            this.context.SourceType,
-                            ref sourceProperty,
-                            StringComparison.Ordinal,
-                            isConstructorParameterPath: false,
-                            out var propertyStrategyFromAttribute))
-                    {
-                        if (!this.TryIsTargetPropertyWritable(targetProperty, out var requiresUnsafeAccessorOnTargetFromAttribute))
-                        {
-                            this.context.ReportDiagnostic(MappaDiagnostics.PropertySetterIsNotAccessible(this.context.GetRootMapMethod().MethodDeclarationSyntax, this.context.TargetType, targetProperty));
-                            return new PropertyMapStrategy(targetProperty, null, noMapStrategy, false);
-                        }
-
-                        propertyStrategyFromAttribute = this.EncapsulateMapStrategyForSourceOptional(sourceProperty, sourceProperties, propertyStrategyFromAttribute);
-                        propertyStrategyFromAttribute = this.EncapsulateMapStrategyForTargetOptional(targetProperty, allTargetProperties, propertyStrategyFromAttribute, out var postConstructorInitializer);
-                        var requiresUnsafeAccessorOnSourceFromAttribute = sourceProperty is not null
-                            && this.TryIsSourcePropertyReadable(sourceProperty, out var sourceRequiresUnsafeFromAttribute)
-                            && sourceRequiresUnsafeFromAttribute;
-                        return new PropertyMapStrategy(
-                            targetProperty,
-                            sourceProperty,
-                            propertyStrategyFromAttribute,
-                            postConstructorInitializer,
-                            chainedSourcePropertyPath,
-                            requiresUnsafeAccessorOnSourceFromAttribute,
-                            requiresUnsafeAccessorOnTargetFromAttribute);
-                    }
-
-                    if (chainedSourcePropertyPath is not null
-                        && this.TryResolveChainedSourceProperty(
-                            chainedSourcePropertyPath,
-                            out var chainedSourceProperties,
-                            out _))
-                    {
-                        var innerSourceType = chainedSourceProperties[chainedSourceProperties.Length - 1].Type;
-                        MapStrategy chainedPropertyStrategy = new IdentityMapStrategy(targetProperty.Type, innerSourceType);
-                        chainedPropertyStrategy = this.EncapsulateMapStrategyForTargetOptional(targetProperty, allTargetProperties, chainedPropertyStrategy, out var chainedPostConstructorInitializer);
-                        this.TryIsTargetPropertyWritable(targetProperty, out var requiresUnsafeAccessorOnTargetFromChain);
-                        return new PropertyMapStrategy(
-                            targetProperty,
-                            null,
-                            chainedPropertyStrategy,
-                            chainedPostConstructorInitializer,
-                            chainedSourcePropertyPath,
-                            requiresUnsafeAccessorOnSource: false,
-                            requiresUnsafeAccessorOnTarget: requiresUnsafeAccessorOnTargetFromChain);
-                    }
-
-                    var canWriteTargetProperty = this.TryIsTargetPropertyWritable(targetProperty, out var requiresUnsafeAccessorOnTargetSetter);
-                    if (sourceProperty is not null &&
-                        !canWriteTargetProperty &&
-                        this.TryIsTargetPropertyGetterReadable(targetProperty, out var requiresUnsafeAccessorOnTargetGetter))
-                    {
-                        if (targetProperty.Type.IsOrImplementIDictionary(this.compilation)
-                            && sourceProperty.Type.IsOrImplementIDictionary(this.compilation)
-                            && this.context.TryGetKeyAndValueStrategy(
-                                targetProperty.Type,
-                                sourceProperty.Type,
-                                this.compilation,
-                                out var keyStrategy,
-                                out var valueStrategy,
-                                this.cancellationToken))
-                        {
-                            var dictionaryPropertyStrategy = new ReadonlyDictionaryPropertyMapStrategy(
-                                targetProperty,
-                                sourceProperty,
-                                keyStrategy,
-                                valueStrategy,
-                                DictionaryAssignmentSettingHelper.GetEffective(this.context.MappaUserSettings.DictionaryAssignment));
-                            this.TryIsSourcePropertyReadable(sourceProperty, out var requiresUnsafeAccessorOnSourceDictionary);
-                            return new PropertyMapStrategy(
-                                targetProperty,
-                                sourceProperty,
-                                dictionaryPropertyStrategy,
-                                true,
-                                requiresUnsafeAccessorOnSource: requiresUnsafeAccessorOnSourceDictionary,
-                                requiresUnsafeAccessorOnTarget: requiresUnsafeAccessorOnTargetGetter);
-                        }
-                        else if ((targetProperty.Type.IsOrDerivedFromStack(this.compilation)
-                                  || targetProperty.Type.IsOrDerivedFromConcurrentStack(this.compilation))
-                                 && (sourceProperty.Type.IsArray() || sourceProperty.Type.IsOrImplementIEnumerable())
-                                 && this.context.TryGetElementStrategy(
-                                     targetProperty.Type,
-                                     sourceProperty.Type,
-                                     this.compilation,
-                                     out var stackElementStrategy,
-                                     this.cancellationToken))
-                        {
-                            var stackPropertyStrategy = new ReadonlyStackPropertyMapStrategy(targetProperty, sourceProperty, stackElementStrategy);
-                            this.TryIsSourcePropertyReadable(sourceProperty, out var requiresUnsafeAccessorOnSourceStack);
-                            return new PropertyMapStrategy(
-                                targetProperty,
-                                sourceProperty,
-                                stackPropertyStrategy,
-                                true,
-                                requiresUnsafeAccessorOnSource: requiresUnsafeAccessorOnSourceStack,
-                                requiresUnsafeAccessorOnTarget: requiresUnsafeAccessorOnTargetGetter);
-                        }
-                        else if ((targetProperty.Type.IsOrDerivedFromQueue(this.compilation)
-                                  || targetProperty.Type.IsOrImplementConcurrentQueue(this.compilation))
-                                 && (sourceProperty.Type.IsArray() || sourceProperty.Type.IsOrImplementIEnumerable())
-                                 && this.context.TryGetElementStrategy(
-                                     targetProperty.Type,
-                                     sourceProperty.Type,
-                                     this.compilation,
-                                     out var queueElementStrategy,
-                                     this.cancellationToken))
-                        {
-                            var queuePropertyStrategy = new ReadonlyQueuePropertyMapStrategy(targetProperty, sourceProperty, queueElementStrategy);
-                            this.TryIsSourcePropertyReadable(sourceProperty, out var requiresUnsafeAccessorOnSourceQueue);
-                            return new PropertyMapStrategy(
-                                targetProperty,
-                                sourceProperty,
-                                queuePropertyStrategy,
-                                true,
-                                requiresUnsafeAccessorOnSource: requiresUnsafeAccessorOnSourceQueue,
-                                requiresUnsafeAccessorOnTarget: requiresUnsafeAccessorOnTargetGetter);
-                        }
-                        else if ((targetProperty.Type.IsOrDerivedFromConcurrentBag(this.compilation)
-                                  || targetProperty.Type.IsOrDerivedFromBlockingCollection(this.compilation))
-                                 && (sourceProperty.Type.IsArray() || sourceProperty.Type.IsOrImplementIEnumerable())
-                                 && this.context.TryGetElementStrategy(
-                                     targetProperty.Type,
-                                     sourceProperty.Type,
-                                     this.compilation,
-                                     out var addCollectionElementStrategy,
-                                     this.cancellationToken))
-                        {
-                            var addCollectionPropertyStrategy = new ReadonlyAddCollectionPropertyMapStrategy(targetProperty, sourceProperty, addCollectionElementStrategy);
-                            this.TryIsSourcePropertyReadable(sourceProperty, out var requiresUnsafeAccessorOnSourceAddCollection);
-                            return new PropertyMapStrategy(
-                                targetProperty,
-                                sourceProperty,
-                                addCollectionPropertyStrategy,
-                                true,
-                                requiresUnsafeAccessorOnSource: requiresUnsafeAccessorOnSourceAddCollection,
-                                requiresUnsafeAccessorOnTarget: requiresUnsafeAccessorOnTargetGetter);
-                        }
-                        else if (targetProperty.Type.IsOrImplementICollection()
-                                 && (sourceProperty.Type.IsArray() || sourceProperty.Type.IsOrImplementIEnumerable())
-                                 && this.context.TryGetElementStrategy(
-                                     targetProperty.Type,
-                                     sourceProperty.Type,
-                                     this.compilation,
-                                     out var elementStrategy,
-                                     this.cancellationToken))
-                        {
-                            var collectionPropertyStrategy = new ReadonlyCollectionPropertyMapStrategy(targetProperty, sourceProperty, elementStrategy);
-                            this.TryIsSourcePropertyReadable(sourceProperty, out var requiresUnsafeAccessorOnSourceCollection);
-                            return new PropertyMapStrategy(
-                                targetProperty,
-                                sourceProperty,
-                                collectionPropertyStrategy,
-                                true,
-                                requiresUnsafeAccessorOnSource: requiresUnsafeAccessorOnSourceCollection,
-                                requiresUnsafeAccessorOnTarget: requiresUnsafeAccessorOnTargetGetter);
-                        }
-
-                        return new PropertyMapStrategy(targetProperty, null, noMapStrategy, false);
-                    }
-
-                    if (sourceProperty is null)
-                    {
-                        return new PropertyMapStrategy(targetProperty, sourceProperty, noMapStrategy, false);
-                    }
-
-                    if (!canWriteTargetProperty)
-                    {
-                        return new PropertyMapStrategy(targetProperty, sourceProperty, noMapStrategy, false);
-                    }
-
-                    var targetPropertyType = targetProperty.Type;
-                    var sourcePropertyType = sourceProperty.Type;
-
-                    if (this.TryGetStrategyBetweenTypes(
-                            targetPropertyType,
-                            sourcePropertyType,
-                            true,
-                            ConstructorMapStrategyDetector.GetNestedTypeMappingPropertyPathContext(targetProperty.Name, nestedPropertyPathContext),
-                            out var propertyStrategy))
-                    {
-                        propertyStrategy = this.EncapsulateMapStrategyForSourceOptional(sourceProperty, sourceProperties, propertyStrategy);
-                        propertyStrategy = this.EncapsulateMapStrategyForTargetOptional(targetProperty, allTargetProperties, propertyStrategy, out var postConstructorInitializer);
-                        this.TryIsSourcePropertyReadable(sourceProperty, out var requiresUnsafeAccessorOnSource);
-                        return new PropertyMapStrategy(
-                            targetProperty,
-                            sourceProperty,
-                            propertyStrategy,
-                            postConstructorInitializer,
-                            requiresUnsafeAccessorOnSource: requiresUnsafeAccessorOnSource,
-                            requiresUnsafeAccessorOnTarget: requiresUnsafeAccessorOnTargetSetter);
-                    }
-
-                    return new PropertyMapStrategy(targetProperty, null, noMapStrategy, false);
-                })
+            .Select(targetProperty => this.TryCreateEmptyCtorPropertyMapStrategy(
+                targetProperty,
+                allTargetProperties,
+                sourceProperties,
+                noMapStrategy))
             .ToArray();
 
         if (Array.Exists(mappedInitializerStrategies, propertyStrategy => propertyStrategy.TargetProperty.IsRequired && propertyStrategy.PropertyStrategy is NoMapStrategy))
@@ -619,42 +258,7 @@ internal sealed partial class ConstructorMapStrategyDetector
             .Where(propertyStrategy => propertyStrategy.PropertyStrategy is NoMapStrategy)
             .ToArray();
 
-        var mustMapAttribute = this.GetMustMapTargetPropertyAttribute();
-        var mustMapFailed = false;
-
-        foreach (var propertyWithoutStrategy in propertiesWithoutStrategy.Select(propertyStrategy => propertyStrategy.TargetProperty))
-        {
-            var targetCollections = propertyWithoutStrategy.Type.IsPostInitializationCollectionType(this.compilation);
-            var hasSetter = this.TryIsTargetPropertyWritable(propertyWithoutStrategy, out _);
-
-            if (!hasSetter && !targetCollections)
-            {
-                continue;
-            }
-
-            var isMustMapCandidate = mustMapAttribute is not null
-                                     && !propertyWithoutStrategy.IsRequired
-                                     && (mustMapAttribute.TargetPropertyNames.Length == 0
-                                         || mustMapAttribute.TargetPropertyNames.Contains(propertyWithoutStrategy.Name, StringComparer.Ordinal));
-
-            if (isMustMapCandidate)
-            {
-                this.context.ReportDiagnostic(MappaDiagnostics.MustMapTargetPropertyWasNotMapped(
-                    this.context.GetRootMapMethod().MethodDeclarationSyntax,
-                    this.context.TargetType,
-                    propertyWithoutStrategy));
-                mustMapFailed = true;
-            }
-            else if (propertiesWithStrategies.Length > 0)
-            {
-                this.context.ReportDiagnostic(MappaDiagnostics.CannotMapNonRequiredProperty(
-                    this.context.GetRootMapMethod().MethodDeclarationSyntax,
-                    this.context.TargetType,
-                    propertyWithoutStrategy));
-            }
-        }
-
-        if (mustMapFailed)
+        if (this.ReportEmptyCtorDiagnosticsForUnmappedProperties(propertiesWithStrategies, propertiesWithoutStrategy))
         {
             return false;
         }

--- a/Mappa.Generator/Algorithm/StrategyDetectors/ConstructorMapStrategyDetector.PropertyPaths.cs
+++ b/Mappa.Generator/Algorithm/StrategyDetectors/ConstructorMapStrategyDetector.PropertyPaths.cs
@@ -37,19 +37,37 @@ internal sealed partial class ConstructorMapStrategyDetector
             return nestedPropertyPathContext;
         }
 
-        // Remaining segments are already relative to the nested type being mapped.
-        // Descend when the current member is an intermediate (non-leaf) remaining segment.
-        if (nestedPropertyPathContext.RemainingTargetSegments.Length > 0)
+        var fromRemainingSegments = TryGetNestedTypeMappingFromRemainingSegments(targetMemberName, nestedPropertyPathContext);
+        if (fromRemainingSegments is not null)
         {
-            if (nestedPropertyPathContext.RemainingTargetSegments[0].Equals(targetMemberName, StringComparison.Ordinal)
-                && nestedPropertyPathContext.RemainingTargetSegments.Length > 1)
-            {
-                return nestedPropertyPathContext.DescendOneLevel();
-            }
-
-            return nestedPropertyPathContext;
+            return fromRemainingSegments;
         }
 
+        return TryGetNestedTypeMappingFromOriginalPath(targetMemberName, nestedPropertyPathContext);
+    }
+
+    private static PropertyPathContext? TryGetNestedTypeMappingFromRemainingSegments(
+        string targetMemberName,
+        PropertyPathContext nestedPropertyPathContext)
+    {
+        if (nestedPropertyPathContext.RemainingTargetSegments.Length == 0)
+        {
+            return null;
+        }
+
+        if (nestedPropertyPathContext.RemainingTargetSegments[0].Equals(targetMemberName, StringComparison.Ordinal)
+            && nestedPropertyPathContext.RemainingTargetSegments.Length > 1)
+        {
+            return nestedPropertyPathContext.DescendOneLevel();
+        }
+
+        return nestedPropertyPathContext;
+    }
+
+    private static PropertyPathContext? TryGetNestedTypeMappingFromOriginalPath(
+        string targetMemberName,
+        PropertyPathContext nestedPropertyPathContext)
+    {
         var originalTargetPath = PropertyPath.Parse(nestedPropertyPathContext.OriginalTargetPath);
         if (!originalTargetPath.IsNested)
         {
@@ -64,6 +82,16 @@ internal sealed partial class ConstructorMapStrategyDetector
         }
 
         return nestedPropertyPathContext;
+    }
+
+    private static bool IsMustMapEmptyCtorUnmappedProperty(
+        IPropertySymbol propertyWithoutStrategy,
+        MappaMustMapTargetPropertyAttribute? mustMapAttribute)
+    {
+        return mustMapAttribute is not null
+               && !propertyWithoutStrategy.IsRequired
+               && (mustMapAttribute.TargetPropertyNames.Length == 0
+                   || mustMapAttribute.TargetPropertyNames.Contains(propertyWithoutStrategy.Name, StringComparer.Ordinal));
     }
 
     private MapMethod GetAttributeMapMethod()
@@ -175,51 +203,21 @@ internal sealed partial class ConstructorMapStrategyDetector
 
         var targetPath = PropertyPath.Parse(usePropertyAttribute.TargetPropertyName);
         var sourcePath = PropertyPath.Parse(usePropertyAttribute.SourcePropertyName);
-        var activePropertyPathContext = this.context.PropertyPathContext;
-        if (activePropertyPathContext?.IsNestedAttributeScope == true)
-        {
-            activePropertyPathContext = PropertyPathAttributeMatching.CreatePropertyPathContext(
-                usePropertyAttribute.TargetPropertyName,
-                usePropertyAttribute.SourcePropertyName);
-        }
+        var activePropertyPathContext = this.GetActivePropertyPathContextForUseProperty(usePropertyAttribute);
 
-        if (this.context.PropertyPathContext is null && !targetPath.IsNested && sourcePath.IsNested)
+        if (this.TryCreateChainedSourceFromRootNestedSource(usePropertyAttribute, targetPath, sourcePath, out chainedSourcePropertyPath))
         {
-            chainedSourcePropertyPath = new ChainedSourcePropertyPathInfo(
-                usePropertyAttribute.SourcePropertyName,
-                sourcePath.Segments,
-                this.context.GetRootSourceType(),
-                this.context.GetRootMapMethod().SourceParameterName);
             return false;
         }
 
-        if (isLeafTargetMapping
-            && (sourcePath.IsNested || activePropertyPathContext is not null)
-            && this.context.PropertyPathContext is not null)
+        if (this.TryCreateChainedSourceForLeafTargetMapping(
+                usePropertyAttribute,
+                sourcePath,
+                activePropertyPathContext,
+                isLeafTargetMapping,
+                out chainedSourcePropertyPath))
         {
-            // Prefer reading remaining segments from the current nested source receiver
-            // so intermediate temps are reused instead of rebuilding the chain from the root.
-            string[] remainingSourceSegments;
-            if (this.context.PropertyPathContext.IsNestedAttributeScope)
-            {
-                remainingSourceSegments = activePropertyPathContext?.RemainingSourceSegments ?? sourcePath.Segments;
-            }
-            else
-            {
-                remainingSourceSegments = this.context.PropertyPathContext.RemainingSourceSegments.Length > 0
-                    ? this.context.PropertyPathContext.RemainingSourceSegments
-                    : sourcePath.Segments;
-            }
-
-            if (remainingSourceSegments.Length > 0)
-            {
-                chainedSourcePropertyPath = new ChainedSourcePropertyPathInfo(
-                    usePropertyAttribute.SourcePropertyName,
-                    remainingSourceSegments,
-                    this.context.SourceType,
-                    string.Empty);
-                return false;
-            }
+            return false;
         }
 
         var expectedSegment = PropertyPathAttributeMatching.GetExpectedSourcePropertyNameForCurrentLevel(
@@ -239,6 +237,89 @@ internal sealed partial class ConstructorMapStrategyDetector
                 usePropertyAttribute.SourcePropertyName)
             : null;
         return true;
+    }
+
+    private PropertyPathContext? GetActivePropertyPathContextForUseProperty(MappaUsePropertyAttribute usePropertyAttribute)
+    {
+        var activePropertyPathContext = this.context.PropertyPathContext;
+        if (activePropertyPathContext?.IsNestedAttributeScope == true)
+        {
+            return PropertyPathAttributeMatching.CreatePropertyPathContext(
+                usePropertyAttribute.TargetPropertyName,
+                usePropertyAttribute.SourcePropertyName);
+        }
+
+        return activePropertyPathContext;
+    }
+
+    private bool TryCreateChainedSourceFromRootNestedSource(
+        MappaUsePropertyAttribute usePropertyAttribute,
+        PropertyPath targetPath,
+        PropertyPath sourcePath,
+        out ChainedSourcePropertyPathInfo? chainedSourcePropertyPath)
+    {
+        chainedSourcePropertyPath = null;
+        if (this.context.PropertyPathContext is not null || targetPath.IsNested || !sourcePath.IsNested)
+        {
+            return false;
+        }
+
+        chainedSourcePropertyPath = new ChainedSourcePropertyPathInfo(
+            usePropertyAttribute.SourcePropertyName,
+            sourcePath.Segments,
+            this.context.GetRootSourceType(),
+            this.context.GetRootMapMethod().SourceParameterName);
+        return true;
+    }
+
+    private bool TryCreateChainedSourceForLeafTargetMapping(
+        MappaUsePropertyAttribute usePropertyAttribute,
+        PropertyPath sourcePath,
+        PropertyPathContext? activePropertyPathContext,
+        bool isLeafTargetMapping,
+        out ChainedSourcePropertyPathInfo? chainedSourcePropertyPath)
+    {
+        chainedSourcePropertyPath = null;
+        if (!isLeafTargetMapping
+            || (!sourcePath.IsNested && activePropertyPathContext is null)
+            || this.context.PropertyPathContext is null)
+        {
+            return false;
+        }
+
+        var remainingSourceSegments = this.GetRemainingSourceSegmentsForLeafMapping(
+            sourcePath,
+            activePropertyPathContext);
+        if (remainingSourceSegments.Length == 0)
+        {
+            return false;
+        }
+
+        chainedSourcePropertyPath = new ChainedSourcePropertyPathInfo(
+            usePropertyAttribute.SourcePropertyName,
+            remainingSourceSegments,
+            this.context.SourceType,
+            string.Empty);
+        return true;
+    }
+
+    private string[] GetRemainingSourceSegmentsForLeafMapping(
+        PropertyPath sourcePath,
+        PropertyPathContext? activePropertyPathContext)
+    {
+        if (this.context.PropertyPathContext is null)
+        {
+            return [];
+        }
+
+        if (this.context.PropertyPathContext.IsNestedAttributeScope)
+        {
+            return activePropertyPathContext?.RemainingSourceSegments ?? sourcePath.Segments;
+        }
+
+        return this.context.PropertyPathContext.RemainingSourceSegments.Length > 0
+            ? this.context.PropertyPathContext.RemainingSourceSegments
+            : sourcePath.Segments;
     }
 
     private bool IsMappingAttributeActiveAtCurrentLevel(string targetPropertyPath)

--- a/Mappa.Generator/Algorithm/StrategyDetectors/ConstructorMapStrategyDetector.cs
+++ b/Mappa.Generator/Algorithm/StrategyDetectors/ConstructorMapStrategyDetector.cs
@@ -402,76 +402,10 @@ internal sealed partial class ConstructorMapStrategyDetector
     private InvokeConstructorMapStrategy EnrichInvokeConstructorMapStrategyWithAssignToContext(
         InvokeConstructorMapStrategy strategy)
     {
-        if (this.context.AlgorithmSettings.UseAttributesForConstructorDetectorSettings
-                .Equals(MappaMapAlgorithmContextSettings.MappaAttributesForConstructorDetectorSettings.Disable)
-            || this.context.MapMethod is null)
-        {
-            return strategy;
-        }
+        var attributesEnabled = !this.context.AlgorithmSettings.UseAttributesForConstructorDetectorSettings
+            .Equals(MappaMapAlgorithmContextSettings.MappaAttributesForConstructorDetectorSettings.Disable);
 
-        var attributes = this.context.MapMethod.GetAttributes<MappaAssignToContextAttribute>();
-        if (attributes.Length == 0)
-        {
-            return strategy;
-        }
-
-        var methodDeclarationSyntax = this.context.MapMethod.MethodDeclarationSyntax
-            ?? throw new MappaGeneratorException("Method declaration syntax has not been defined.");
-        var rootMapMethod = this.context.GetRootMapMethod();
-        var methodName = rootMapMethod.MethodName;
-        var targetTypeName = this.context.TargetType.ToDisplayString();
-        var providesContext = rootMapMethod.ProvideMappaContextWhenInvoked();
-
-        var duplicateContextKeys = new HashSet<string>(
-            attributes
-                .GroupBy(attribute => attribute.ContextKey, StringComparer.Ordinal)
-                .Where(group => group.Count() > 1)
-                .Select(group => group.Key),
-            StringComparer.Ordinal);
-
-        foreach (var duplicateContextKey in duplicateContextKeys)
-        {
-            this.context.ReportDiagnostic(MappaDiagnostics.MultipleMappaAssignToContextAttributesUseTheSameContextKey(
-                methodDeclarationSyntax,
-                methodName,
-                duplicateContextKey));
-        }
-
-        List<MappaAssignToContextEntry> assignToContextEntries = new();
-        string? contextParameterName = null;
-
-        foreach (var attribute in attributes)
-        {
-            if (duplicateContextKeys.Contains(attribute.ContextKey))
-            {
-                continue;
-            }
-
-            if (!providesContext)
-            {
-                this.context.ReportDiagnostic(MappaDiagnostics.CannotUseMappaAssignToContextAttributeWithoutContextParameter(
-                    methodDeclarationSyntax,
-                    methodName,
-                    attribute.ContextKey));
-                continue;
-            }
-
-            if (!this.TryResolveAssignToContextTargetMember(attribute.TargetPropertyName))
-            {
-                this.context.ReportDiagnostic(MappaDiagnostics.MappaAssignToContextTargetMemberDoesNotExistOrIsNotAccessible(
-                    methodDeclarationSyntax,
-                    methodName,
-                    attribute.ContextKey,
-                    attribute.TargetPropertyName,
-                    targetTypeName));
-                continue;
-            }
-
-            assignToContextEntries.Add(new MappaAssignToContextEntry(attribute.ContextKey, attribute.TargetPropertyName));
-            contextParameterName ??= rootMapMethod.GetMappaContextParameterName();
-        }
-
-        if (assignToContextEntries.Count == 0)
+        if (!this.TryBuildAssignToContextEnrichment(attributesEnabled, out var entries, out var contextParameterName))
         {
             return strategy;
         }
@@ -482,7 +416,7 @@ internal sealed partial class ConstructorMapStrategyDetector
             strategy.Constructor,
             strategy.ParametersMapStrategies,
             strategy.InitializerStrategies,
-            [.. assignToContextEntries],
+            entries,
             contextParameterName,
             strategy.RequiresUnsafeAccessorOnConstructor);
     }
@@ -613,65 +547,15 @@ internal sealed partial class ConstructorMapStrategyDetector
             return false;
         }
 
-        // Apply the unique attribute that has been discovered.
         var attribute = matchingAttributes.Single();
-        switch (attribute)
-        {
-            case MappaInvokeMethodAttribute mappaInvokeMethodAttribute:
-                if (!string.IsNullOrWhiteSpace(mappaInvokeMethodAttribute.SourcePropertyName))
-                {
-                    this.ReportMappaUsePropertySourcePropertyWillNotBeUsedIfPresent(
-                        targetName,
-                        stringComparison,
-                        nameof(MappaInvokeMethodAttribute));
-                    this.TryResolveSourcePropertyForMappaInvokeMethodAttribute(
-                        mappaInvokeMethodAttribute,
-                        sourceClassType,
-                        isConstructorParameterPath,
-                        ref sourceProperty);
-                }
-
-                this.TryGetStrategyUsingMappaInvokeMethodAttribute(
-                    targetName,
-                    targetType,
-                    sourceClassType,
-                    sourceProperty,
-                    mappaInvokeMethodAttribute,
-                    stringComparison,
-                    out strategy);
-                break;
-            case MappaAssignFromContextAttribute mappaAssignFromContextAttribute:
-                this.TryGetStrategyUsingMappaAssignFromContextAttribute(
-                    targetName,
-                    targetType,
-                    mappaAssignFromContextAttribute,
-                    ref sourceProperty,
-                    out strategy);
-                if (strategy is not NoMapStrategy)
-                {
-                    this.ReportMappaUsePropertySourcePropertyWillNotBeUsedIfPresent(
-                        targetName,
-                        stringComparison,
-                        nameof(MappaAssignFromContextAttribute));
-                }
-
-                break;
-            case MappaAssignFromConstantAttribute mappaAssignFromConstantAttribute:
-                TryGetStrategyUsingMappaAssignFromConstantAttribute(
-                    targetType,
-                    mappaAssignFromConstantAttribute,
-                    out strategy);
-                if (strategy is not NoMapStrategy)
-                {
-                    sourceProperty = null; // Ignore any input property.
-                    this.ReportMappaUsePropertySourcePropertyWillNotBeUsedIfPresent(
-                        targetName,
-                        stringComparison,
-                        nameof(MappaAssignFromConstantAttribute));
-                }
-
-                break;
-        }
+        strategy = this.TryGetStrategyFromSingleTargetPropertyAttribute(
+            targetName,
+            targetType,
+            sourceClassType,
+            ref sourceProperty,
+            stringComparison,
+            isConstructorParameterPath,
+            attribute);
 
         return strategy is not NoMapStrategy;
     }
@@ -763,174 +647,6 @@ internal sealed partial class ConstructorMapStrategyDetector
             this.context.ReportDiagnostic(MappaDiagnostics.CannotUseMappaAssignFromContextAttributeWithoutContextParameter(
                 mapMethodMethodDeclarationSyntax,
                 targetName));
-        }
-    }
-
-    private void TryGetStrategyUsingMappaInvokeMethodAttribute(
-        string targetName,
-        ITypeSymbol targetType,
-        ITypeSymbol sourceClassType,
-        IPropertySymbol? sourceProperty,
-        MappaInvokeMethodAttribute mappaInvokeMethodAttribute,
-        StringComparison stringComparison,
-        out MapStrategy strategy)
-    {
-        strategy = new NoMapStrategy(targetType, null!);
-
-        var mapMethod = this.GetAttributeMapMethod();
-        var mapMethodMethodDeclarationSyntax = mapMethod.MethodDeclarationSyntax ?? throw new MappaGeneratorException("Method declaration syntax has not been defined.");
-        var mapMethodClass = mapMethod.ContainingType;
-
-        var rootMethod = this.context.GetRootMapMethod();
-        ISymbol? fieldOrProperty = null;
-        InvokeMethodResolutionResult resolutionResult;
-        IMethodSymbol? method;
-        if (mappaInvokeMethodAttribute.FieldName is not null)
-        {
-            fieldOrProperty = this.compilation.LocateAccessibleFieldOrPropertyInTypeHierarchy(
-                mapMethodClass,
-                mappaInvokeMethodAttribute.FieldName,
-                mapMethodClass);
-
-            if (fieldOrProperty is null)
-            {
-                this.context.ReportDiagnostic(MappaDiagnostics.CannotFindFieldOrProperty(
-                    mapMethodMethodDeclarationSyntax,
-                    mappaInvokeMethodAttribute.FieldName));
-                return;
-            }
-
-            if (rootMethod.CanBeUsedByStaticMethod && !fieldOrProperty.IsStatic)
-            {
-                this.context.ReportDiagnostic(MappaDiagnostics.FieldOrPropertyMustBeStatic(
-                      fieldOrProperty.Name,
-                      rootMethod.Location));
-                return;
-            }
-
-            var fieldOrPropertyType = fieldOrProperty switch
-            {
-                IFieldSymbol field => field.Type,
-                IPropertySymbol property => property.Type,
-                _ => throw new MappaGeneratorException($"Unexpected symbol kind '{fieldOrProperty.Kind}' for field or property '{fieldOrProperty.Name}'."),
-            };
-
-            resolutionResult = this.TryResolveInvokeMethodForAttribute(
-                mapMethodClass,
-                fieldOrPropertyType.LocateMethods(mappaInvokeMethodAttribute.MethodName),
-                mappaInvokeMethodAttribute.MethodName,
-                targetType,
-                sourceClassType,
-                sourceProperty,
-                InvokeMethodStaticRequirement.NotStatic,
-                rootMethod,
-                mapMethodMethodDeclarationSyntax,
-                out method);
-        }
-        else if (mappaInvokeMethodAttribute.ClassType is not null)
-        {
-            var className = this.compilation.GetTypeByMetadataName(
-                mappaInvokeMethodAttribute.ClassType.FullName ?? throw new MappaGeneratorException("Cannot detect type full name"));
-            if (className is null)
-            {
-                this.context.ReportDiagnostic(MappaDiagnostics.CannotDetectType(
-                    mapMethodMethodDeclarationSyntax,
-                    mappaInvokeMethodAttribute.ClassType.FullName!));
-                return;
-            }
-
-            resolutionResult = this.TryResolveInvokeMethodForAttribute(
-                mapMethodClass,
-                className.LocateMethods(mappaInvokeMethodAttribute.MethodName),
-                mappaInvokeMethodAttribute.MethodName,
-                targetType,
-                sourceClassType,
-                sourceProperty,
-                InvokeMethodStaticRequirement.Static,
-                rootMethod,
-                mapMethodMethodDeclarationSyntax,
-                out method);
-        }
-        else
-        {
-            var rootMapMethod = rootMethod;
-            var staticRequirement = rootMapMethod.CanBeUsedByStaticMethod
-                ? InvokeMethodStaticRequirement.Static
-                : InvokeMethodStaticRequirement.StaticOrNotStatic;
-
-            resolutionResult = this.TryResolveInvokeMethodForAttribute(
-                mapMethodClass,
-                mapMethodClass.LocateMethods(mappaInvokeMethodAttribute.MethodName),
-                mappaInvokeMethodAttribute.MethodName,
-                targetType,
-                sourceClassType,
-                sourceProperty,
-                staticRequirement,
-                rootMethod,
-                mapMethodMethodDeclarationSyntax,
-                out method);
-        }
-
-        if (resolutionResult is InvokeMethodResolutionResult.Ambiguous)
-        {
-            return;
-        }
-
-        if (resolutionResult is not InvokeMethodResolutionResult.Success || method is null)
-        {
-            var displayClassName = mappaInvokeMethodAttribute.ClassType is not null
-                ? mappaInvokeMethodAttribute.ClassType.FullName ?? "unknown"
-                : mapMethodClass.ToDisplayString();
-            this.context.ReportDiagnostic(MappaDiagnostics.CannotDetectSuitableMethodToInvokeForParameter(
-                mapMethodMethodDeclarationSyntax,
-                targetName,
-                mappaInvokeMethodAttribute.MethodName,
-                displayClassName));
-            return;
-        }
-
-        var contextParameterName = method.MethodHasMappaContextParameter(this.compilation)
-            ? rootMethod.MaybeGetMappaContextParameterName()
-            : null;
-
-        strategy = new MappaInvokeMethodAttributeStrategy(
-            targetType,
-            sourceClassType,
-            mappaInvokeMethodAttribute,
-            fieldOrProperty,
-            method,
-            sourceProperty,
-            this.GetAttributeMapMethod().NullableEnabled,
-            contextParameterName);
-
-        var usePropertyAttributes = this.GetAttributeMapMethod()
-            .GetAttributes<MappaUsePropertyAttribute>()
-            .Where(attribute => this.AttributeTargetPathMatches(attribute.TargetPropertyName, targetName, stringComparison))
-            .ToArray();
-
-        string? explicitSourcePropertyName = null;
-        if (!string.IsNullOrWhiteSpace(mappaInvokeMethodAttribute.SourcePropertyName))
-        {
-            explicitSourcePropertyName = mappaInvokeMethodAttribute.SourcePropertyName;
-        }
-        else if (usePropertyAttributes.Length == 1)
-        {
-            explicitSourcePropertyName = usePropertyAttributes[0].SourcePropertyName;
-        }
-
-        if (explicitSourcePropertyName is not null &&
-            !method.UsesSourceProperty(
-                this.compilation,
-                sourceProperty,
-                sourceClassType,
-                this.context.IsNullableEnabled()))
-        {
-            this.context.ReportDiagnostic(MappaDiagnostics.MappaUsePropertyNotUsedByInvokeMethod(
-                mapMethodMethodDeclarationSyntax,
-                this.context.GetRootMapMethod().MethodName,
-                targetName,
-                explicitSourcePropertyName,
-                mappaInvokeMethodAttribute.MethodName));
         }
     }
 

--- a/Mappa.Generator/Algorithm/StrategyDetectors/ContainerMapStrategyDetector.cs
+++ b/Mappa.Generator/Algorithm/StrategyDetectors/ContainerMapStrategyDetector.cs
@@ -18,6 +18,119 @@ namespace Mappa.Generator.Algorithm.StrategyDetectors;
 internal sealed class ContainerMapStrategyDetector
     : IMapStrategyDetector
 {
+    private static readonly Func<ITypeSymbol, Compilation, bool>[] SourceCollectionTypePredicates =
+    {
+        static (type, _) => type.IsOrImplementIEnumerable(),
+        static (type, compilation) => type.IsSpan(compilation),
+        static (type, compilation) => type.IsMemory(compilation),
+        static (type, compilation) => type.IsReadOnlySpan(compilation),
+        static (type, compilation) => type.IsReadOnlyMemory(compilation),
+    };
+
+    private static readonly Func<ITypeSymbol, Compilation, bool>[] SupportedCollectionTargetTypePredicates =
+    {
+        static (type, _) => type.IsArray(),
+        static (type, _) => type.IsIEnumerable(),
+        static (type, _) => type.IsIList(),
+        static (type, _) => type.IsIReadOnlyList(),
+        static (type, compilation) => type.IsList(compilation),
+        static (type, _) => type.IsOrImplementICollection(),
+        static (type, _) => type.IsIReadOnlyCollection(),
+        static (type, compilation) => type.IsSpan(compilation),
+        static (type, compilation) => type.IsReadOnlySpan(compilation),
+        static (type, compilation) => type.IsMemory(compilation),
+        static (type, compilation) => type.IsReadOnlyMemory(compilation),
+        static (type, compilation) => type.IsOrDerivedFromStack(compilation),
+        static (type, compilation) => type.IsOrDerivedFromQueue(compilation),
+        static (type, compilation) => type.IsOrImplementISet(compilation),
+        static (type, compilation) => type.IsIReadOnlySet(compilation),
+        static (type, compilation) => type.IsHashSet(compilation),
+        static (type, compilation) => type.IsReadOnlyCollection(compilation),
+        static (type, compilation) => type.IsReadOnlySet(compilation),
+        static (type, compilation) => type.IsFrozenSet(compilation),
+        static (type, compilation) => type.IsIImmutableSet(compilation),
+        static (type, compilation) => type.IsImmutableHashSet(compilation),
+        static (type, compilation) => type.IsImmutableSortedSet(compilation),
+        static (type, compilation) => type.IsIImmutableList(compilation),
+        static (type, compilation) => type.IsImmutableArray(compilation),
+        static (type, compilation) => type.IsImmutableList(compilation),
+        static (type, compilation) => type.IsIImmutableQueue(compilation),
+        static (type, compilation) => type.IsImmutableQueue(compilation),
+        static (type, compilation) => type.IsIImmutableStack(compilation),
+        static (type, compilation) => type.IsImmutableStack(compilation),
+        static (type, compilation) => type.IsOrDerivedFromBlockingCollection(compilation),
+        static (type, compilation) => type.IsOrDerivedFromConcurrentBag(compilation),
+        static (type, compilation) => type.IsOrDerivedFromConcurrentStack(compilation),
+        static (type, compilation) => type.IsOrImplementConcurrentQueue(compilation),
+        static (type, compilation) => type.IsIProducerConsumerCollection(compilation),
+    };
+
+    private static readonly Func<ITypeSymbol, Compilation, bool>[] SupportedCollectionInterfaceTargetPredicates =
+    {
+        static (type, _) => type.IsIEnumerable(),
+        static (type, _) => type.IsIList(),
+        static (type, _) => type.IsIReadOnlyList(),
+        static (type, _) => type.IsICollection(),
+        static (type, _) => type.IsIReadOnlyCollection(),
+        static (type, compilation) => type.IsISet(compilation),
+        static (type, compilation) => type.IsIReadOnlySet(compilation),
+        static (type, compilation) => type.IsIImmutableSet(compilation),
+        static (type, compilation) => type.IsIImmutableList(compilation),
+        static (type, compilation) => type.IsIImmutableQueue(compilation),
+        static (type, compilation) => type.IsIImmutableStack(compilation),
+        static (type, compilation) => type.IsIProducerConsumerCollection(compilation),
+    };
+
+    private static readonly Func<ITypeSymbol, Compilation, bool>[] BuiltInCollectionConstructorTargetPredicates =
+    {
+        static (type, compilation) => type.IsReadOnlyCollection(compilation),
+        static (type, compilation) => type.IsReadOnlySet(compilation),
+        static (type, compilation) => type.IsFrozenSet(compilation),
+        static (type, compilation) => type.IsImmutableHashSet(compilation),
+        static (type, compilation) => type.IsImmutableSortedSet(compilation),
+        static (type, compilation) => type.IsImmutableArray(compilation),
+        static (type, compilation) => type.IsImmutableList(compilation),
+        static (type, compilation) => type.IsImmutableQueue(compilation),
+        static (type, compilation) => type.IsImmutableStack(compilation),
+    };
+
+    private static readonly Func<ITypeSymbol, Compilation, bool>[] CapacityConstructorSupportPredicates =
+    {
+        static (type, _) => type.ImplementICollection(),
+        static (type, compilation) => type.ImplementISet(compilation),
+        static (type, compilation) => type.IsOrDerivedFromStack(compilation),
+        static (type, compilation) => type.IsOrDerivedFromQueue(compilation),
+        static (type, compilation) => type.IsOrDerivedFromBlockingCollection(compilation),
+    };
+
+    private static readonly Func<ITypeSymbol, Compilation, bool>[] DictionaryConcreteTargetTypePredicates =
+    [
+        static (type, compilation) => type.IsOrImplementIDictionary(compilation),
+        static (type, compilation) => type.IsIEnumerableOfKeyValuePairs(compilation),
+        static (type, compilation) => type.IsIReadOnlyDictionary(compilation),
+        static (type, compilation) => type.IsReadOnlyDictionary(compilation),
+        static (type, compilation) => type.IsIImmutableDictionary(compilation),
+        static (type, compilation) => type.IsImmutableDictionary(compilation),
+        static (type, compilation) => type.IsImmutableSortedDictionary(compilation),
+        static (type, compilation) => type.IsFrozenDictionary(compilation),
+    ];
+
+    private static readonly Func<ITypeSymbol, Compilation, bool>[] DictionaryInterfaceTargetTypePredicates =
+    [
+        static (type, compilation) => type.IsIDictionary(compilation),
+        static (type, compilation) => type.IsIEnumerableOfKeyValuePairs(compilation),
+        static (type, compilation) => type.IsIReadOnlyDictionary(compilation),
+        static (type, compilation) => type.IsIImmutableDictionary(compilation),
+    ];
+
+    private static readonly Func<ITypeSymbol, Compilation, bool>[] DictionaryBuiltInConstructorTargetPredicates =
+    [
+        static (type, compilation) => type.IsReadOnlyDictionary(compilation),
+        static (type, compilation) => type.IsImmutableDictionary(compilation),
+        static (type, compilation) => type.IsImmutableSortedDictionary(compilation),
+        static (type, compilation) => type.IsFrozenDictionary(compilation),
+    ];
+
     private readonly MappaMapAlgorithmContext context;
     private readonly Compilation compilation;
     private readonly CancellationToken cancellationToken;
@@ -77,217 +190,165 @@ internal sealed class ContainerMapStrategyDetector
             ? EnumerableConcreteTypeSetting.List
             : enumerableConcreteTypeSetting;
 
+    private static bool MatchesAnyPredicate(
+        ITypeSymbol type,
+        Compilation compilation,
+        Func<ITypeSymbol, Compilation, bool>[] predicates)
+        => predicates.Any(predicate => predicate(type, compilation));
+
+    private static bool IsSourceCollectionType(ITypeSymbol type, Compilation compilation)
+        => MatchesAnyPredicate(type, compilation, SourceCollectionTypePredicates);
+
+    private static bool IsSupportedCollectionTargetType(ITypeSymbol type, Compilation compilation)
+        => MatchesAnyPredicate(type, compilation, SupportedCollectionTargetTypePredicates);
+
     private bool CanMapDictionaryToDictionary(out MapStrategy keyStrategy, out MapStrategy valueStrategy)
     {
-        var isSourceDictionary = this.context.SourceType.IsOrImplementIDictionary(this.compilation)
-                                 || this.context.TargetType.IsIReadOnlyDictionary(this.compilation)
-                                 || this.context.TargetType.IsOrImplementIEnumerableOfKeyValuePair(this.compilation);
-        var isTargetDictionary = (this.context.TargetType.IsOrImplementIDictionary(this.compilation)
-                                  || this.context.TargetType.IsIEnumerableOfKeyValuePairs(this.compilation)
-                                  || this.context.TargetType.IsIReadOnlyDictionary(this.compilation)
-                                  || this.context.TargetType.IsReadOnlyDictionary(this.compilation)
-                                  || this.context.TargetType.IsIImmutableDictionary(this.compilation)
-                                  || this.context.TargetType.IsImmutableDictionary(this.compilation)
-                                  || this.context.TargetType.IsImmutableSortedDictionary(this.compilation)
-                                  || this.context.TargetType.IsFrozenDictionary(this.compilation))
-            && IfInterfaceAcceptOnlyIDictionary();
-
         keyStrategy = new NoMapStrategy(this.context.TargetType, this.context.SourceType);
         valueStrategy = new NoMapStrategy(this.context.TargetType, this.context.SourceType);
 
-        return isSourceDictionary && isTargetDictionary && this.context.TryGetKeyAndValueStrategy(
+        if (!this.IsDictionaryMappingSourceSideEligible())
+        {
+            return false;
+        }
+
+        if (!MatchesAnyPredicate(this.context.TargetType, this.compilation, DictionaryConcreteTargetTypePredicates)
+            || !this.TargetTypeAcceptsDictionaryMapping())
+        {
+            return false;
+        }
+
+        return this.context.TryGetKeyAndValueStrategy(
             this.compilation,
             out keyStrategy,
             out valueStrategy,
             this.cancellationToken);
+    }
 
-        bool IfInterfaceAcceptOnlyIDictionary()
+    private bool IsDictionaryMappingSourceSideEligible()
+        => this.context.SourceType.IsOrImplementIDictionary(this.compilation)
+           || this.context.TargetType.IsIReadOnlyDictionary(this.compilation)
+           || this.context.TargetType.IsOrImplementIEnumerableOfKeyValuePair(this.compilation);
+
+    private bool TargetTypeAcceptsDictionaryMapping()
+    {
+        if (this.context.TargetType.TypeKind is TypeKind.Interface)
         {
-            if (this.context.TargetType.TypeKind is TypeKind.Interface)
-            {
-                return this.context.TargetType.IsIDictionary(this.compilation)
-                       || this.context.TargetType.IsIEnumerableOfKeyValuePairs(this.compilation)
-                       || this.context.TargetType.IsIReadOnlyDictionary(this.compilation)
-                       || this.context.TargetType.IsIImmutableDictionary(this.compilation)
-                       ;
-            }
-
-            // Target type MUST have a constructor with no arguments
-            // unless it is a ReadOnlyDictionary, ImmutableDictionary or a FrozenDictionary
-            // for which special coding is provided.
-            if (this.context.TargetType.IsReadOnlyDictionary(this.compilation)
-                || this.context.TargetType.IsImmutableDictionary(this.compilation)
-                || this.context.TargetType.IsImmutableSortedDictionary(this.compilation)
-                || this.context.TargetType.IsFrozenDictionary(this.compilation))
-            {
-                return true;
-            }
-
-            return this.context.TargetType.HasSymbolAccessibleZeroParametersConstructor(this.compilation, this.context.MapMethod?.MethodSymbol);
+            return MatchesAnyPredicate(
+                this.context.TargetType,
+                this.compilation,
+                DictionaryInterfaceTargetTypePredicates);
         }
+
+        if (MatchesAnyPredicate(
+                this.context.TargetType,
+                this.compilation,
+                DictionaryBuiltInConstructorTargetPredicates))
+        {
+            return true;
+        }
+
+        return this.context.TargetType.HasSymbolAccessibleZeroParametersConstructor(this.compilation, this.context.MapMethod?.MethodSymbol);
     }
 
     private bool CanMapCollectionToCollection(out MapStrategy elementStrategy)
     {
-        var sourceIsQueryable = this.context.SourceType.IsOrImplementIQueryable(this.compilation);
-        var targetIsQueryable = this.context.TargetType.IsOrImplementIQueryable(this.compilation);
+        elementStrategy = new NoMapStrategy(this.context.TargetType, this.context.SourceType);
 
-        if (sourceIsQueryable || targetIsQueryable)
+        if (this.RejectQueryableCollectionToCollectionMapping())
         {
-            if (sourceIsQueryable
-                && !targetIsQueryable
-                && this.context.MapMethod is not null
-                && this.IsConcreteCollectionTarget())
-            {
-                this.context.ReportDiagnostic(
-                    MappaDiagnostics.IQueryableMappedAsCollection(
-                        this.context.MapMethod.MethodDeclarationSyntax?.GetLocation(),
-                        this.context.MapMethod.MethodName));
-            }
-
-            elementStrategy = new NoMapStrategy(this.context.TargetType, this.context.SourceType);
             return false;
         }
 
-        var isSourceCollection = this.context.SourceType.IsOrImplementIEnumerable()
-            || this.context.SourceType.IsSpan(this.compilation)
-            || this.context.SourceType.IsMemory(this.compilation)
-            || this.context.SourceType.IsReadOnlySpan(this.compilation)
-            || this.context.SourceType.IsReadOnlyMemory(this.compilation);
+        if (!IsSourceCollectionType(this.context.SourceType, this.compilation))
+        {
+            return false;
+        }
 
-        var isTargetCollection = (this.context.TargetType.IsArray()
-                                 || this.context.TargetType.IsIEnumerable()
-                                 || this.context.TargetType.IsIList()
-                                 || this.context.TargetType.IsIReadOnlyList()
-                                 || this.context.TargetType.IsList(this.compilation)
-                                 || this.context.TargetType.IsOrImplementICollection()
-                                 || this.context.TargetType.IsIReadOnlyCollection()
-                                 || this.context.TargetType.IsSpan(this.compilation)
-                                 || this.context.TargetType.IsReadOnlySpan(this.compilation)
-                                 || this.context.TargetType.IsMemory(this.compilation)
-                                 || this.context.TargetType.IsReadOnlyMemory(this.compilation)
-                                 || this.context.TargetType.IsOrDerivedFromStack(this.compilation)
-                                 || this.context.TargetType.IsOrDerivedFromQueue(this.compilation)
-                                 || this.context.TargetType.IsOrImplementISet(this.compilation)
-                                 || this.context.TargetType.IsIReadOnlySet(this.compilation)
-                                 || this.context.TargetType.IsHashSet(this.compilation)
-                                 || this.context.TargetType.IsReadOnlyCollection(this.compilation)
-                                 || this.context.TargetType.IsReadOnlySet(this.compilation)
-                                 || this.context.TargetType.IsFrozenSet(this.compilation)
-                                 || this.context.TargetType.IsIImmutableSet(this.compilation)
-                                 || this.context.TargetType.IsImmutableHashSet(this.compilation)
-                                 || this.context.TargetType.IsImmutableSortedSet(this.compilation)
-                                 || this.context.TargetType.IsIImmutableList(this.compilation)
-                                 || this.context.TargetType.IsImmutableArray(this.compilation)
-                                 || this.context.TargetType.IsImmutableList(this.compilation)
-                                 || this.context.TargetType.IsIImmutableQueue(this.compilation)
-                                 || this.context.TargetType.IsImmutableQueue(this.compilation)
-                                 || this.context.TargetType.IsIImmutableStack(this.compilation)
-                                 || this.context.TargetType.IsImmutableStack(this.compilation)
-                                 || this.context.TargetType.IsOrDerivedFromBlockingCollection(this.compilation)
-                                 || this.context.TargetType.IsOrDerivedFromConcurrentBag(this.compilation)
-                                 || this.context.TargetType.IsOrDerivedFromConcurrentStack(this.compilation)
-                                 || this.context.TargetType.IsOrImplementConcurrentQueue(this.compilation)
-                                 || this.context.TargetType.IsIProducerConsumerCollection(this.compilation))
-                                 && InterfaceAndConstructorChecks();
+        if (!IsSupportedCollectionTargetType(this.context.TargetType, this.compilation))
+        {
+            return false;
+        }
 
-        elementStrategy = new NoMapStrategy(this.context.TargetType, this.context.SourceType);
+        if (!this.PassesInterfaceAndConstructorChecks())
+        {
+            return false;
+        }
 
-        return isSourceCollection && isTargetCollection && this.context.TryGetElementStrategy(
+        return this.context.TryGetElementStrategy(
             this.compilation,
             out elementStrategy,
             this.cancellationToken);
-
-        bool InterfaceAndConstructorChecks()
-        {
-            if (this.context.TargetType.TypeKind is TypeKind.Array)
-            {
-                return true;
-            }
-
-            if (this.context.TargetType.TypeKind is TypeKind.Interface)
-            {
-                return this.context.TargetType.IsIEnumerable()
-                       || this.context.TargetType.IsIList()
-                       || this.context.TargetType.IsIReadOnlyList()
-                       || this.context.TargetType.IsICollection()
-                       || this.context.TargetType.IsIReadOnlyCollection()
-                       || this.context.TargetType.IsISet(this.compilation)
-                       || this.context.TargetType.IsIReadOnlySet(this.compilation)
-                       || this.context.TargetType.IsIImmutableSet(this.compilation)
-                       || this.context.TargetType.IsIImmutableList(this.compilation)
-                       || this.context.TargetType.IsIImmutableQueue(this.compilation)
-                       || this.context.TargetType.IsIImmutableStack(this.compilation)
-                       || this.context.TargetType.IsIProducerConsumerCollection(this.compilation);
-            }
-
-            // For the following concrete types a suitable constructor exists.
-            if (this.context.TargetType.IsReadOnlyCollection(this.compilation)
-                || this.context.TargetType.IsReadOnlySet(this.compilation)
-                || this.context.TargetType.IsFrozenSet(this.compilation)
-                || this.context.TargetType.IsImmutableHashSet(this.compilation)
-                || this.context.TargetType.IsImmutableSortedSet(this.compilation)
-                || this.context.TargetType.IsImmutableArray(this.compilation)
-                || this.context.TargetType.IsImmutableList(this.compilation)
-                || this.context.TargetType.IsImmutableQueue(this.compilation)
-                || this.context.TargetType.IsImmutableStack(this.compilation))
-            {
-                return true;
-            }
-
-            // Any other concrete type must either have:
-            // - a constructor with no parameters
-            // - (only if ContainerCapacityConstructors is enabled) a constructor with one integer
-            //   parameter and implement either: ICollection{T}, ISet{T}, IQueue{T}, IStack{T}
-            //   or derive BlockingCollection{T}.
-            return this.context.TargetType.HasSymbolAccessibleZeroParametersConstructor(this.compilation, this.context.MapMethod?.MethodSymbol)
-                || (this.context.MappaUserSettings.ContainerCapacityConstructors is BooleanSetting.Enable
-                    && this.context.TargetType.TypeKind != TypeKind.Interface
-                    && CanSupportImplementationWithCapacityConstructor()
-                    && this.context.TargetType.HasSymbolAccessibleSingleIntegerParametersConstructor(this.compilation, this.context.MapMethod?.MethodSymbol));
-        }
-
-        bool CanSupportImplementationWithCapacityConstructor()
-            => this.context.TargetType.ImplementICollection()
-            || this.context.TargetType.ImplementISet(this.compilation)
-            || this.context.TargetType.IsOrDerivedFromStack(this.compilation)
-            || this.context.TargetType.IsOrDerivedFromQueue(this.compilation)
-            || this.context.TargetType.IsOrDerivedFromBlockingCollection(this.compilation);
     }
 
+    private bool RejectQueryableCollectionToCollectionMapping()
+    {
+        var sourceIsQueryable = this.context.SourceType.IsOrImplementIQueryable(this.compilation);
+        var targetIsQueryable = this.context.TargetType.IsOrImplementIQueryable(this.compilation);
+        if (!sourceIsQueryable && !targetIsQueryable)
+        {
+            return false;
+        }
+
+        if (sourceIsQueryable
+            && !targetIsQueryable
+            && this.context.MapMethod is not null
+            && this.IsConcreteCollectionTarget())
+        {
+            this.context.ReportDiagnostic(
+                MappaDiagnostics.IQueryableMappedAsCollection(
+                    this.context.MapMethod.MethodDeclarationSyntax?.GetLocation(),
+                    this.context.MapMethod.MethodName));
+        }
+
+        return true;
+    }
+
+    private bool PassesInterfaceAndConstructorChecks()
+    {
+        if (this.context.TargetType.TypeKind is TypeKind.Array)
+        {
+            return true;
+        }
+
+        if (this.context.TargetType.TypeKind is TypeKind.Interface)
+        {
+            return MatchesAnyPredicate(
+                this.context.TargetType,
+                this.compilation,
+                SupportedCollectionInterfaceTargetPredicates);
+        }
+
+        // For the following concrete types a suitable constructor exists.
+        if (MatchesAnyPredicate(
+                this.context.TargetType,
+                this.compilation,
+                BuiltInCollectionConstructorTargetPredicates))
+        {
+            return true;
+        }
+
+        // Any other concrete type must either have:
+        // - a constructor with no parameters
+        // - (only if ContainerCapacityConstructors is enabled) a constructor with one integer
+        //   parameter and implement either: ICollection{T}, ISet{T}, IQueue{T}, IStack{T}
+        //   or derive BlockingCollection{T}.
+        return this.context.TargetType.HasSymbolAccessibleZeroParametersConstructor(this.compilation, this.context.MapMethod?.MethodSymbol)
+            || this.PassesCapacityConstructorChecks();
+    }
+
+    private bool PassesCapacityConstructorChecks()
+        => this.context.MappaUserSettings.ContainerCapacityConstructors is BooleanSetting.Enable
+            && this.context.TargetType.TypeKind != TypeKind.Interface
+            && this.CanSupportImplementationWithCapacityConstructor()
+            && this.context.TargetType.HasSymbolAccessibleSingleIntegerParametersConstructor(this.compilation, this.context.MapMethod?.MethodSymbol);
+
+    private bool CanSupportImplementationWithCapacityConstructor()
+        => MatchesAnyPredicate(
+            this.context.TargetType,
+            this.compilation,
+            CapacityConstructorSupportPredicates);
+
     private bool IsConcreteCollectionTarget()
-        => this.context.TargetType.IsArray()
-           || this.context.TargetType.IsIEnumerable()
-           || this.context.TargetType.IsIList()
-           || this.context.TargetType.IsIReadOnlyList()
-           || this.context.TargetType.IsList(this.compilation)
-           || this.context.TargetType.IsOrImplementICollection()
-           || this.context.TargetType.IsIReadOnlyCollection()
-           || this.context.TargetType.IsSpan(this.compilation)
-           || this.context.TargetType.IsReadOnlySpan(this.compilation)
-           || this.context.TargetType.IsMemory(this.compilation)
-           || this.context.TargetType.IsReadOnlyMemory(this.compilation)
-           || this.context.TargetType.IsOrDerivedFromStack(this.compilation)
-           || this.context.TargetType.IsOrDerivedFromQueue(this.compilation)
-           || this.context.TargetType.IsOrImplementISet(this.compilation)
-           || this.context.TargetType.IsIReadOnlySet(this.compilation)
-           || this.context.TargetType.IsHashSet(this.compilation)
-           || this.context.TargetType.IsReadOnlyCollection(this.compilation)
-           || this.context.TargetType.IsReadOnlySet(this.compilation)
-           || this.context.TargetType.IsFrozenSet(this.compilation)
-           || this.context.TargetType.IsIImmutableSet(this.compilation)
-           || this.context.TargetType.IsImmutableHashSet(this.compilation)
-           || this.context.TargetType.IsImmutableSortedSet(this.compilation)
-           || this.context.TargetType.IsIImmutableList(this.compilation)
-           || this.context.TargetType.IsImmutableArray(this.compilation)
-           || this.context.TargetType.IsImmutableList(this.compilation)
-           || this.context.TargetType.IsIImmutableQueue(this.compilation)
-           || this.context.TargetType.IsImmutableQueue(this.compilation)
-           || this.context.TargetType.IsIImmutableStack(this.compilation)
-           || this.context.TargetType.IsImmutableStack(this.compilation)
-           || this.context.TargetType.IsOrDerivedFromBlockingCollection(this.compilation)
-           || this.context.TargetType.IsOrDerivedFromConcurrentBag(this.compilation)
-           || this.context.TargetType.IsOrDerivedFromConcurrentStack(this.compilation)
-           || this.context.TargetType.IsOrImplementConcurrentQueue(this.compilation)
-           || this.context.TargetType.IsIProducerConsumerCollection(this.compilation);
+        => IsSupportedCollectionTargetType(this.context.TargetType, this.compilation);
 }

--- a/Mappa.Generator/Algorithm/StrategyDetectors/DateAndTimeMapStrategyDetector.cs
+++ b/Mappa.Generator/Algorithm/StrategyDetectors/DateAndTimeMapStrategyDetector.cs
@@ -37,112 +37,39 @@ internal sealed class DateAndTimeMapStrategyDetector
     {
         mapStrategy = new NoMapStrategy(this.context.TargetType, this.context.TargetType);
 
-        // 01. DateTime -> DateOnly.
-        if (this.CanMapDateTimeToDateOnly())
+        foreach (var candidate in this.GetDateTimeMappingCandidates())
+#pragma warning disable S3267 // Loops should be simplified using the "Where" LINQ method
         {
-            mapStrategy = new DateTimeToDateOnlyMapStrategy(
-                this.context.TargetType,
-                this.context.SourceType);
-        }
+            if (!candidate.CanMap())
+            {
+                continue;
+            }
 
-        // 02. DateTime -> TimeOnly
-        else if (this.CanMapDateTimeToTimeOnly())
-        {
-            mapStrategy = new DateTimeToTimeOnlyMapStrategy(
-                this.context.TargetType,
-                this.context.SourceType);
+            mapStrategy = candidate.CreateStrategy();
+            return true;
         }
+#pragma warning restore S3267 // Loops should be simplified using the "Where" LINQ method
 
-        // 03. DateOnly -> DateTime
-        else if (this.CanMapDateOnlyToDateTime())
-        {
-            mapStrategy = new DateOnlyToDateTimeMapStrategy(
-                this.context.TargetType,
-                this.context.SourceType);
-        }
+        return false;
+    }
 
-        // 04. DateTime -> long.
-        else if (this.CanMapDateTimeToLong())
-        {
-            mapStrategy = new DateTimeToLongMapStrategy(
-                this.context.TargetType,
-                this.context.SourceType);
-        }
-
-        // 05. long -> DateTime.
-        else if (this.CanMapLongOrSmallerNumericTypeToDateTime())
-        {
-            mapStrategy = new LongToDateTimeMapStrategy(
-                this.context.TargetType,
-                this.context.SourceType);
-        }
-
-        // 06. DateOnly -> long.
-        else if (this.CanMapDateOnlyToLong())
-        {
-            mapStrategy = new DateOnlyToLongMapStrategy(
-                this.context.TargetType,
-                this.context.SourceType);
-        }
-
-        // 07. TimeSpan -> double.
-        else if (this.CanMapTimeSpanToDouble())
-        {
-            mapStrategy = new TimeSpanToDoubleMapStrategy(
-                this.context.TargetType,
-                this.context.SourceType);
-        }
-
-        // 08. double -> TimeSpan.
-        else if (this.CanMapDoubleToTimeSpan())
-        {
-            mapStrategy = new DoubleToTimeSpanMapStrategy(
-                this.context.TargetType,
-                this.context.SourceType);
-        }
-
-        // 09. DateTimeOffset -> DateOnly.
-        else if (this.CanMapDateTimeOffsetToDateOnly())
-        {
-            mapStrategy = new DateTimeOffsetToDateOnlyMapStrategy(
-                this.context.TargetType,
-                this.context.SourceType);
-        }
-
-        // 10. DateTimeOffset -> TimeOnly
-        else if (this.CanMapDateTimeOffsetToTimeOnly())
-        {
-            mapStrategy = new DateTimeOffsetToTimeOnlyMapStrategy(
-                this.context.TargetType,
-                this.context.SourceType);
-        }
-
-        // 11. DateTimeOffset -> long.
-        else if (this.CanMapDateTimeOffsetToLong())
-        {
-            mapStrategy = new DateTimeOffsetToLongMapStrategy(
-                this.context.TargetType,
-                this.context.SourceType);
-        }
-
-        // 12. long -> DateTimeOffset.
-        else if (this.CanMapLongOrSmallerNumericTypeToDateTimeOffset())
-        {
-            mapStrategy = new LongToDateTimeOffsetMapStrategy(
-                this.context.TargetType,
-                this.context.SourceType);
-        }
-
-        // 13. DateTimeOffset -> DateTime.
-        // NOTE: The reverse is handled by the identity strategy.
-        else if (this.CanMapDateTimeOffsetToDateTime())
-        {
-            mapStrategy = new DateTimeOffsetToDateTimeMapStrategy(
-                this.context.TargetType,
-                this.context.SourceType);
-        }
-
-        return mapStrategy is not NoMapStrategy;
+    private IEnumerable<(Func<bool> CanMap, Func<MapStrategy> CreateStrategy)> GetDateTimeMappingCandidates()
+    {
+        var targetType = this.context.TargetType;
+        var sourceType = this.context.SourceType;
+        yield return (this.CanMapDateTimeToDateOnly, () => new DateTimeToDateOnlyMapStrategy(targetType, sourceType));
+        yield return (this.CanMapDateTimeToTimeOnly, () => new DateTimeToTimeOnlyMapStrategy(targetType, sourceType));
+        yield return (this.CanMapDateOnlyToDateTime, () => new DateOnlyToDateTimeMapStrategy(targetType, sourceType));
+        yield return (this.CanMapDateTimeToLong, () => new DateTimeToLongMapStrategy(targetType, sourceType));
+        yield return (this.CanMapLongOrSmallerNumericTypeToDateTime, () => new LongToDateTimeMapStrategy(targetType, sourceType));
+        yield return (this.CanMapDateOnlyToLong, () => new DateOnlyToLongMapStrategy(targetType, sourceType));
+        yield return (this.CanMapTimeSpanToDouble, () => new TimeSpanToDoubleMapStrategy(targetType, sourceType));
+        yield return (this.CanMapDoubleToTimeSpan, () => new DoubleToTimeSpanMapStrategy(targetType, sourceType));
+        yield return (this.CanMapDateTimeOffsetToDateOnly, () => new DateTimeOffsetToDateOnlyMapStrategy(targetType, sourceType));
+        yield return (this.CanMapDateTimeOffsetToTimeOnly, () => new DateTimeOffsetToTimeOnlyMapStrategy(targetType, sourceType));
+        yield return (this.CanMapDateTimeOffsetToLong, () => new DateTimeOffsetToLongMapStrategy(targetType, sourceType));
+        yield return (this.CanMapLongOrSmallerNumericTypeToDateTimeOffset, () => new LongToDateTimeOffsetMapStrategy(targetType, sourceType));
+        yield return (this.CanMapDateTimeOffsetToDateTime, () => new DateTimeOffsetToDateTimeMapStrategy(targetType, sourceType));
     }
 
     private bool CanMapDateTimeToDateOnly()

--- a/Mappa.Generator/Algorithm/StrategyDetectors/IdentityMapStrategyDetector.cs
+++ b/Mappa.Generator/Algorithm/StrategyDetectors/IdentityMapStrategyDetector.cs
@@ -250,38 +250,48 @@ internal sealed class IdentityMapStrategyDetector
     }
 
     private bool CanMapUsingMapToSameTypeRule()
-    {
-        // (non-nullable): T -> T
-        // (nullable): T -> T or T? -> T?
-        // (nullable) T -> T? && T is refType
-        // (nullable || not-nullable) T -> T? && T is not refType
-        return (this.notNullableEnabled &&
-                SymbolEqualityComparer.Default.Equals(this.context.TargetType, this.context.SourceType))
-               || (this.nullableEnabled &&
-                   this.context.TargetType.IsEqualTo(this.context.SourceType, true))
-               || (this.nullableEnabled && SymbolEqualityComparer.Default.Equals(
-                                           this.context.TargetType,
-                                           this.context.SourceType)
-                                           && this.context.TargetType is
-                                               { NullableAnnotation: NullableAnnotation.Annotated, IsReferenceType: true })
-               || (this.context.TargetType is
-                       { NullableAnnotation: NullableAnnotation.Annotated, IsReferenceType: false }
-                   && this.context.TargetType.IsNullableGenericType(this.context.SourceType, this.nullableEnabled));
-    }
+        => this.CanMapSameTypeWhenNullableDisabled()
+           || this.CanMapSameTypeWhenNullableEnabled()
+           || this.CanMapReferenceSourceToAnnotatedSameType()
+           || this.CanMapValueTypeToNullableGenericSameType();
+
+    private bool CanMapSameTypeWhenNullableDisabled()
+        => this.notNullableEnabled
+           && SymbolEqualityComparer.Default.Equals(this.context.TargetType, this.context.SourceType);
+
+    private bool CanMapSameTypeWhenNullableEnabled()
+        => this.nullableEnabled
+           && this.context.TargetType.IsEqualTo(this.context.SourceType, true);
+
+    private bool CanMapReferenceSourceToAnnotatedSameType()
+        => this.nullableEnabled
+           && SymbolEqualityComparer.Default.Equals(this.context.TargetType, this.context.SourceType)
+           && this.context.TargetType is
+               { NullableAnnotation: NullableAnnotation.Annotated, IsReferenceType: true };
+
+    private bool CanMapValueTypeToNullableGenericSameType()
+        => this.context.TargetType is
+               { NullableAnnotation: NullableAnnotation.Annotated, IsReferenceType: false }
+           && this.context.TargetType.IsNullableGenericType(this.context.SourceType, this.nullableEnabled);
 
     private bool CanMapUsingMapToObjectRule()
-    {
-        // (non-nullable): T -> object
-        // (nullable): T -> object?
-        // (nullable) T -> object (When T is not NOT nullable annotated)
-        return (this.notNullableEnabled && this.context.TargetType.IsObject())
-               || (this.nullableEnabled && this.context.TargetType.IsObject() &&
-                   this.context.TargetType.NullableAnnotation == NullableAnnotation.Annotated)
-               || (this.nullableEnabled
-                   && this.context.TargetType.IsObject()
-                   && this.context.TargetType.NullableAnnotation == NullableAnnotation.NotAnnotated
-                   && this.context.SourceType.NullableAnnotation == NullableAnnotation.NotAnnotated);
-    }
+        => this.CanMapToObjectWhenNullableDisabled()
+           || this.CanMapToNullableObjectWhenNullableEnabled()
+           || this.CanMapToNonAnnotatedObjectWhenBothNotAnnotated();
+
+    private bool CanMapToObjectWhenNullableDisabled()
+        => this.notNullableEnabled && this.context.TargetType.IsObject();
+
+    private bool CanMapToNullableObjectWhenNullableEnabled()
+        => this.nullableEnabled
+           && this.context.TargetType.IsObject()
+           && this.context.TargetType.NullableAnnotation == NullableAnnotation.Annotated;
+
+    private bool CanMapToNonAnnotatedObjectWhenBothNotAnnotated()
+        => this.nullableEnabled
+           && this.context.TargetType.IsObject()
+           && this.context.TargetType.NullableAnnotation == NullableAnnotation.NotAnnotated
+           && this.context.SourceType.NullableAnnotation == NullableAnnotation.NotAnnotated;
 
     private bool CanMapUsingImplicitConversion()
     {

--- a/Mappa.Generator/Algorithm/StrategyDetectors/PolymorphismMapStrategyDetector.cs
+++ b/Mappa.Generator/Algorithm/StrategyDetectors/PolymorphismMapStrategyDetector.cs
@@ -35,152 +35,23 @@ internal sealed class PolymorphismMapStrategyDetector(MappaMapAlgorithmContext c
             return false;
         }
 
-        // Check the attributes.
-        var sourceTypeFullNames = new HashSet<string>();
-        var subtypesMappingsStrategies = new List<MapStrategy>();
-        var rootMapMethod = this.context.GetRootMapMethod();
-        foreach (var attribute in typeMappingAttributes)
+        if (!this.TryBuildSubtypeMappingStrategies(typeMappingAttributes, out var subtypesMappingsStrategies))
         {
-            // Check attribute source type name is valid.
-            if (string.IsNullOrWhiteSpace(attribute.SourceType.FullName))
-            {
-                // We ignore attribute will null values so this should never happen.
-                throw new MappaGeneratorException("The source type cannot be loaded at compile time");
-            }
-
-            // Check attribute source type is not duplicated.
-            if (!sourceTypeFullNames.Add(attribute.SourceType.FullName))
-            {
-                this.context.ReportDiagnostic(MappaDiagnostics.MappaTypeMappingAttributeHaveTheSameSourceType(attribute.SourceType.FullName, rootMapMethod.Location));
-                return false;
-            }
-
-            // Check attribute target type name is valid.
-            if (string.IsNullOrWhiteSpace(attribute.TargetType.FullName))
-            {
-                // We ignore attribute will null values so this should never happen.
-                throw new MappaGeneratorException("The target type cannot be loaded at compile time");
-            }
-
-            // Check attribute source type can be loaded.
-            var attributeSourceType = this.compilation.GetTypeByMetadataName(attribute.SourceType.FullName);
-            if (attributeSourceType is null)
-            {
-                throw new MappaGeneratorException($"The source type '{attribute.SourceType.FullName}' cannot be correctly laded at compile time.");
-            }
-
-            // Check attribute target type can be loaded.
-            var attributeTargetType = this.compilation.GetTypeByMetadataName(attribute.TargetType.FullName);
-            if (attributeTargetType is null)
-            {
-                throw new MappaGeneratorException($"The target type '{attribute.SourceType.FullName}' cannot be correctly laded at compile time.");
-            }
-
-            // Check attribute source type and map method source type are different types.
-            if (SymbolEqualityComparer.Default.Equals(attributeSourceType, this.context.SourceType))
-            {
-                this.context.ReportDiagnostic(MappaDiagnostics.MappaTypeMappingAttributeMapsSourceType(attribute.SourceType.FullName, rootMapMethod.Location));
-                return false;
-            }
-
-            // Check attribute source type is derived form the source type in the map method somehow.
-            if (!attributeSourceType.IsImplementingOrIsDerivedFromClass(this.context.SourceType))
-            {
-                this.context.ReportDiagnostic(MappaDiagnostics.MappaTypeMappingAttributeSourceTypeNotDeriveOrImplementMapMethodSourceType(
-                    attributeSourceType.ToDisplayString(),
-                    this.context.SourceType.ToDisplayString(),
-                    rootMapMethod.Location));
-                return false;
-            }
-
-            // Check attribute target type is derived form the target type in the map method somehow.
-            if (!attributeTargetType.IsImplementingOrIsDerivedFromClass(this.context.TargetType))
-            {
-                this.context.ReportDiagnostic(MappaDiagnostics.MappaTypeMappingAttributeTargetTypeNotDeriveOrImplementMapMethodTargetType(
-                        attributeTargetType.ToDisplayString(),
-                        this.context.TargetType.ToDisplayString(),
-                        rootMapMethod.Location));
-                return false;
-            }
-
-            // At this stage any nullability concern is already handled by the nullability detector
-            // and if we do not force it to be NotAnnotated it will be None which is handled like
-            // annotated to support the non-nullable context.
-            var sourceType = attributeSourceType.WithNullableAnnotation(NullableAnnotation.NotAnnotated);
-            var targetType = attributeTargetType.WithNullableAnnotation(NullableAnnotation.NotAnnotated);
-
-            // Identify mapping from attribute source type to attribute target type.
-            var attributeContext = new DerivedMappaMapAlgorithmContext(this.context, targetType, sourceType);
-            var attributeAlgorithm = new TypeMapIdentifierWithMapMethodAlgorithm(attributeContext, this.compilation, this.cancellationToken);
-            var attributeStrategy = attributeAlgorithm.GetStrategy();
-            if (attributeStrategy is NoMapStrategy)
-            {
-                // No need to add a diagnostic: the algorithm will add one if needed.
-                return false;
-            }
-
-            subtypesMappingsStrategies.Add(attributeStrategy);
+            return false;
         }
 
         var mappaTypeMappingDefaultAttribute = this.GetTypeMappingDefaultAttribute()
                                                ?? new MappaTypeMappingDefaultAttribute(MappaTypeMappingDefaultBehavior.Throw);
 
-        var methodSymbolContainingSymbol = rootMapMethod.ContainingType as ITypeSymbol ?? throw new MappaGeneratorException("Method parent is not a type symbol");
-        var mapMethodHasTwoParameters = rootMapMethod.RequireMappaContextWhenInvoked();
-        var validationSuccessful = mappaTypeMappingDefaultAttribute.IsValid(
-            this.context.TargetType,
-            this.context.SourceType,
-            methodSymbolContainingSymbol,
-            rootMapMethod.NullableEnabled,
-            mapMethodHasTwoParameters,
-            this.compilation,
-            rootMapMethod.Location,
-            out var validationDiagnosis,
-            out var resolvedInvokeMethod);
-        foreach (var diagnostic in validationDiagnosis)
+        var rootMapMethod = this.context.GetRootMapMethod();
+        if (!this.TryValidateTypeMappingDefaultAttribute(mappaTypeMappingDefaultAttribute, rootMapMethod, out var resolvedInvokeMethod))
         {
-            this.context.ReportDiagnostic(diagnostic);
-        }
-
-        if (!validationSuccessful)
-        {
-            // No need to report any extra diagnostic.
             return false;
         }
 
-        // Identify a mapping if required.
-        MapStrategy defaultMappingStrategy = new NoMapStrategy(this.context.TargetType, this.context.SourceType);
-        if (mappaTypeMappingDefaultAttribute.Behavior is MappaTypeMappingDefaultBehavior.MapSourceType)
+        if (!this.TryBuildDefaultMappingStrategy(mappaTypeMappingDefaultAttribute, rootMapMethod, out var defaultMappingStrategy))
         {
-            var targetTypeFullNameFromAttribute = mappaTypeMappingDefaultAttribute.Type?.FullName;
-
-            var targetSymbol = (!string.IsNullOrWhiteSpace(targetTypeFullNameFromAttribute) ? this.compilation.GetTypeByMetadataName(targetTypeFullNameFromAttribute!) : null)
-                               ?? this.context.TargetType;
-
-            if (targetSymbol.TypeKind == TypeKind.Interface)
-            {
-                this.context.ReportDiagnostic(MappaDiagnostics.TypeMustBeConcrete(targetSymbol.ToDisplayString(), rootMapMethod.Location));
-                return false;
-            }
-
-            if (targetSymbol.IsAbstract)
-            {
-                this.context.ReportDiagnostic(MappaDiagnostics.TypeMustBeConcrete(targetSymbol.ToDisplayString(), rootMapMethod.Location));
-                return false;
-            }
-
-            var derivedContext = new DerivedMappaMapAlgorithmContext(this.context, targetSymbol, this.context.SourceType);
-            var algorithm = new TypeMapIdentifierAlgorithm(derivedContext, this.compilation, this.cancellationToken);
-            using (this.context.AlgorithmSettings.DetectMappingCycles.Apply(false))
-            {
-                defaultMappingStrategy = algorithm.GetStrategy();
-            }
-
-            if (defaultMappingStrategy is NoMapStrategy)
-            {
-                // No need to add a diagnostic: the algorithm will add one if needed.
-                return false;
-            }
+            return false;
         }
 
         mapStrategy = new PolymorphismMapStrategy(
@@ -192,6 +63,217 @@ internal sealed class PolymorphismMapStrategyDetector(MappaMapAlgorithmContext c
             rootMapMethod.NullableEnabled,
             rootMapMethod.MaybeGetMappaContextParameterName(),
             resolvedInvokeMethod);
+        return true;
+    }
+
+    private bool TryBuildSubtypeMappingStrategies(
+        MappaTypeMappingAttribute[] typeMappingAttributes,
+        out List<MapStrategy> subtypesMappingsStrategies)
+    {
+        subtypesMappingsStrategies = [];
+        var sourceTypeFullNames = new HashSet<string>();
+        var rootMapMethod = this.context.GetRootMapMethod();
+        foreach (var attribute in typeMappingAttributes)
+        {
+            if (!this.TryBuildSubtypeMappingStrategy(
+                    attribute,
+                    sourceTypeFullNames,
+                    rootMapMethod,
+                    out var attributeStrategy))
+            {
+                return false;
+            }
+
+            subtypesMappingsStrategies.Add(attributeStrategy);
+        }
+
+        return true;
+    }
+
+    private bool TryBuildSubtypeMappingStrategy(
+        MappaTypeMappingAttribute attribute,
+        HashSet<string> sourceTypeFullNames,
+        MapMethod rootMapMethod,
+        out MapStrategy attributeStrategy)
+    {
+        attributeStrategy = new NoMapStrategy(this.context.TargetType, this.context.SourceType);
+
+        // Check attribute source type name is valid.
+        if (string.IsNullOrWhiteSpace(attribute.SourceType.FullName))
+        {
+            // We ignore attribute will null values so this should never happen.
+            throw new MappaGeneratorException("The source type cannot be loaded at compile time");
+        }
+
+        // Check attribute source type is not duplicated.
+        if (!sourceTypeFullNames.Add(attribute.SourceType.FullName))
+        {
+            this.context.ReportDiagnostic(MappaDiagnostics.MappaTypeMappingAttributeHaveTheSameSourceType(attribute.SourceType.FullName, rootMapMethod.Location));
+            return false;
+        }
+
+        // Check attribute target type name is valid.
+        if (string.IsNullOrWhiteSpace(attribute.TargetType.FullName))
+        {
+            // We ignore attribute will null values so this should never happen.
+            throw new MappaGeneratorException("The target type cannot be loaded at compile time");
+        }
+
+        // Check attribute source type can be loaded.
+        var attributeSourceType = this.compilation.GetTypeByMetadataName(attribute.SourceType.FullName);
+        if (attributeSourceType is null)
+        {
+            throw new MappaGeneratorException($"The source type '{attribute.SourceType.FullName}' cannot be correctly laded at compile time.");
+        }
+
+        // Check attribute target type can be loaded.
+        var attributeTargetType = this.compilation.GetTypeByMetadataName(attribute.TargetType.FullName);
+        if (attributeTargetType is null)
+        {
+            throw new MappaGeneratorException($"The target type '{attribute.SourceType.FullName}' cannot be correctly laded at compile time.");
+        }
+
+        if (!this.ValidateAttributeSourceAndTargetTypes(attribute, attributeSourceType, attributeTargetType, rootMapMethod))
+        {
+            return false;
+        }
+
+        // At this stage any nullability concern is already handled by the nullability detector
+        // and if we do not force it to be NotAnnotated it will be None which is handled like
+        // annotated to support the non-nullable context.
+        var sourceType = attributeSourceType.WithNullableAnnotation(NullableAnnotation.NotAnnotated);
+        var targetType = attributeTargetType.WithNullableAnnotation(NullableAnnotation.NotAnnotated);
+
+        // Identify mapping from attribute source type to attribute target type.
+        var attributeContext = new DerivedMappaMapAlgorithmContext(this.context, targetType, sourceType);
+        var attributeAlgorithm = new TypeMapIdentifierWithMapMethodAlgorithm(attributeContext, this.compilation, this.cancellationToken);
+        attributeStrategy = attributeAlgorithm.GetStrategy();
+        if (attributeStrategy is NoMapStrategy)
+        {
+            // No need to add a diagnostic: the algorithm will add one if needed.
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool ValidateAttributeSourceAndTargetTypes(
+        MappaTypeMappingAttribute attribute,
+        ITypeSymbol attributeSourceType,
+        ITypeSymbol attributeTargetType,
+        MapMethod rootMapMethod)
+    {
+        // Check attribute source type and map method source type are different types.
+        if (SymbolEqualityComparer.Default.Equals(attributeSourceType, this.context.SourceType))
+        {
+            this.context.ReportDiagnostic(MappaDiagnostics.MappaTypeMappingAttributeMapsSourceType(attribute.SourceType.FullName, rootMapMethod.Location));
+            return false;
+        }
+
+        // Check attribute source type is derived form the source type in the map method somehow.
+        if (!attributeSourceType.IsImplementingOrIsDerivedFromClass(this.context.SourceType))
+        {
+            this.context.ReportDiagnostic(MappaDiagnostics.MappaTypeMappingAttributeSourceTypeNotDeriveOrImplementMapMethodSourceType(
+                attributeSourceType.ToDisplayString(),
+                this.context.SourceType.ToDisplayString(),
+                rootMapMethod.Location));
+            return false;
+        }
+
+        // Check attribute target type is derived form the target type in the map method somehow.
+        if (!attributeTargetType.IsImplementingOrIsDerivedFromClass(this.context.TargetType))
+        {
+            this.context.ReportDiagnostic(MappaDiagnostics.MappaTypeMappingAttributeTargetTypeNotDeriveOrImplementMapMethodTargetType(
+                    attributeTargetType.ToDisplayString(),
+                    this.context.TargetType.ToDisplayString(),
+                    rootMapMethod.Location));
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool TryValidateTypeMappingDefaultAttribute(
+        MappaTypeMappingDefaultAttribute mappaTypeMappingDefaultAttribute,
+        MapMethod rootMapMethod,
+        out IMethodSymbol? resolvedInvokeMethod)
+    {
+        resolvedInvokeMethod = null;
+        var methodSymbolContainingSymbol = rootMapMethod.ContainingType as ITypeSymbol ?? throw new MappaGeneratorException("Method parent is not a type symbol");
+        var mapMethodHasTwoParameters = rootMapMethod.RequireMappaContextWhenInvoked();
+        var validationSuccessful = mappaTypeMappingDefaultAttribute.IsValid(
+            this.context.TargetType,
+            this.context.SourceType,
+            methodSymbolContainingSymbol,
+            rootMapMethod.NullableEnabled,
+            mapMethodHasTwoParameters,
+            this.compilation,
+            rootMapMethod.Location,
+            out var validationDiagnosis,
+            out resolvedInvokeMethod);
+        foreach (var diagnostic in validationDiagnosis)
+        {
+            this.context.ReportDiagnostic(diagnostic);
+        }
+
+        return validationSuccessful;
+    }
+
+    private bool TryBuildDefaultMappingStrategy(
+        MappaTypeMappingDefaultAttribute mappaTypeMappingDefaultAttribute,
+        MapMethod rootMapMethod,
+        out MapStrategy defaultMappingStrategy)
+    {
+        defaultMappingStrategy = new NoMapStrategy(this.context.TargetType, this.context.SourceType);
+        if (mappaTypeMappingDefaultAttribute.Behavior is not MappaTypeMappingDefaultBehavior.MapSourceType)
+        {
+            return true;
+        }
+
+        var targetSymbol = this.ResolveDefaultMappingTargetSymbol(mappaTypeMappingDefaultAttribute);
+        if (!this.ValidateDefaultMappingTargetIsConcrete(targetSymbol, rootMapMethod))
+        {
+            return false;
+        }
+
+        var derivedContext = new DerivedMappaMapAlgorithmContext(this.context, targetSymbol, this.context.SourceType);
+        var algorithm = new TypeMapIdentifierAlgorithm(derivedContext, this.compilation, this.cancellationToken);
+        using (this.context.AlgorithmSettings.DetectMappingCycles.Apply(false))
+        {
+            defaultMappingStrategy = algorithm.GetStrategy();
+        }
+
+        if (defaultMappingStrategy is NoMapStrategy)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private ITypeSymbol ResolveDefaultMappingTargetSymbol(MappaTypeMappingDefaultAttribute mappaTypeMappingDefaultAttribute)
+    {
+        var targetTypeFullNameFromAttribute = mappaTypeMappingDefaultAttribute.Type?.FullName;
+        if (targetTypeFullNameFromAttribute is { Length: > 0 } metadataName)
+        {
+            var targetSymbolFromMetadata = this.compilation.GetTypeByMetadataName(metadataName);
+            if (targetSymbolFromMetadata is not null)
+            {
+                return targetSymbolFromMetadata;
+            }
+        }
+
+        return this.context.TargetType;
+    }
+
+    private bool ValidateDefaultMappingTargetIsConcrete(ITypeSymbol targetSymbol, MapMethod rootMapMethod)
+    {
+        if (targetSymbol.TypeKind == TypeKind.Interface || targetSymbol.IsAbstract)
+        {
+            this.context.ReportDiagnostic(MappaDiagnostics.TypeMustBeConcrete(targetSymbol.ToDisplayString(), rootMapMethod.Location));
+            return false;
+        }
+
         return true;
     }
 

--- a/Mappa.Generator/Algorithm/StrategyDetectors/QueryableProjectionMapStrategyDetector.cs
+++ b/Mappa.Generator/Algorithm/StrategyDetectors/QueryableProjectionMapStrategyDetector.cs
@@ -42,6 +42,64 @@ internal sealed class QueryableProjectionMapStrategyDetector
     {
         mapStrategy = new NoMapStrategy(this.context.TargetType, this.context.SourceType);
 
+        if (!this.TryGetQueryableElementMapping(
+                out var sourceElementType,
+                out var targetElementType,
+                out var normalizedElementStrategy))
+        {
+            return false;
+        }
+
+        var mapMethodSymbol = this.context.MapMethod?.MethodSymbol;
+        if (mapMethodSymbol is null)
+        {
+            return false;
+        }
+
+        mapStrategy = new QueryableProjectionMapStrategy(
+            this.context.TargetType,
+            this.context.SourceType,
+            normalizedElementStrategy,
+            sourceElementType,
+            targetElementType,
+            mapMethodSymbol);
+        return true;
+    }
+
+    private bool TryGetQueryableElementMapping(
+        out ITypeSymbol sourceElementType,
+        out ITypeSymbol targetElementType,
+        out MapStrategy normalizedElementStrategy)
+    {
+        normalizedElementStrategy = new NoMapStrategy(this.context.TargetType, this.context.SourceType);
+        sourceElementType = this.context.SourceType;
+        targetElementType = this.context.TargetType;
+
+        if (!this.CanStartQueryableElementMapping())
+        {
+            return false;
+        }
+
+        if (!this.TryGetDistinctQueryableElementTypes(out sourceElementType, out targetElementType))
+        {
+            return false;
+        }
+
+        var mapMethod = this.context.MapMethod;
+        if (mapMethod is null)
+        {
+            return false;
+        }
+
+        return this.TryGetProjectableQueryableElementStrategy(
+            mapMethod,
+            sourceElementType,
+            targetElementType,
+            out normalizedElementStrategy);
+    }
+
+    private bool CanStartQueryableElementMapping()
+    {
         if (this.context.MapMethod is null)
         {
             return false;
@@ -52,22 +110,33 @@ internal sealed class QueryableProjectionMapStrategyDetector
             return false;
         }
 
-        if (!this.context.SourceType.IsOrImplementIQueryable(this.compilation)
-            || !this.context.TargetType.IsOrImplementIQueryable(this.compilation))
+        return this.context.SourceType.IsOrImplementIQueryable(this.compilation)
+               && this.context.TargetType.IsOrImplementIQueryable(this.compilation);
+    }
+
+    private bool TryGetDistinctQueryableElementTypes(
+        out ITypeSymbol sourceElementType,
+        out ITypeSymbol targetElementType)
+    {
+        sourceElementType = this.context.SourceType;
+        targetElementType = this.context.TargetType;
+
+        if (!this.context.SourceType.TryGetQueryableElementType(this.compilation, out sourceElementType)
+            || !this.context.TargetType.TryGetQueryableElementType(this.compilation, out targetElementType))
         {
             return false;
         }
 
-        if (!this.context.SourceType.TryGetQueryableElementType(this.compilation, out var sourceElementType)
-            || !this.context.TargetType.TryGetQueryableElementType(this.compilation, out var targetElementType))
-        {
-            return false;
-        }
+        return !SymbolEqualityComparer.Default.Equals(sourceElementType, targetElementType);
+    }
 
-        if (SymbolEqualityComparer.Default.Equals(sourceElementType, targetElementType))
-        {
-            return false;
-        }
+    private bool TryGetProjectableQueryableElementStrategy(
+        MapMethod mapMethod,
+        ITypeSymbol sourceElementType,
+        ITypeSymbol targetElementType,
+        out MapStrategy normalizedElementStrategy)
+    {
+        normalizedElementStrategy = new NoMapStrategy(this.context.TargetType, this.context.SourceType);
 
         var derivedContext = new DerivedMappaMapAlgorithmContext(
             this.context,
@@ -83,32 +152,14 @@ internal sealed class QueryableProjectionMapStrategyDetector
             return false;
         }
 
-        if (!ProjectionCapabilityAnalyzer.TryAnalyze(
-                elementStrategy,
-                new ProjectionCapabilityAnalysisContext(
-                    this.context,
-                    this.compilation,
-                    this.context.MapMethod.MethodName,
-                    this.context.MapMethod.MethodDeclarationSyntax?.GetLocation(),
-                    this.cancellationToken),
-                out var normalizedElementStrategy))
-        {
-            return false;
-        }
-
-        var mapMethodSymbol = this.context.MapMethod.MethodSymbol;
-        if (mapMethodSymbol is null)
-        {
-            return false;
-        }
-
-        mapStrategy = new QueryableProjectionMapStrategy(
-            this.context.TargetType,
-            this.context.SourceType,
-            normalizedElementStrategy,
-            sourceElementType,
-            targetElementType,
-            mapMethodSymbol);
-        return true;
+        return ProjectionCapabilityAnalyzer.TryAnalyze(
+            elementStrategy,
+            new ProjectionCapabilityAnalysisContext(
+                this.context,
+                this.compilation,
+                mapMethod.MethodName,
+                mapMethod.MethodDeclarationSyntax?.GetLocation(),
+                this.cancellationToken),
+            out normalizedElementStrategy);
     }
 }

--- a/Mappa.Generator/Algorithm/StrategyDetectors/StringMapStrategyDetector.TryDetect.cs
+++ b/Mappa.Generator/Algorithm/StrategyDetectors/StringMapStrategyDetector.TryDetect.cs
@@ -1,0 +1,41 @@
+// <copyright file="StringMapStrategyDetector.TryDetect.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using Mappa.Generator.Models.Strategies;
+
+namespace Mappa.Generator.Algorithm.StrategyDetectors;
+
+/// <summary>
+/// String mapping detection branches for <see cref="StringMapStrategyDetector"/>.
+/// </summary>
+internal sealed partial class StringMapStrategyDetector
+{
+    /// <inheritdoc/>
+    public bool TryDetect(out MapStrategy mapStrategy)
+    {
+        mapStrategy = new NoMapStrategy(this.context.TargetType, this.context.TargetType);
+
+        if (this.TryDetectPrimitiveStringMappings(out mapStrategy)
+            || this.TryDetectParseAndToStringMappings(out mapStrategy))
+        {
+            return true;
+        }
+
+        return mapStrategy is not NoMapStrategy;
+    }
+
+    private bool TryDetectPrimitiveStringMappings(out MapStrategy mapStrategy)
+        => this.TryDetectStringToNumber(out mapStrategy)
+           || this.TryDetectStringToDateTime(out mapStrategy)
+           || this.TryDetectStringToDateTimeOffset(out mapStrategy)
+           || this.TryDetectStringToTimeSpan(out mapStrategy)
+           || this.TryDetectStringToTimeOnly(out mapStrategy)
+           || this.TryDetectStringToDateOnly(out mapStrategy);
+
+    private bool TryDetectParseAndToStringMappings(out MapStrategy mapStrategy)
+        => this.TryDetectStringToGuid(out mapStrategy)
+           || this.TryDetectStringToUri(out mapStrategy)
+           || this.TryDetectUsingStaticParseMethod(out mapStrategy)
+           || this.TryDetectToString(out mapStrategy);
+}

--- a/Mappa.Generator/Algorithm/StrategyDetectors/StringMapStrategyDetector.cs
+++ b/Mappa.Generator/Algorithm/StrategyDetectors/StringMapStrategyDetector.cs
@@ -19,7 +19,7 @@ namespace Mappa.Generator.Algorithm.StrategyDetectors;
 /// <summary>
 /// Detector for string related strategies.
 /// </summary>
-internal sealed class StringMapStrategyDetector
+internal sealed partial class StringMapStrategyDetector
     : IMapStrategyDetector
 {
     private readonly MappaMapAlgorithmContext context;
@@ -38,170 +38,209 @@ internal sealed class StringMapStrategyDetector
         this.compilation = compilation;
     }
 
-    /// <inheritdoc/>
-    public bool TryDetect(out MapStrategy mapStrategy)
+    private bool TryDetectStringToNumber(out MapStrategy mapStrategy)
     {
-        mapStrategy = new NoMapStrategy(this.context.TargetType, this.context.TargetType);
-
-        // 01. string -> numeric : ParseNumberStrategy
-        if (this.CanMapStringToNumber())
+        mapStrategy = new NoMapStrategy(this.context.TargetType, this.context.SourceType);
+        if (!this.CanMapStringToNumber())
         {
-            var numberStyle = this.GetNumericNumberStyleWithSource(this.context.TargetType, out var numberStylePropertyName);
-            this.WarnIfInvalidNumberStyle(numberStyle, numberStylePropertyName);
-
-            mapStrategy = new StringToNumberMapStrategy(
-                this.context.TargetType,
-                this.context.SourceType,
-                this.GetActualCultureSettingsInfo(),
-                this.context.MappaUserSettings.CultureName,
-                numberStyle);
+            return false;
         }
 
-        // 02. string -> DateTime : InvokeParseStringWithFormatMapStrategy
-        else if (this.CanMapStringToDateTime())
-        {
-            var actualCultureSettingsInfo = this.GetActualCultureSettingsInfo();
-            WarnIfOnlyFormatIsProvided(actualCultureSettingsInfo, this.context.MappaUserSettings.DateTimeFormat);
-            var dateTimeStyle = this.ResolveDateTimeStyleWithSource(
-                this.context.MappaUserSettings.DateTimeStyle,
-                nameof(MappaSettingsAttribute.DateTimeStyle),
-                out var dateTimeStylePropertyName);
-            this.WarnIfInvalidDateTimeStyle(dateTimeStyle, dateTimeStylePropertyName);
+        var numberStyle = this.GetNumericNumberStyleWithSource(this.context.TargetType, out var numberStylePropertyName);
+        this.WarnIfInvalidNumberStyle(numberStyle, numberStylePropertyName);
+        mapStrategy = new StringToNumberMapStrategy(
+            this.context.TargetType,
+            this.context.SourceType,
+            this.GetActualCultureSettingsInfo(),
+            this.context.MappaUserSettings.CultureName,
+            numberStyle);
+        return true;
+    }
 
-            mapStrategy = new InvokeParseStringWithFormatMapStrategy(
-                this.context.TargetType,
-                this.context.SourceType,
-                this.context.MappaUserSettings.DateTimeFormat,
-                actualCultureSettingsInfo,
-                this.context.MappaUserSettings.CultureName,
-                dateTimeStyle);
+    private bool TryDetectStringToDateTime(out MapStrategy mapStrategy)
+    {
+        mapStrategy = new NoMapStrategy(this.context.TargetType, this.context.SourceType);
+        if (!this.CanMapStringToDateTime())
+        {
+            return false;
         }
 
-        // 03. string -> DateTimeOffset : InvokeParseStringWithFormatMapStrategy
-        else if (this.CanMapStringToDateTimeOffset())
-        {
-            var actualCultureSettingsInfo = this.GetActualCultureSettingsInfo();
-            WarnIfOnlyFormatIsProvided(actualCultureSettingsInfo, this.context.MappaUserSettings.DateTimeOffsetFormat);
-            var dateTimeStyle = this.ResolveDateTimeStyleWithSource(
-                this.context.MappaUserSettings.DateTimeOffsetStyle,
-                nameof(MappaSettingsAttribute.DateTimeOffsetStyle),
-                out var dateTimeStylePropertyName);
-            this.WarnIfInvalidDateTimeStyle(dateTimeStyle, dateTimeStylePropertyName);
+        var actualCultureSettingsInfo = this.GetActualCultureSettingsInfo();
+        this.WarnIfOnlyFormatIsProvided(actualCultureSettingsInfo, this.context.MappaUserSettings.DateTimeFormat);
+        var dateTimeStyle = this.ResolveDateTimeStyleWithSource(
+            this.context.MappaUserSettings.DateTimeStyle,
+            nameof(MappaSettingsAttribute.DateTimeStyle),
+            out var dateTimeStylePropertyName);
+        this.WarnIfInvalidDateTimeStyle(dateTimeStyle, dateTimeStylePropertyName);
+        mapStrategy = new InvokeParseStringWithFormatMapStrategy(
+            this.context.TargetType,
+            this.context.SourceType,
+            this.context.MappaUserSettings.DateTimeFormat,
+            actualCultureSettingsInfo,
+            this.context.MappaUserSettings.CultureName,
+            dateTimeStyle);
+        return true;
+    }
 
-            mapStrategy = new InvokeParseStringWithFormatMapStrategy(
-                this.context.TargetType,
-                this.context.SourceType,
-                this.context.MappaUserSettings.DateTimeOffsetFormat,
-                actualCultureSettingsInfo,
-                this.context.MappaUserSettings.CultureName,
-                dateTimeStyle);
+    private bool TryDetectStringToDateTimeOffset(out MapStrategy mapStrategy)
+    {
+        mapStrategy = new NoMapStrategy(this.context.TargetType, this.context.SourceType);
+        if (!this.CanMapStringToDateTimeOffset())
+        {
+            return false;
         }
 
-        // 04. string -> TimeSpan : InvokeParseStringWithFormatMapStrategy
-        else if (this.CanMapStringToTimeSpan())
-        {
-            var actualCultureSettingsInfo = this.GetActualCultureSettingsInfo();
-            WarnIfOnlyFormatIsProvided(actualCultureSettingsInfo, this.context.MappaUserSettings.TimeSpanFormat);
+        var actualCultureSettingsInfo = this.GetActualCultureSettingsInfo();
+        this.WarnIfOnlyFormatIsProvided(actualCultureSettingsInfo, this.context.MappaUserSettings.DateTimeOffsetFormat);
+        var dateTimeStyle = this.ResolveDateTimeStyleWithSource(
+            this.context.MappaUserSettings.DateTimeOffsetStyle,
+            nameof(MappaSettingsAttribute.DateTimeOffsetStyle),
+            out var dateTimeStylePropertyName);
+        this.WarnIfInvalidDateTimeStyle(dateTimeStyle, dateTimeStylePropertyName);
+        mapStrategy = new InvokeParseStringWithFormatMapStrategy(
+            this.context.TargetType,
+            this.context.SourceType,
+            this.context.MappaUserSettings.DateTimeOffsetFormat,
+            actualCultureSettingsInfo,
+            this.context.MappaUserSettings.CultureName,
+            dateTimeStyle);
+        return true;
+    }
 
-            mapStrategy = new InvokeParseStringWithFormatMapStrategy(
-                this.context.TargetType,
-                this.context.SourceType,
-                this.context.MappaUserSettings.TimeSpanFormat,
-                actualCultureSettingsInfo,
-                this.context.MappaUserSettings.CultureName,
-                null);
+    private bool TryDetectStringToTimeSpan(out MapStrategy mapStrategy)
+    {
+        mapStrategy = new NoMapStrategy(this.context.TargetType, this.context.SourceType);
+        if (!this.CanMapStringToTimeSpan())
+        {
+            return false;
         }
 
-        // 05. string -> TimeOnly : InvokeParseStringWithFormatMapStrategy
-        else if (this.CanMapStringToTimeOnly())
-        {
-            var dateTimeStyle = this.ResolveDateTimeStyleWithSource(
-                this.context.MappaUserSettings.TimeOnlyStyle,
-                nameof(MappaSettingsAttribute.TimeOnlyStyle),
-                out var dateTimeStylePropertyName);
-            this.WarnIfInvalidDateTimeStyle(dateTimeStyle, dateTimeStylePropertyName);
+        var actualCultureSettingsInfo = this.GetActualCultureSettingsInfo();
+        this.WarnIfOnlyFormatIsProvided(actualCultureSettingsInfo, this.context.MappaUserSettings.TimeSpanFormat);
+        mapStrategy = new InvokeParseStringWithFormatMapStrategy(
+            this.context.TargetType,
+            this.context.SourceType,
+            this.context.MappaUserSettings.TimeSpanFormat,
+            actualCultureSettingsInfo,
+            this.context.MappaUserSettings.CultureName,
+            null);
+        return true;
+    }
 
-            mapStrategy = new InvokeParseStringWithFormatForDateOnlyAndTimeOnlyMapStrategy(
-                this.context.TargetType,
-                this.context.SourceType,
-                this.context.MappaUserSettings.TimeOnlyFormat,
-                this.GetActualCultureSettingsInfo(),
-                this.context.MappaUserSettings.CultureName,
-                dateTimeStyle);
+    private bool TryDetectStringToTimeOnly(out MapStrategy mapStrategy)
+    {
+        mapStrategy = new NoMapStrategy(this.context.TargetType, this.context.SourceType);
+        if (!this.CanMapStringToTimeOnly())
+        {
+            return false;
         }
 
-        // 06. string -> DateOnly : InvokeParseStringWithFormatMapStrategy
-        else if (this.CanMapStringToDateOnly())
-        {
-            var dateTimeStyle = this.ResolveDateTimeStyleWithSource(
-                this.context.MappaUserSettings.DateOnlyStyle,
-                nameof(MappaSettingsAttribute.DateOnlyStyle),
-                out var dateTimeStylePropertyName);
-            this.WarnIfInvalidDateTimeStyle(dateTimeStyle, dateTimeStylePropertyName);
+        var dateTimeStyle = this.ResolveDateTimeStyleWithSource(
+            this.context.MappaUserSettings.TimeOnlyStyle,
+            nameof(MappaSettingsAttribute.TimeOnlyStyle),
+            out var dateTimeStylePropertyName);
+        this.WarnIfInvalidDateTimeStyle(dateTimeStyle, dateTimeStylePropertyName);
+        mapStrategy = new InvokeParseStringWithFormatForDateOnlyAndTimeOnlyMapStrategy(
+            this.context.TargetType,
+            this.context.SourceType,
+            this.context.MappaUserSettings.TimeOnlyFormat,
+            this.GetActualCultureSettingsInfo(),
+            this.context.MappaUserSettings.CultureName,
+            dateTimeStyle);
+        return true;
+    }
 
-            mapStrategy = new InvokeParseStringWithFormatForDateOnlyAndTimeOnlyMapStrategy(
-                this.context.TargetType,
-                this.context.SourceType,
-                this.context.MappaUserSettings.DateOnlyFormat,
-                this.GetActualCultureSettingsInfo(),
-                this.context.MappaUserSettings.CultureName,
-                dateTimeStyle);
+    private bool TryDetectStringToDateOnly(out MapStrategy mapStrategy)
+    {
+        mapStrategy = new NoMapStrategy(this.context.TargetType, this.context.SourceType);
+        if (!this.CanMapStringToDateOnly())
+        {
+            return false;
         }
 
-        // 07. string -> Guid : ParseGuidStrategy
-        else if (this.CanMapStringToGuid())
+        var dateTimeStyle = this.ResolveDateTimeStyleWithSource(
+            this.context.MappaUserSettings.DateOnlyStyle,
+            nameof(MappaSettingsAttribute.DateOnlyStyle),
+            out var dateTimeStylePropertyName);
+        this.WarnIfInvalidDateTimeStyle(dateTimeStyle, dateTimeStylePropertyName);
+        mapStrategy = new InvokeParseStringWithFormatForDateOnlyAndTimeOnlyMapStrategy(
+            this.context.TargetType,
+            this.context.SourceType,
+            this.context.MappaUserSettings.DateOnlyFormat,
+            this.GetActualCultureSettingsInfo(),
+            this.context.MappaUserSettings.CultureName,
+            dateTimeStyle);
+        return true;
+    }
+
+    private bool TryDetectStringToGuid(out MapStrategy mapStrategy)
+    {
+        mapStrategy = new NoMapStrategy(this.context.TargetType, this.context.SourceType);
+        if (!this.CanMapStringToGuid())
         {
-            mapStrategy = new StringToGuidMapStrategy(
-                this.context.TargetType,
-                this.context.SourceType,
-                this.context.MappaUserSettings.GuidFormat,
-                this.GetActualCultureSettingsInfo(),
-                this.context.MappaUserSettings.CultureName);
+            return false;
         }
 
-        // 08. string -> Uri : ParseUriStrategy
-        else if (this.CanMapStringToUri())
+        mapStrategy = new StringToGuidMapStrategy(
+            this.context.TargetType,
+            this.context.SourceType,
+            this.context.MappaUserSettings.GuidFormat,
+            this.GetActualCultureSettingsInfo(),
+            this.context.MappaUserSettings.CultureName);
+        return true;
+    }
+
+    private bool TryDetectStringToUri(out MapStrategy mapStrategy)
+    {
+        mapStrategy = new NoMapStrategy(this.context.TargetType, this.context.SourceType);
+        if (!this.CanMapStringToUri())
         {
-            mapStrategy = new StringToUriMapStrategy(
-                this.context.TargetType,
-                this.context.SourceType);
+            return false;
         }
 
-        // 09. string -> T when static T T.Parse(string) method exists
-        else if (this.CanMapUsingStaticParseMethod())
+        mapStrategy = new StringToUriMapStrategy(this.context.TargetType, this.context.SourceType);
+        return true;
+    }
+
+    private bool TryDetectUsingStaticParseMethod(out MapStrategy mapStrategy)
+    {
+        mapStrategy = new NoMapStrategy(this.context.TargetType, this.context.SourceType);
+        if (!this.CanMapUsingStaticParseMethod())
         {
-           mapStrategy = new InvokeParseMethodMapStrategy(
-               this.context.TargetType,
-               this.context.SourceType);
+            return false;
         }
 
-        // 10. S -> string : InvokeToStringStrategy
-        else if (this.CanMapToString())
+        mapStrategy = new InvokeParseMethodMapStrategy(this.context.TargetType, this.context.SourceType);
+        return true;
+    }
+
+    private bool TryDetectToString(out MapStrategy mapStrategy)
+    {
+        mapStrategy = new NoMapStrategy(this.context.TargetType, this.context.SourceType);
+        if (!this.CanMapToString())
         {
-            var formatAndCulture = this.IdentifyFormatAndCulture();
-            mapStrategy = new InvokeToStringMapStrategy(
-                this.context.TargetType,
-                this.context.SourceType,
-                formatAndCulture.Format,
-                formatAndCulture.CultureInfoSetting,
-                formatAndCulture.CultureName);
+            return false;
         }
 
-        return mapStrategy is not NoMapStrategy;
+        var formatAndCulture = this.IdentifyFormatAndCulture();
+        mapStrategy = new InvokeToStringMapStrategy(
+            this.context.TargetType,
+            this.context.SourceType,
+            formatAndCulture.Format,
+            formatAndCulture.CultureInfoSetting,
+            formatAndCulture.CultureName);
+        return true;
+    }
 
-        void WarnIfOnlyFormatIsProvided(CultureInfoSetting actualCultureSettingsInfo, string? format)
+    private void WarnIfOnlyFormatIsProvided(CultureInfoSetting actualCultureSettingsInfo, string? format)
+    {
+        if (!string.IsNullOrWhiteSpace(format)
+            && (actualCultureSettingsInfo is CultureInfoSetting.None || actualCultureSettingsInfo is CultureInfoSetting.Undefined))
         {
-            // If format is provided but not the culture then we have a problem
-            // because some types (DateTime, DateTimeOffset, TimeSpan) does not support
-            // ParseExact(string value, string format) so format will be ignored.
-            if (!string.IsNullOrWhiteSpace(format)
-                && (actualCultureSettingsInfo is CultureInfoSetting.None || actualCultureSettingsInfo is CultureInfoSetting.Undefined))
-            {
-                var rootMethod = this.context.GetRootMapMethod();
-                this.context.ReportDiagnostic(MappaDiagnostics.ParseExactDoesNotAcceptOnlyFormat(
-                    rootMethod.MethodDeclarationSyntax,
-                    this.context.TargetType.ToDisplayString()));
-            }
+            var rootMethod = this.context.GetRootMapMethod();
+            this.context.ReportDiagnostic(MappaDiagnostics.ParseExactDoesNotAcceptOnlyFormat(
+                rootMethod.MethodDeclarationSyntax,
+                this.context.TargetType.ToDisplayString()));
         }
     }
 
@@ -310,33 +349,78 @@ internal sealed class StringMapStrategyDetector
 
     private NumberStyles? GetNumericNumberStyleWithSource(ITypeSymbol typeSymbol, out string? propertyName)
     {
-        var settings = this.context.MappaUserSettings;
-        var typeStyle = typeSymbol.SpecialType switch
+        if (this.TryGetPerTypeNumericNumberStyle(typeSymbol.SpecialType, out var typeStyle, out var typeStylePropertyName))
         {
-            SpecialType.System_Byte => (settings.ByteStyle, nameof(MappaSettingsAttribute.ByteStyle)),
-            SpecialType.System_SByte => (settings.SByteStyle, nameof(MappaSettingsAttribute.SByteStyle)),
-            SpecialType.System_Int16 => (settings.ShortStyle, nameof(MappaSettingsAttribute.ShortStyle)),
-            SpecialType.System_UInt16 => (settings.UShortStyle, nameof(MappaSettingsAttribute.UShortStyle)),
-            SpecialType.System_Int32 => (settings.IntStyle, nameof(MappaSettingsAttribute.IntStyle)),
-            SpecialType.System_UInt32 => (settings.UIntStyle, nameof(MappaSettingsAttribute.UIntStyle)),
-            SpecialType.System_Int64 => (settings.LongStyle, nameof(MappaSettingsAttribute.LongStyle)),
-            SpecialType.System_UInt64 => (settings.ULongStyle, nameof(MappaSettingsAttribute.ULongStyle)),
-            SpecialType.System_Decimal => (settings.DecimalStyle, nameof(MappaSettingsAttribute.DecimalStyle)),
-            SpecialType.System_Single => (settings.FloatStyle, nameof(MappaSettingsAttribute.FloatStyle)),
-            SpecialType.System_Double => (settings.DoubleStyle, nameof(MappaSettingsAttribute.DoubleStyle)),
-            _ => ((NumberStyles?)null, null),
-        };
-
-        if (typeStyle.Item1.HasValue)
-        {
-            propertyName = typeStyle.Item2;
-            return typeStyle.Item1;
+            propertyName = typeStylePropertyName;
+            return typeStyle;
         }
 
-        propertyName = settings.GlobalNumberStyle.HasValue
+        propertyName = this.context.MappaUserSettings.GlobalNumberStyle.HasValue
             ? nameof(MappaSettingsAttribute.GlobalNumberStyle)
             : null;
-        return settings.GlobalNumberStyle;
+        return this.context.MappaUserSettings.GlobalNumberStyle;
+    }
+
+    private bool TryGetPerTypeNumericNumberStyle(
+        SpecialType specialType,
+        out NumberStyles? numberStyle,
+        out string? propertyName)
+    {
+        var settings = this.context.MappaUserSettings;
+        numberStyle = null;
+        propertyName = null;
+
+        switch (specialType)
+        {
+            case SpecialType.System_Byte:
+                numberStyle = settings.ByteStyle;
+                propertyName = nameof(MappaSettingsAttribute.ByteStyle);
+                break;
+            case SpecialType.System_SByte:
+                numberStyle = settings.SByteStyle;
+                propertyName = nameof(MappaSettingsAttribute.SByteStyle);
+                break;
+            case SpecialType.System_Int16:
+                numberStyle = settings.ShortStyle;
+                propertyName = nameof(MappaSettingsAttribute.ShortStyle);
+                break;
+            case SpecialType.System_UInt16:
+                numberStyle = settings.UShortStyle;
+                propertyName = nameof(MappaSettingsAttribute.UShortStyle);
+                break;
+            case SpecialType.System_Int32:
+                numberStyle = settings.IntStyle;
+                propertyName = nameof(MappaSettingsAttribute.IntStyle);
+                break;
+            case SpecialType.System_UInt32:
+                numberStyle = settings.UIntStyle;
+                propertyName = nameof(MappaSettingsAttribute.UIntStyle);
+                break;
+            case SpecialType.System_Int64:
+                numberStyle = settings.LongStyle;
+                propertyName = nameof(MappaSettingsAttribute.LongStyle);
+                break;
+            case SpecialType.System_UInt64:
+                numberStyle = settings.ULongStyle;
+                propertyName = nameof(MappaSettingsAttribute.ULongStyle);
+                break;
+            case SpecialType.System_Decimal:
+                numberStyle = settings.DecimalStyle;
+                propertyName = nameof(MappaSettingsAttribute.DecimalStyle);
+                break;
+            case SpecialType.System_Single:
+                numberStyle = settings.FloatStyle;
+                propertyName = nameof(MappaSettingsAttribute.FloatStyle);
+                break;
+            case SpecialType.System_Double:
+                numberStyle = settings.DoubleStyle;
+                propertyName = nameof(MappaSettingsAttribute.DoubleStyle);
+                break;
+            default:
+                return false;
+        }
+
+        return numberStyle.HasValue;
     }
 
     private DateTimeStyles? ResolveDateTimeStyleWithSource(

--- a/Mappa.Generator/Algorithm/TypeMapIdentifierAlgorithm.cs
+++ b/Mappa.Generator/Algorithm/TypeMapIdentifierAlgorithm.cs
@@ -168,55 +168,14 @@ internal class TypeMapIdentifierAlgorithm
             // If the operation has been cancelled: stop!
             this.CancellationToken.ThrowIfCancellationRequested();
 
-            switch (detector)
+            if (this.ShouldSkipDetector(detector))
             {
-                // Skip the constructor strategy in order to avoid infinite loops
-                // in the case this algorithm is run inside the constructor strategy
-                // detector itself.
-                case ConstructorMapStrategyDetector when !this.Context.AlgorithmSettings.UseConstructorMapStrategyDetector:
-
-                // Skip the nullable reference strategy in order to avoid infinite loops
-                // in the case this algorithm is run inside the nullable reference strategy
-                // detector itself.
-                case NullableMapStrategyDetector when !this.Context.AlgorithmSettings.UseNullableMapStrategyDetector:
-
-                // Skip the identity strategy when resolving nested field mappings for nested deep copy,
-                // or when nested property-path attributes require constructor-based property mapping.
-                case IdentityMapStrategyDetector when !this.Context.AlgorithmSettings.UseIdentityMapStrategyDetector:
-                case IdentityMapStrategyDetector when this.Context.PropertyPathContext is { IsNestedAttributeScope: true }:
-                case IdentityMapStrategyDetector when this.Context.PropertyPathContext?.RemainingTargetSegments.Length > 0:
-                    continue;
-
-                // Polymorphism detector can only run at the root or if following a
-                // nullable detector.
-                case PolymorphismMapStrategyDetector:
-                    if (!CanExecutePolymorphismMapStrategyDetector(this.Context.AlgorithmSettings.Detectors, this.Context.GetRootMapMethod()))
-                    {
-                        continue;
-                    }
-
-                    break;
-
-                // Do not run the identity mapper if we could instead run the mappa polymorphism strategy
-                // where there is at least one TypeMapping attribute.
-                case IdentityMapStrategyDetector:
-                    if (CanExecutePolymorphismMapStrategyDetector(this.Context.AlgorithmSettings.Detectors, this.Context.GetRootMapMethod()))
-                    {
-                        continue;
-                    }
-
-                    break;
+                continue;
             }
 
-            using (this.Context.AlgorithmSettings.ApplyAlgorithmContextDefaults())
+            if (this.TryDetectWithDetector(detector, out var detectedStrategy))
             {
-                using (this.Context.AlgorithmSettings.Detectors.Apply(detector.GetType()))
-                {
-                    if (detector.TryDetect(out var detectedStrategy))
-                    {
-                        return detectedStrategy;
-                    }
-                }
+                return detectedStrategy;
             }
 
             // If any error diagnostic has been reported there is no point in going ahead.
@@ -237,24 +196,6 @@ internal class TypeMapIdentifierAlgorithm
         }
 
         return new NoMapStrategy(this.Context.TargetType, this.Context.SourceType);
-
-        // Identify if the polymorphism detector can actually be executed.
-        static bool CanExecutePolymorphismMapStrategyDetector(StackSetting<Type> detectorsStack, MapMethod mapMethod)
-            => mapMethod.HasAnyAttribute<MappaTypeMappingAttribute>() && detectorsStack.Count switch
-            {
-                // If only one item is present on the stack then
-                // there is actually nothing on the stack beside
-                // the default value null.
-                1 => true,
-
-                // If one detector is on the stack you can apply the polymorphism
-                // detector only if that detector is the nullability detector.
-                2 => detectorsStack.CurrentValue == typeof(NullableMapStrategyDetector),
-
-                // In any other scenario the polymorphism detector
-                // cannot be used.
-                _ => false,
-            };
     }
 
     /// <summary>
@@ -272,6 +213,71 @@ internal class TypeMapIdentifierAlgorithm
         }
 
         return strategy;
+    }
+
+    private static bool CanExecutePolymorphismMapStrategyDetector(StackSetting<Type> detectorsStack, MapMethod mapMethod)
+        => mapMethod.HasAnyAttribute<MappaTypeMappingAttribute>() && detectorsStack.Count switch
+        {
+            // If only one item is present on the stack then
+            // there is actually nothing on the stack beside
+            // the default value null.
+            1 => true,
+
+            // If one detector is on the stack you can apply the polymorphism
+            // detector only if that detector is the nullability detector.
+            2 => detectorsStack.CurrentValue == typeof(NullableMapStrategyDetector),
+
+            // In any other scenario the polymorphism detector
+            // cannot be used.
+            _ => false,
+        };
+
+    private bool ShouldSkipDetector(IMapStrategyDetector detector)
+    {
+        if (this.ShouldSkipConstructorOrNullableDetector(detector)
+            || this.ShouldSkipIdentityDetectorForSettingsOrNestedPaths(detector))
+        {
+            return true;
+        }
+
+        if (detector is PolymorphismMapStrategyDetector)
+        {
+            return !CanExecutePolymorphismMapStrategyDetector(this.Context.AlgorithmSettings.Detectors, this.Context.GetRootMapMethod());
+        }
+
+        if (detector is IdentityMapStrategyDetector)
+        {
+            return CanExecutePolymorphismMapStrategyDetector(this.Context.AlgorithmSettings.Detectors, this.Context.GetRootMapMethod());
+        }
+
+        return false;
+    }
+
+    private bool ShouldSkipConstructorOrNullableDetector(IMapStrategyDetector detector)
+        => (detector is ConstructorMapStrategyDetector && !this.Context.AlgorithmSettings.UseConstructorMapStrategyDetector)
+           || (detector is NullableMapStrategyDetector && !this.Context.AlgorithmSettings.UseNullableMapStrategyDetector);
+
+    private bool ShouldSkipIdentityDetectorForSettingsOrNestedPaths(IMapStrategyDetector detector)
+        => detector is IdentityMapStrategyDetector
+           && (!this.Context.AlgorithmSettings.UseIdentityMapStrategyDetector
+               || this.Context.PropertyPathContext is { IsNestedAttributeScope: true }
+               || this.Context.PropertyPathContext?.RemainingTargetSegments.Length > 0);
+
+    private bool TryDetectWithDetector(IMapStrategyDetector detector, out MapStrategy detectedStrategy)
+    {
+        detectedStrategy = new NoMapStrategy(this.Context.TargetType, this.Context.SourceType);
+        using (this.Context.AlgorithmSettings.ApplyAlgorithmContextDefaults())
+        {
+            using (this.Context.AlgorithmSettings.Detectors.Apply(detector.GetType()))
+            {
+                if (detector.TryDetect(out detectedStrategy))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     private bool ShouldReportMappingCycle()

--- a/Mappa.Generator/Algorithm/TypeMapIdentifierWithMapMethodAlgorithm.cs
+++ b/Mappa.Generator/Algorithm/TypeMapIdentifierWithMapMethodAlgorithm.cs
@@ -41,63 +41,102 @@ internal sealed class TypeMapIdentifierWithMapMethodAlgorithm
     {
         this.CancellationToken.ThrowIfCancellationRequested();
 
-        if (this.Context.PropertyPathContext is null)
+        var existingStrategy = this.TryGetExistingMapMethodStrategy();
+        if (existingStrategy is not null)
         {
-            if (this.Context.TryGetMethod(this.Context.TargetType, this.Context.SourceType, out var mapMethod))
-            {
-                var mapMethodRequireMappaContext = mapMethod.RequireMappaContextWhenInvoked();
-                var rootMapMethod = this.Context.GetRootMapMethod();
-                var callerMethodProvideMappaContext = rootMapMethod.ProvideMappaContextWhenInvoked();
-
-                if (!mapMethodRequireMappaContext || /* mapMethodRequireMappaContext && */ callerMethodProvideMappaContext)
-                {
-                    this.MaybeReportNestedMapWithoutMappaContext(mapMethod, mapMethodRequireMappaContext);
-                    return this.WrapIfNullableReferenceSource(
-                        new MethodMapStrategy(mapMethod, rootMapMethod.MaybeGetMappaContextParameterName()));
-                }
-            }
-
-            if (this.Context.MappaUserSettings.CompatibleMapMethod is BooleanSetting.Enable
-                && this.Context.TryGetCompatibleMethod(this.Context.TargetType, this.Context.SourceType, this.Compilation, out mapMethod)
-                && !ReferenceEquals(mapMethod, this.Context.GetRootMapMethod()))
-            {
-                var mapMethodRequireMappaContext = mapMethod.RequireMappaContextWhenInvoked();
-                var rootMapMethod = this.Context.GetRootMapMethod();
-                var callerMethodProvideMappaContext = rootMapMethod.ProvideMappaContextWhenInvoked();
-
-                if (!mapMethodRequireMappaContext || /* mapMethodRequireMappaContext && */ callerMethodProvideMappaContext)
-                {
-                    this.MaybeReportNestedMapWithoutMappaContext(mapMethod, mapMethodRequireMappaContext);
-                    return this.WrapIfNullableReferenceSource(
-                        new CompatibleMethodMapStrategy(
-                            this.Context.TargetType,
-                            this.Context.SourceType,
-                            mapMethod,
-                            rootMapMethod.MaybeGetMappaContextParameterName()));
-                }
-            }
-
-            if (this.Context.TryGetPolymorphicMethod(this.Context.TargetType, this.Context.SourceType, this.Context.MappaUserSettings, out mapMethod)
-                && !ReferenceEquals(mapMethod, this.Context.GetRootMapMethod()))
-            {
-                var mapMethodRequireMappaContext = mapMethod.RequireMappaContextWhenInvoked();
-                var rootMapMethod = this.Context.GetRootMapMethod();
-                var callerMethodProvideMappaContext = rootMapMethod.ProvideMappaContextWhenInvoked();
-
-                if (!mapMethodRequireMappaContext || /* mapMethodRequireMappaContext && */ callerMethodProvideMappaContext)
-                {
-                    this.MaybeReportNestedMapWithoutMappaContext(mapMethod, mapMethodRequireMappaContext);
-                    return this.WrapIfNullableReferenceSource(
-                        new PolymorphicMethodMapStrategy(
-                            this.Context.TargetType,
-                            this.Context.SourceType,
-                            mapMethod,
-                            rootMapMethod.MaybeGetMappaContextParameterName()));
-                }
-            }
+            return existingStrategy;
         }
 
         return this.ComputeStrategy();
+    }
+
+    private MapStrategy? TryGetExistingMapMethodStrategy()
+    {
+        if (this.Context.PropertyPathContext is not null)
+        {
+            return null;
+        }
+
+        return this.TryGetDirectMethodStrategy()
+               ?? this.TryGetCompatibleMethodStrategy()
+               ?? this.TryGetPolymorphicMethodStrategy();
+    }
+
+    private MapStrategy? TryGetDirectMethodStrategy()
+    {
+        if (!this.Context.TryGetMethod(this.Context.TargetType, this.Context.SourceType, out var mapMethod))
+        {
+            return null;
+        }
+
+        return this.TryCreateWrappedMapMethodStrategy(
+            mapMethod,
+            (method, contextParameterName) => new MethodMapStrategy(method, contextParameterName));
+    }
+
+    private MapStrategy? TryGetCompatibleMethodStrategy()
+    {
+        if (this.Context.MappaUserSettings.CompatibleMapMethod is not BooleanSetting.Enable)
+        {
+            return null;
+        }
+
+        if (!this.Context.TryGetCompatibleMethod(this.Context.TargetType, this.Context.SourceType, this.Compilation, out var mapMethod))
+        {
+            return null;
+        }
+
+        if (ReferenceEquals(mapMethod, this.Context.GetRootMapMethod()))
+        {
+            return null;
+        }
+
+        return this.TryCreateWrappedMapMethodStrategy(
+            mapMethod,
+            (method, contextParameterName) => new CompatibleMethodMapStrategy(
+                this.Context.TargetType,
+                this.Context.SourceType,
+                method,
+                contextParameterName));
+    }
+
+    private MapStrategy? TryGetPolymorphicMethodStrategy()
+    {
+        if (!this.Context.TryGetPolymorphicMethod(this.Context.TargetType, this.Context.SourceType, this.Context.MappaUserSettings, out var mapMethod))
+        {
+            return null;
+        }
+
+        if (ReferenceEquals(mapMethod, this.Context.GetRootMapMethod()))
+        {
+            return null;
+        }
+
+        return this.TryCreateWrappedMapMethodStrategy(
+            mapMethod,
+            (method, contextParameterName) => new PolymorphicMethodMapStrategy(
+                this.Context.TargetType,
+                this.Context.SourceType,
+                method,
+                contextParameterName));
+    }
+
+    private MapStrategy? TryCreateWrappedMapMethodStrategy(
+        MapMethod mapMethod,
+        Func<MapMethod, string?, MapStrategy> createStrategy)
+    {
+        var mapMethodRequireMappaContext = mapMethod.RequireMappaContextWhenInvoked();
+        var rootMapMethod = this.Context.GetRootMapMethod();
+        var callerMethodProvideMappaContext = rootMapMethod.ProvideMappaContextWhenInvoked();
+
+        if (mapMethodRequireMappaContext && !callerMethodProvideMappaContext)
+        {
+            return null;
+        }
+
+        this.MaybeReportNestedMapWithoutMappaContext(mapMethod, mapMethodRequireMappaContext);
+        return this.WrapIfNullableReferenceSource(
+            createStrategy(mapMethod, rootMapMethod.MaybeGetMappaContextParameterName()));
     }
 
     private void MaybeReportNestedMapWithoutMappaContext(MapMethod mapMethod, bool mapMethodRequireMappaContext)

--- a/Mappa.Generator/Builders/Expressions/ProjectionExpressionBuilder.cs
+++ b/Mappa.Generator/Builders/Expressions/ProjectionExpressionBuilder.cs
@@ -18,6 +18,60 @@ namespace Mappa.Generator.Builders.Expressions;
 /// </summary>
 internal static class ProjectionExpressionBuilder
 {
+    private static readonly Dictionary<Type, Func<MapStrategy, string, ExpressionBuildContext, string>> ExpressionBuilders =
+        new()
+        {
+            [typeof(IdentityMapStrategy)] = static (_, source, _) => BuildIdentityExpression(source),
+            [typeof(NullableStrategy)] = static (strategy, source, context) =>
+                BuildNullableExpression((NullableStrategy)strategy, source, context),
+            [typeof(InvokeConstructorMapStrategy)] = static (strategy, source, context) =>
+                BuildConstructorExpression((InvokeConstructorMapStrategy)strategy, source, context),
+            [typeof(ParameterMapStrategy)] = static (strategy, source, context) =>
+                BuildParameterExpression((ParameterMapStrategy)strategy, source, context),
+            [typeof(PropertyMapStrategy)] = static (strategy, source, context) =>
+                BuildPropertyExpression((PropertyMapStrategy)strategy, source, context),
+            [typeof(EnumToEnumMapStrategy)] = static (strategy, source, _) =>
+                EnumMapSwitchExpressionHelper.BuildSwitchExpression(((EnumToEnumMapStrategy)strategy).EnumMapConfiguration, source),
+            [typeof(EnumToIntegralMapStrategy)] = static (strategy, source, _) =>
+                EnumMapSwitchExpressionHelper.BuildSwitchExpression(((EnumToIntegralMapStrategy)strategy).EnumMapConfiguration, source),
+            [typeof(EnumToStringMapStrategy)] = static (strategy, source, _) =>
+                EnumMapSwitchExpressionHelper.BuildSwitchExpression(((EnumToStringMapStrategy)strategy).EnumMapConfiguration, source),
+            [typeof(IntegralToEnumMapStrategy)] = static (strategy, source, _) =>
+                BuildIntegralToEnumExpression((IntegralToEnumMapStrategy)strategy, source),
+            [typeof(StringToEnumMapStrategy)] = static (strategy, source, _) =>
+                BuildStringToEnumExpression((StringToEnumMapStrategy)strategy, source),
+            [typeof(InvokeParseMethodMapStrategy)] = static (strategy, source, _) =>
+                $"{((InvokeParseMethodMapStrategy)strategy).TargetType.ToDisplayString()}.Parse({source})",
+            [typeof(InvokeToStringMapStrategy)] = static (strategy, source, _) =>
+                BuildToStringExpression((InvokeToStringMapStrategy)strategy, source),
+            [typeof(InvokeParseStringWithFormatMapStrategy)] = static (strategy, source, _) =>
+                BuildParseWithFormatExpression((InvokeParseStringWithFormatMapStrategy)strategy, source),
+            [typeof(InvokeParseStringWithFormatForDateOnlyAndTimeOnlyMapStrategy)] = static (strategy, source, _) =>
+                BuildParseDateOnlyOrTimeOnlyExpression((InvokeParseStringWithFormatForDateOnlyAndTimeOnlyMapStrategy)strategy, source),
+            [typeof(StringToNumberMapStrategy)] = static (strategy, source, _) =>
+                BuildStringToNumberExpression((StringToNumberMapStrategy)strategy, source),
+            [typeof(StringToUriMapStrategy)] = static (_, source, _) => $"new System.Uri({source})",
+            [typeof(DateOnlyToDateTimeMapStrategy)] = static (_, source, _) =>
+                $"new System.DateTime({source}, System.TimeOnly.MinValue, System.DateTimeKind.Utc)",
+            [typeof(DateOnlyToLongMapStrategy)] = static (_, source, _) =>
+                $"(long)new System.DateTime({source}, System.TimeOnly.MinValue, System.DateTimeKind.Utc).ToUniversalTime().Subtract(System.DateTime.UnixEpoch).TotalSeconds",
+            [typeof(DateTimeOffsetToDateOnlyMapStrategy)] = static (_, source, _) =>
+                $"System.DateOnly.FromDateTime({source}.DateTime)",
+            [typeof(DateTimeOffsetToDateTimeMapStrategy)] = static (_, source, _) => $"{source}.DateTime",
+            [typeof(DateTimeOffsetToLongMapStrategy)] = static (_, source, _) => $"{source}.ToUnixTimeSeconds()",
+            [typeof(DateTimeOffsetToTimeOnlyMapStrategy)] = static (_, source, _) =>
+                $"System.TimeOnly.FromDateTime({source}.DateTime)",
+            [typeof(DateTimeToDateOnlyMapStrategy)] = static (_, source, _) => $"System.DateOnly.FromDateTime({source})",
+            [typeof(DateTimeToLongMapStrategy)] = static (_, source, _) =>
+                $"(long){source}.ToUniversalTime().Subtract(System.DateTime.UnixEpoch).TotalSeconds",
+            [typeof(DateTimeToTimeOnlyMapStrategy)] = static (_, source, _) => $"System.TimeOnly.FromDateTime({source})",
+            [typeof(DoubleToTimeSpanMapStrategy)] = static (_, source, _) => $"System.TimeSpan.FromDays({source})",
+            [typeof(LongToDateTimeMapStrategy)] = static (_, source, _) => $"System.DateTime.UnixEpoch.AddSeconds({source})",
+            [typeof(LongToDateTimeOffsetMapStrategy)] = static (_, source, _) =>
+                $"System.DateTimeOffset.FromUnixTimeSeconds({source})",
+            [typeof(TimeSpanToDoubleMapStrategy)] = static (_, source, _) => $"{source}.TotalDays",
+        };
+
     /// <summary>
     /// Attempts to build a projection expression for the specified strategy.
     /// </summary>
@@ -38,47 +92,12 @@ internal static class ProjectionExpressionBuilder
             return false;
         }
 
-        expression = strategy switch
+        if (!ExpressionBuilders.TryGetValue(strategy.GetType(), out var builder))
         {
-            IdentityMapStrategy => BuildIdentityExpression(source),
-            NullableStrategy nullableStrategy => BuildNullableExpression(nullableStrategy, source, context),
-            InvokeConstructorMapStrategy invokeConstructorMapStrategy => BuildConstructorExpression(invokeConstructorMapStrategy, source, context),
-            ParameterMapStrategy parameterMapStrategy => BuildParameterExpression(parameterMapStrategy, source, context),
-            PropertyMapStrategy propertyMapStrategy => BuildPropertyExpression(propertyMapStrategy, source, context),
-            EnumToEnumMapStrategy enumToEnumMapStrategy => EnumMapSwitchExpressionHelper.BuildSwitchExpression(
-                enumToEnumMapStrategy.EnumMapConfiguration,
-                source),
-            EnumToIntegralMapStrategy enumToIntegralMapStrategy => EnumMapSwitchExpressionHelper.BuildSwitchExpression(
-                enumToIntegralMapStrategy.EnumMapConfiguration,
-                source),
-            EnumToStringMapStrategy enumToStringMapStrategy => EnumMapSwitchExpressionHelper.BuildSwitchExpression(
-                enumToStringMapStrategy.EnumMapConfiguration,
-                source),
-            IntegralToEnumMapStrategy integralToEnumMapStrategy => BuildIntegralToEnumExpression(integralToEnumMapStrategy, source),
-            StringToEnumMapStrategy stringToEnumMapStrategy => BuildStringToEnumExpression(stringToEnumMapStrategy, source),
-            InvokeParseMethodMapStrategy invokeParseMethodMapStrategy => $"{invokeParseMethodMapStrategy.TargetType.ToDisplayString()}.Parse({source})",
-            InvokeToStringMapStrategy invokeToStringMapStrategy => BuildToStringExpression(invokeToStringMapStrategy, source),
-            InvokeParseStringWithFormatMapStrategy invokeParseStringWithFormatMapStrategy => BuildParseWithFormatExpression(invokeParseStringWithFormatMapStrategy, source),
-            InvokeParseStringWithFormatForDateOnlyAndTimeOnlyMapStrategy invokeParseStringWithFormatForDateOnlyAndTimeOnlyMapStrategy
-                => BuildParseDateOnlyOrTimeOnlyExpression(invokeParseStringWithFormatForDateOnlyAndTimeOnlyMapStrategy, source),
-            StringToNumberMapStrategy stringToNumberMapStrategy => BuildStringToNumberExpression(stringToNumberMapStrategy, source),
-            StringToUriMapStrategy => $"new System.Uri({source})",
-            DateOnlyToDateTimeMapStrategy => $"new System.DateTime({source}, System.TimeOnly.MinValue, System.DateTimeKind.Utc)",
-            DateOnlyToLongMapStrategy => $"(long)new System.DateTime({source}, System.TimeOnly.MinValue, System.DateTimeKind.Utc).ToUniversalTime().Subtract(System.DateTime.UnixEpoch).TotalSeconds",
-            DateTimeOffsetToDateOnlyMapStrategy => $"System.DateOnly.FromDateTime({source}.DateTime)",
-            DateTimeOffsetToDateTimeMapStrategy => $"{source}.DateTime",
-            DateTimeOffsetToLongMapStrategy => $"{source}.ToUnixTimeSeconds()",
-            DateTimeOffsetToTimeOnlyMapStrategy => $"System.TimeOnly.FromDateTime({source}.DateTime)",
-            DateTimeToDateOnlyMapStrategy => $"System.DateOnly.FromDateTime({source})",
-            DateTimeToLongMapStrategy => $"(long){source}.ToUniversalTime().Subtract(System.DateTime.UnixEpoch).TotalSeconds",
-            DateTimeToTimeOnlyMapStrategy => $"System.TimeOnly.FromDateTime({source})",
-            DoubleToTimeSpanMapStrategy => $"System.TimeSpan.FromDays({source})",
-            LongToDateTimeMapStrategy => $"System.DateTime.UnixEpoch.AddSeconds({source})",
-            LongToDateTimeOffsetMapStrategy => $"System.DateTimeOffset.FromUnixTimeSeconds({source})",
-            TimeSpanToDoubleMapStrategy => $"{source}.TotalDays",
-            _ => throw new MappaGeneratorException($"Unsupported projection strategy '{strategy.GetType().Name}'."),
-        };
+            throw new MappaGeneratorException($"Unsupported projection strategy '{strategy.GetType().Name}'.");
+        }
 
+        expression = builder(strategy, source, context);
         return true;
     }
 

--- a/Mappa.Generator/Builders/MappaDependencyInjectionFileBuilder.cs
+++ b/Mappa.Generator/Builders/MappaDependencyInjectionFileBuilder.cs
@@ -110,6 +110,34 @@ internal sealed class MappaDependencyInjectionFileBuilder
             _ => "public",
         };
 
+    private static void AppendInterfaceOnlyMapperRegistrations(
+        PrettyCode.StringBuilder builder,
+        string addMethodName,
+        string mapperTypeName,
+        ImmutableArray<INamedTypeSymbol> interfaces)
+    {
+        foreach (var @interface in interfaces)
+        {
+            var interfaceTypeName = $"global::{@interface.ToDisplayString()}";
+            builder.AppendLine($"services.{addMethodName}<{interfaceTypeName}, {mapperTypeName}>();");
+        }
+    }
+
+    private static void AppendInterfaceAndClassMapperRegistrations(
+        PrettyCode.StringBuilder builder,
+        string addMethodName,
+        string mapperTypeName,
+        ImmutableArray<INamedTypeSymbol> interfaces)
+    {
+        builder.AppendLine($"services.{addMethodName}<{mapperTypeName}>();");
+        foreach (var @interface in interfaces)
+        {
+            var interfaceTypeName = $"global::{@interface.ToDisplayString()}";
+            builder.AppendLine(
+                $"services.{addMethodName}<{interfaceTypeName}, {mapperTypeName}>(serviceProvider => serviceProvider.GetRequiredService<{mapperTypeName}>());");
+        }
+    }
+
     private string BuildClassSource()
     {
         var builder = new PrettyCode.StringBuilder();
@@ -156,40 +184,32 @@ internal sealed class MappaDependencyInjectionFileBuilder
         builder.AppendLine($"{modifiers} global::Microsoft.Extensions.DependencyInjection.IServiceCollection {methodName}({parameter})");
         using (builder.CurlyBracesBlock())
         {
-            foreach (var (mapper, interfaces) in this.Mappers)
-            {
-                var mapperTypeName = $"global::{mapper.ToDisplayString()}";
-                switch (this.AttributeData.InjectInterfaces)
-                {
-                    case MappaDependencyInjectionInjectInterfaces.InterfaceOnly:
-                        foreach (var @interface in interfaces)
-                        {
-                            var interfaceTypeName = $"global::{@interface.ToDisplayString()}";
-                            builder.AppendLine($"services.{addMethodName}<{interfaceTypeName}, {mapperTypeName}>();");
-                        }
-
-                        break;
-
-                    case MappaDependencyInjectionInjectInterfaces.InterfaceAndClass:
-                        builder.AppendLine($"services.{addMethodName}<{mapperTypeName}>();");
-                        foreach (var @interface in interfaces)
-                        {
-                            var interfaceTypeName = $"global::{@interface.ToDisplayString()}";
-                            builder.AppendLine(
-                                $"services.{addMethodName}<{interfaceTypeName}, {mapperTypeName}>(serviceProvider => serviceProvider.GetRequiredService<{mapperTypeName}>());");
-                        }
-
-                        break;
-
-                    default:
-                        builder.AppendLine($"services.{addMethodName}<{mapperTypeName}>();");
-                        break;
-                }
-            }
-
+            this.AppendMapperServiceRegistrations(builder, addMethodName);
             builder.AppendLine("return services;");
         }
 
         return builder.ToString();
+    }
+
+    private void AppendMapperServiceRegistrations(PrettyCode.StringBuilder builder, string addMethodName)
+    {
+        foreach (var (mapper, interfaces) in this.Mappers)
+        {
+            var mapperTypeName = $"global::{mapper.ToDisplayString()}";
+            switch (this.AttributeData.InjectInterfaces)
+            {
+                case MappaDependencyInjectionInjectInterfaces.InterfaceOnly:
+                    AppendInterfaceOnlyMapperRegistrations(builder, addMethodName, mapperTypeName, interfaces);
+                    break;
+
+                case MappaDependencyInjectionInjectInterfaces.InterfaceAndClass:
+                    AppendInterfaceAndClassMapperRegistrations(builder, addMethodName, mapperTypeName, interfaces);
+                    break;
+
+                default:
+                    builder.AppendLine($"services.{addMethodName}<{mapperTypeName}>();");
+                    break;
+            }
+        }
     }
 }

--- a/Mappa.Generator/Builders/Strategies/CollectionToCollectionMapStrategyBuilder.cs
+++ b/Mappa.Generator/Builders/Strategies/CollectionToCollectionMapStrategyBuilder.cs
@@ -18,7 +18,207 @@ namespace Mappa.Generator.Builders.Strategies;
 internal sealed class CollectionToCollectionMapStrategyBuilder(CollectionToCollectionMapStrategy strategy)
     : IMappaStrategyBuilder
 {
+    private static readonly Func<ITypeSymbol, Compilation, bool>[] ArraySpanMemoryOrImmutableQueueStackPredicates =
+    [
+        static (type, _) => type.IsArray(),
+        static (type, compilation) => type.IsSpan(compilation),
+        static (type, compilation) => type.IsReadOnlySpan(compilation),
+        static (type, compilation) => type.IsMemory(compilation),
+        static (type, compilation) => type.IsReadOnlyMemory(compilation),
+        static (type, compilation) => type.IsIImmutableQueue(compilation),
+        static (type, compilation) => type.IsImmutableQueue(compilation),
+        static (type, compilation) => type.IsIImmutableStack(compilation),
+        static (type, compilation) => type.IsImmutableStack(compilation),
+    ];
+
+    private static readonly Func<ITypeSymbol, Compilation, bool>[] ListLikeEnumerableTargetPredicates =
+    [
+        static (type, _) => type.IsIEnumerable(),
+        static (type, compilation) => type.IsList(compilation),
+        static (type, _) => type.IsIList(),
+        static (type, _) => type.IsIReadOnlyList(),
+        static (type, _) => type.IsICollection(),
+        static (type, _) => type.IsIReadOnlyCollection(),
+        static (type, compilation) => type.IsReadOnlyCollection(compilation),
+        static (type, compilation) => type.IsFrozenSet(compilation),
+        static (type, compilation) => type.IsIImmutableSet(compilation),
+        static (type, compilation) => type.IsImmutableHashSet(compilation),
+        static (type, compilation) => type.IsImmutableSortedSet(compilation),
+        static (type, compilation) => type.IsIImmutableList(compilation),
+        static (type, compilation) => type.IsImmutableArray(compilation),
+        static (type, compilation) => type.IsImmutableList(compilation),
+    ];
+
+    private static readonly PostLoopDispatchEntry[] PostLoopDispatchEntries =
+    [
+        new(
+            IsSpanMemoryOrReadOnlyWrapperTarget,
+            static (stringBuilder, context, targetTypeSymbol, ref targetVariableName) =>
+                AppendConstructFromBufferPostLoop(stringBuilder, context, targetTypeSymbol, ref targetVariableName),
+            stopAfterMatch: true),
+        new(
+            static (type, compilation) => type.IsFrozenSet(compilation),
+            static (stringBuilder, context, targetTypeSymbol, ref targetVariableName) =>
+                AppendFrozenSetPostLoop(stringBuilder, context, targetTypeSymbol, ref targetVariableName),
+            stopAfterMatch: true),
+        new(
+            static (type, compilation) =>
+                type.IsIImmutableSet(compilation) || type.IsImmutableHashSet(compilation),
+            static (stringBuilder, context, targetTypeSymbol, ref targetVariableName) =>
+                AppendImmutableHashSetPostLoop(stringBuilder, context, targetTypeSymbol, ref targetVariableName),
+            stopAfterMatch: true),
+        new(
+            static (type, compilation) => type.IsImmutableSortedSet(compilation),
+            static (stringBuilder, context, targetTypeSymbol, ref targetVariableName) =>
+                AppendImmutableSortedSetPostLoop(stringBuilder, context, targetTypeSymbol, ref targetVariableName),
+            stopAfterMatch: true),
+        new(
+            static (type, compilation) =>
+                type.IsIImmutableList(compilation) || type.IsImmutableArray(compilation),
+            static (stringBuilder, context, targetTypeSymbol, ref targetVariableName) =>
+                AppendImmutableArrayPostLoop(stringBuilder, context, targetTypeSymbol, ref targetVariableName),
+            stopAfterMatch: true),
+        new(
+            static (type, compilation) => type.IsImmutableList(compilation),
+            static (stringBuilder, context, targetTypeSymbol, ref targetVariableName) =>
+                AppendImmutableListPostLoop(stringBuilder, context, targetTypeSymbol, ref targetVariableName),
+            stopAfterMatch: true),
+        new(
+            static (type, compilation) =>
+                type.IsIImmutableQueue(compilation) || type.IsImmutableQueue(compilation),
+            static (stringBuilder, context, targetTypeSymbol, ref targetVariableName) =>
+                AppendImmutableQueuePostLoop(stringBuilder, context, targetTypeSymbol, ref targetVariableName),
+            stopAfterMatch: true),
+        new(
+            static (type, compilation) =>
+                type.IsIImmutableStack(compilation) || type.IsImmutableStack(compilation),
+            static (stringBuilder, context, targetTypeSymbol, ref targetVariableName) =>
+                AppendImmutableStackPostLoop(stringBuilder, context, targetTypeSymbol, ref targetVariableName),
+            stopAfterMatch: false),
+    ];
+
+    private static readonly TargetVariableDispatchEntry[] TargetVariableDispatchEntries =
+    [
+        new(
+            static ctx => IsFastCollectionArrayTarget(
+                ctx.FastCollections,
+                ctx.SourceTypeSymbol,
+                ctx.TargetTypeSymbol,
+                ctx.BuilderContext.Compilation),
+            static ctx => AppendFastCollectionArrayTarget(
+                ctx.StringBuilder,
+                ctx.Source,
+                ctx.BuilderContext,
+                ctx.TargetTypeSymbol,
+                ctx.SourceTypeSymbol,
+                ctx.State)),
+        new(
+            static ctx => IsArraySpanMemoryOrImmutableQueueStackTarget(ctx.TargetTypeSymbol, ctx.BuilderContext.Compilation),
+            static ctx => AppendArraySpanMemoryOrImmutableQueueStackTarget(
+                ctx.StringBuilder,
+                ctx.Source,
+                ctx.BuilderContext,
+                ctx.TargetTypeSymbol,
+                ctx.SourceTypeSymbol,
+                ctx.PreventEnumerableCount,
+                ctx.EnumerableConcreteType,
+                ctx.State)),
+        new(
+            static ctx => IsHashSetLikeTarget(ctx.TargetTypeSymbol, ctx.BuilderContext.Compilation),
+            static ctx => AppendHashSetLikeTarget(
+                ctx.StringBuilder,
+                ctx.Source,
+                ctx.BuilderContext,
+                ctx.TargetTypeSymbol,
+                ctx.SourceTypeSymbol,
+                ctx.State)),
+        new(
+            static ctx => ctx.TargetTypeSymbol.IsOrDerivedFromStack(ctx.BuilderContext.Compilation),
+            static ctx => AppendStackTarget(
+                ctx.StringBuilder,
+                ctx.Source,
+                ctx.BuilderContext,
+                ctx.MethodSymbol,
+                ctx.TargetTypeSymbol,
+                ctx.SourceTypeSymbol,
+                ctx.ContainerCapacityConstructors,
+                ctx.State)),
+        new(
+            static ctx => ctx.TargetTypeSymbol.IsOrDerivedFromConcurrentStack(ctx.BuilderContext.Compilation),
+            static ctx => AppendConcurrentStackTarget(ctx.StringBuilder, ctx.TargetTypeSymbol, ctx.State)),
+        new(
+            static ctx => ctx.TargetTypeSymbol.IsOrDerivedFromQueue(ctx.BuilderContext.Compilation),
+            static ctx => AppendQueueTarget(
+                ctx.StringBuilder,
+                ctx.Source,
+                ctx.BuilderContext,
+                ctx.MethodSymbol,
+                ctx.TargetTypeSymbol,
+                ctx.SourceTypeSymbol,
+                ctx.ContainerCapacityConstructors,
+                ctx.State)),
+        new(
+            static ctx => ctx.TargetTypeSymbol.IsOrImplementConcurrentQueue(ctx.BuilderContext.Compilation),
+            static ctx => AppendConcurrentQueueTarget(ctx.StringBuilder, ctx.TargetTypeSymbol, ctx.State)),
+        new(
+            static ctx => IsBlockingCollectionOrConcurrentBagTarget(ctx.TargetTypeSymbol, ctx.BuilderContext.Compilation),
+            static ctx => AppendBlockingCollectionOrConcurrentBagTarget(
+                ctx.StringBuilder,
+                ctx.Source,
+                ctx.BuilderContext,
+                ctx.MethodSymbol,
+                ctx.TargetTypeSymbol,
+                ctx.SourceTypeSymbol,
+                ctx.ContainerCapacityConstructors,
+                ctx.State)),
+        new(
+            static ctx => ShouldUseArrayForEnumerableInterfaceTarget(ctx.TargetTypeSymbol, ctx.EnumerableConcreteType),
+            AppendArrayEnumerableInterfaceTarget),
+        new(
+            static ctx => IsListLikeEnumerableTarget(ctx.TargetTypeSymbol, ctx.BuilderContext.Compilation),
+            static ctx => AppendListLikeEnumerableTarget(
+                ctx.StringBuilder,
+                ctx.Source,
+                ctx.BuilderContext,
+                ctx.TargetTypeSymbol,
+                ctx.SourceTypeSymbol,
+                ctx.State)),
+        new(
+            static ctx => ctx.TargetTypeSymbol.IsIProducerConsumerCollection(ctx.BuilderContext.Compilation),
+            static ctx => AppendProducerConsumerCollectionTarget(ctx.StringBuilder, ctx.TargetTypeSymbol, ctx.State)),
+        new(
+            static ctx => ctx.TargetTypeSymbol.ImplementISet(ctx.BuilderContext.Compilation),
+            static ctx => AppendImplementISetTarget(
+                ctx.StringBuilder,
+                ctx.Source,
+                ctx.BuilderContext,
+                ctx.MethodSymbol,
+                ctx.TargetTypeSymbol,
+                ctx.SourceTypeSymbol,
+                ctx.ContainerCapacityConstructors,
+                ctx.State)),
+        new(
+            static ctx => ctx.TargetTypeSymbol.ImplementICollection(),
+            static ctx => AppendImplementICollectionTarget(
+                ctx.StringBuilder,
+                ctx.Source,
+                ctx.BuilderContext,
+                ctx.MethodSymbol,
+                ctx.TargetTypeSymbol,
+                ctx.SourceTypeSymbol,
+                ctx.ContainerCapacityConstructors,
+                ctx.State)),
+    ];
+
     private readonly CollectionToCollectionMapStrategy strategy = strategy;
+
+    private delegate void PostLoopAppendAction(
+        PrettyCode.StringBuilder stringBuilder,
+        MappaBuilderContext context,
+        ITypeSymbol targetTypeSymbol,
+        ref string targetVariableName);
+
+    private delegate void TargetVariableBranchAppender(AppendTargetVariableContext context);
 
     private enum InsertionMethod
     {
@@ -70,41 +270,17 @@ internal sealed class CollectionToCollectionMapStrategyBuilder(CollectionToColle
                 stringBuilder.AppendLine(targetElementCode);
             }
 
-            switch (addMethod)
-            {
-                case InsertionMethod.Indexer:
-                    var index = loopCounterTemporary ?? targetCounterTemporary ?? throw new MappaGeneratorException("Cannot identify a suitable index");
-                    stringBuilder.AppendLine($"{variableToAccessFrom ?? targetVariableName}[{index}] = {targetElementVariable};");
-
-                    // If there is no counting variable from the loop the target counter must be increased.
-                    if (string.IsNullOrWhiteSpace(loopCounterTemporary))
-                    {
-                        stringBuilder.AppendLine($"{targetCounterTemporary} = {targetCounterTemporary} + 1;");
-                    }
-
-                    break;
-                case InsertionMethod.Add:
-                    if (interfaceMethodAccessMode == InterfaceMethodAccessMode.InterfaceExplicit)
-                    {
-                        var interfaceTemporary = context.NextTemporary();
-                        stringBuilder.AppendLine($"{interfaceToAccessFrom} {interfaceTemporary} = {targetVariableName};");
-                        stringBuilder.AppendLine($"{interfaceTemporary}.Add({targetElementVariable});");
-                    }
-                    else
-                    {
-                        stringBuilder.AppendLine($"{targetVariableName}.Add({targetElementVariable});");
-                    }
-
-                    break;
-                case InsertionMethod.Push:
-                    stringBuilder.AppendLine($"{targetVariableName}.Push({targetElementVariable});");
-                    break;
-                case InsertionMethod.Enqueue:
-                    stringBuilder.AppendLine($"{targetVariableName}.Enqueue({targetElementVariable});");
-                    break;
-                default:
-                    throw new MappaGeneratorException("Unexpected add method.");
-            }
+            AppendMappedElementToTarget(
+                stringBuilder,
+                context,
+                addMethod,
+                targetVariableName,
+                variableToAccessFrom,
+                interfaceMethodAccessMode,
+                interfaceToAccessFrom,
+                targetElementVariable,
+                loopCounterTemporary,
+                targetCounterTemporary);
         }
 
         // For some types we need to do a bit of post-processing to make sure we always return the correct type
@@ -112,6 +288,86 @@ internal sealed class CollectionToCollectionMapStrategyBuilder(CollectionToColle
         AppendPostLoopCode(stringBuilder, context, this.strategy.TargetType, ref targetVariableName, usedGrowableBuffer);
 
         return (targetVariableName, stringBuilder.ToString());
+    }
+
+    private static void AppendMappedElementToTarget(
+        PrettyCode.StringBuilder stringBuilder,
+        MappaBuilderContext context,
+        InsertionMethod addMethod,
+        string targetVariableName,
+        string? variableToAccessFrom,
+        InterfaceMethodAccessMode interfaceMethodAccessMode,
+        string interfaceToAccessFrom,
+        string targetElementVariable,
+        string? loopCounterTemporary,
+        string? targetCounterTemporary)
+    {
+        switch (addMethod)
+        {
+            case InsertionMethod.Indexer:
+                AppendMappedElementWithIndexer(
+                    stringBuilder,
+                    targetVariableName,
+                    variableToAccessFrom,
+                    targetElementVariable,
+                    loopCounterTemporary,
+                    targetCounterTemporary);
+                break;
+            case InsertionMethod.Add:
+                AppendMappedElementWithAdd(
+                    stringBuilder,
+                    context,
+                    targetVariableName,
+                    interfaceMethodAccessMode,
+                    interfaceToAccessFrom,
+                    targetElementVariable);
+                break;
+            case InsertionMethod.Push:
+                stringBuilder.AppendLine($"{targetVariableName}.Push({targetElementVariable});");
+                break;
+            case InsertionMethod.Enqueue:
+                stringBuilder.AppendLine($"{targetVariableName}.Enqueue({targetElementVariable});");
+                break;
+            default:
+                throw new MappaGeneratorException("Unexpected add method.");
+        }
+    }
+
+    private static void AppendMappedElementWithIndexer(
+        PrettyCode.StringBuilder stringBuilder,
+        string targetVariableName,
+        string? variableToAccessFrom,
+        string targetElementVariable,
+        string? loopCounterTemporary,
+        string? targetCounterTemporary)
+    {
+        var index = loopCounterTemporary ?? targetCounterTemporary ?? throw new MappaGeneratorException("Cannot identify a suitable index");
+        stringBuilder.AppendLine($"{variableToAccessFrom ?? targetVariableName}[{index}] = {targetElementVariable};");
+
+        if (string.IsNullOrWhiteSpace(loopCounterTemporary))
+        {
+            stringBuilder.AppendLine($"{targetCounterTemporary} = {targetCounterTemporary} + 1;");
+        }
+    }
+
+    private static void AppendMappedElementWithAdd(
+        PrettyCode.StringBuilder stringBuilder,
+        MappaBuilderContext context,
+        string targetVariableName,
+        InterfaceMethodAccessMode interfaceMethodAccessMode,
+        string interfaceToAccessFrom,
+        string targetElementVariable)
+    {
+        if (interfaceMethodAccessMode == InterfaceMethodAccessMode.InterfaceExplicit)
+        {
+            var interfaceTemporary = context.NextTemporary();
+            stringBuilder.AppendLine($"{interfaceToAccessFrom} {interfaceTemporary} = {targetVariableName};");
+            stringBuilder.AppendLine($"{interfaceTemporary}.Add({targetElementVariable});");
+        }
+        else
+        {
+            stringBuilder.AppendLine($"{targetVariableName}.Add({targetElementVariable});");
+        }
     }
 
     private static void AppendPostLoopCode(
@@ -123,86 +379,148 @@ internal sealed class CollectionToCollectionMapStrategyBuilder(CollectionToColle
     {
         if (usedGrowableBuffer)
         {
-            var elementTypeDisplayString = targetTypeSymbol.GetElementType().ToDisplayString();
-            var arrayVariableName = context.NextTemporary();
-            stringBuilder.AppendEmptyLine();
-            stringBuilder.AppendLine($"{elementTypeDisplayString}[] {arrayVariableName} = {targetVariableName}.ToArray();");
-            targetVariableName = arrayVariableName;
+            AppendGrowableBufferToArrayPostLoop(stringBuilder, context, targetTypeSymbol, ref targetVariableName);
         }
 
-        if (targetTypeSymbol.IsSpan(context.Compilation)
-            || targetTypeSymbol.IsReadOnlySpan(context.Compilation)
-            || targetTypeSymbol.IsMemory(context.Compilation)
-            || targetTypeSymbol.IsReadOnlyMemory(context.Compilation)
-            || targetTypeSymbol.IsReadOnlyCollection(context.Compilation)
-            || targetTypeSymbol.IsReadOnlySet(context.Compilation))
+        var compilation = context.Compilation;
+        foreach (var entry in PostLoopDispatchEntries)
         {
-            var targetTypeDisplayString = targetTypeSymbol.ToDisplayString();
-            var postLoopVariableName = context.NextTemporary();
-            stringBuilder.AppendEmptyLine();
-            stringBuilder.AppendLine($"global::{targetTypeDisplayString} {postLoopVariableName} = new global::{targetTypeDisplayString}({targetVariableName});");
-            targetVariableName = postLoopVariableName;
+            if (!entry.Matches(targetTypeSymbol, compilation))
+            {
+                continue;
+            }
+
+            entry.Append(stringBuilder, context, targetTypeSymbol, ref targetVariableName);
+            if (entry.StopAfterMatch)
+            {
+                return;
+            }
         }
-        else if (targetTypeSymbol.IsFrozenSet(context.Compilation))
-        {
-            var postLoopVariableName = context.NextTemporary();
-            stringBuilder.AppendEmptyLine();
-            string elementTypeDisplayString = targetTypeSymbol.GetElementType().ToDisplayString();
-            stringBuilder.AppendLine($"global::System.Collections.Frozen.FrozenSet<{elementTypeDisplayString}> {postLoopVariableName} = System.Collections.Frozen.FrozenSet.ToFrozenSet<{elementTypeDisplayString}>({targetVariableName});");
-            targetVariableName = postLoopVariableName;
-        }
-        else if (targetTypeSymbol.IsIImmutableSet(context.Compilation)
-                 || targetTypeSymbol.IsImmutableHashSet(context.Compilation))
-        {
-            var postLoopVariableName = context.NextTemporary();
-            stringBuilder.AppendEmptyLine();
-            string elementTypeDisplayString = targetTypeSymbol.GetElementType().ToDisplayString();
-            stringBuilder.AppendLine($"global::{targetTypeSymbol.ToDisplayString()} {postLoopVariableName} = System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet<{elementTypeDisplayString}>({targetVariableName});");
-            targetVariableName = postLoopVariableName;
-        }
-        else if (targetTypeSymbol.IsImmutableSortedSet(context.Compilation))
-        {
-            var postLoopVariableName = context.NextTemporary();
-            stringBuilder.AppendEmptyLine();
-            string elementTypeDisplayString = targetTypeSymbol.GetElementType().ToDisplayString();
-            stringBuilder.AppendLine($"global::System.Collections.Immutable.ImmutableSortedSet<{elementTypeDisplayString}> {postLoopVariableName} = System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet<{elementTypeDisplayString}>({targetVariableName});");
-            targetVariableName = postLoopVariableName;
-        }
-        else if (targetTypeSymbol.IsIImmutableList(context.Compilation)
-                 || targetTypeSymbol.IsImmutableArray(context.Compilation))
-        {
-            var postLoopVariableName = context.NextTemporary();
-            stringBuilder.AppendEmptyLine();
-            string elementTypeDisplayString = targetTypeSymbol.GetElementType().ToDisplayString();
-            stringBuilder.AppendLine($"global::{targetTypeSymbol.ToDisplayString()} {postLoopVariableName} = System.Collections.Immutable.ImmutableArray.ToImmutableArray<{elementTypeDisplayString}>({targetVariableName});");
-            targetVariableName = postLoopVariableName;
-        }
-        else if (targetTypeSymbol.IsImmutableList(context.Compilation))
-        {
-            var postLoopVariableName = context.NextTemporary();
-            stringBuilder.AppendEmptyLine();
-            string elementTypeDisplayString = targetTypeSymbol.GetElementType().ToDisplayString();
-            stringBuilder.AppendLine($"global::System.Collections.Immutable.ImmutableList<{elementTypeDisplayString}> {postLoopVariableName} = System.Collections.Immutable.ImmutableList.ToImmutableList<{elementTypeDisplayString}>({targetVariableName});");
-            targetVariableName = postLoopVariableName;
-        }
-        else if (targetTypeSymbol.IsIImmutableQueue(context.Compilation)
-                 || targetTypeSymbol.IsImmutableQueue(context.Compilation))
-        {
-            var postLoopVariableName = context.NextTemporary();
-            stringBuilder.AppendEmptyLine();
-            string elementTypeDisplayString = targetTypeSymbol.GetElementType().ToDisplayString();
-            stringBuilder.AppendLine($"global::{targetTypeSymbol.ToDisplayString()} {postLoopVariableName} = System.Collections.Immutable.ImmutableQueue.Create<{elementTypeDisplayString}>({targetVariableName});");
-            targetVariableName = postLoopVariableName;
-        }
-        else if (targetTypeSymbol.IsIImmutableStack(context.Compilation)
-                 || targetTypeSymbol.IsImmutableStack(context.Compilation))
-        {
-            var postLoopVariableName = context.NextTemporary();
-            stringBuilder.AppendEmptyLine();
-            string elementTypeDisplayString = targetTypeSymbol.GetElementType().ToDisplayString();
-            stringBuilder.AppendLine($"global::{targetTypeSymbol.ToDisplayString()} {postLoopVariableName} = System.Collections.Immutable.ImmutableStack.Create<{elementTypeDisplayString}>({targetVariableName});");
-            targetVariableName = postLoopVariableName;
-        }
+    }
+
+    private static bool IsSpanMemoryOrReadOnlyWrapperTarget(ITypeSymbol targetTypeSymbol, Compilation compilation)
+        => targetTypeSymbol.IsSpan(compilation)
+           || targetTypeSymbol.IsReadOnlySpan(compilation)
+           || targetTypeSymbol.IsMemory(compilation)
+           || targetTypeSymbol.IsReadOnlyMemory(compilation)
+           || targetTypeSymbol.IsReadOnlyCollection(compilation)
+           || targetTypeSymbol.IsReadOnlySet(compilation);
+
+    private static void AppendGrowableBufferToArrayPostLoop(
+        PrettyCode.StringBuilder stringBuilder,
+        MappaBuilderContext context,
+        ITypeSymbol targetTypeSymbol,
+        ref string targetVariableName)
+    {
+        var elementTypeDisplayString = targetTypeSymbol.GetElementType().ToDisplayString();
+        var arrayVariableName = context.NextTemporary();
+        stringBuilder.AppendEmptyLine();
+        stringBuilder.AppendLine($"{elementTypeDisplayString}[] {arrayVariableName} = {targetVariableName}.ToArray();");
+        targetVariableName = arrayVariableName;
+    }
+
+    private static void AppendConstructFromBufferPostLoop(
+        PrettyCode.StringBuilder stringBuilder,
+        MappaBuilderContext context,
+        ITypeSymbol targetTypeSymbol,
+        ref string targetVariableName)
+    {
+        var targetTypeDisplayString = targetTypeSymbol.ToDisplayString();
+        var postLoopVariableName = context.NextTemporary();
+        stringBuilder.AppendEmptyLine();
+        stringBuilder.AppendLine($"global::{targetTypeDisplayString} {postLoopVariableName} = new global::{targetTypeDisplayString}({targetVariableName});");
+        targetVariableName = postLoopVariableName;
+    }
+
+    private static void AppendFrozenSetPostLoop(
+        PrettyCode.StringBuilder stringBuilder,
+        MappaBuilderContext context,
+        ITypeSymbol targetTypeSymbol,
+        ref string targetVariableName)
+    {
+        var postLoopVariableName = context.NextTemporary();
+        stringBuilder.AppendEmptyLine();
+        string elementTypeDisplayString = targetTypeSymbol.GetElementType().ToDisplayString();
+        stringBuilder.AppendLine($"global::System.Collections.Frozen.FrozenSet<{elementTypeDisplayString}> {postLoopVariableName} = System.Collections.Frozen.FrozenSet.ToFrozenSet<{elementTypeDisplayString}>({targetVariableName});");
+        targetVariableName = postLoopVariableName;
+    }
+
+    private static void AppendImmutableHashSetPostLoop(
+        PrettyCode.StringBuilder stringBuilder,
+        MappaBuilderContext context,
+        ITypeSymbol targetTypeSymbol,
+        ref string targetVariableName)
+    {
+        var postLoopVariableName = context.NextTemporary();
+        stringBuilder.AppendEmptyLine();
+        string elementTypeDisplayString = targetTypeSymbol.GetElementType().ToDisplayString();
+        stringBuilder.AppendLine($"global::{targetTypeSymbol.ToDisplayString()} {postLoopVariableName} = System.Collections.Immutable.ImmutableHashSet.ToImmutableHashSet<{elementTypeDisplayString}>({targetVariableName});");
+        targetVariableName = postLoopVariableName;
+    }
+
+    private static void AppendImmutableSortedSetPostLoop(
+        PrettyCode.StringBuilder stringBuilder,
+        MappaBuilderContext context,
+        ITypeSymbol targetTypeSymbol,
+        ref string targetVariableName)
+    {
+        var postLoopVariableName = context.NextTemporary();
+        stringBuilder.AppendEmptyLine();
+        string elementTypeDisplayString = targetTypeSymbol.GetElementType().ToDisplayString();
+        stringBuilder.AppendLine($"global::System.Collections.Immutable.ImmutableSortedSet<{elementTypeDisplayString}> {postLoopVariableName} = System.Collections.Immutable.ImmutableSortedSet.ToImmutableSortedSet<{elementTypeDisplayString}>({targetVariableName});");
+        targetVariableName = postLoopVariableName;
+    }
+
+    private static void AppendImmutableArrayPostLoop(
+        PrettyCode.StringBuilder stringBuilder,
+        MappaBuilderContext context,
+        ITypeSymbol targetTypeSymbol,
+        ref string targetVariableName)
+    {
+        var postLoopVariableName = context.NextTemporary();
+        stringBuilder.AppendEmptyLine();
+        string elementTypeDisplayString = targetTypeSymbol.GetElementType().ToDisplayString();
+        stringBuilder.AppendLine($"global::{targetTypeSymbol.ToDisplayString()} {postLoopVariableName} = System.Collections.Immutable.ImmutableArray.ToImmutableArray<{elementTypeDisplayString}>({targetVariableName});");
+        targetVariableName = postLoopVariableName;
+    }
+
+    private static void AppendImmutableListPostLoop(
+        PrettyCode.StringBuilder stringBuilder,
+        MappaBuilderContext context,
+        ITypeSymbol targetTypeSymbol,
+        ref string targetVariableName)
+    {
+        var postLoopVariableName = context.NextTemporary();
+        stringBuilder.AppendEmptyLine();
+        string elementTypeDisplayString = targetTypeSymbol.GetElementType().ToDisplayString();
+        stringBuilder.AppendLine($"global::System.Collections.Immutable.ImmutableList<{elementTypeDisplayString}> {postLoopVariableName} = System.Collections.Immutable.ImmutableList.ToImmutableList<{elementTypeDisplayString}>({targetVariableName});");
+        targetVariableName = postLoopVariableName;
+    }
+
+    private static void AppendImmutableQueuePostLoop(
+        PrettyCode.StringBuilder stringBuilder,
+        MappaBuilderContext context,
+        ITypeSymbol targetTypeSymbol,
+        ref string targetVariableName)
+    {
+        var postLoopVariableName = context.NextTemporary();
+        stringBuilder.AppendEmptyLine();
+        string elementTypeDisplayString = targetTypeSymbol.GetElementType().ToDisplayString();
+        stringBuilder.AppendLine($"global::{targetTypeSymbol.ToDisplayString()} {postLoopVariableName} = System.Collections.Immutable.ImmutableQueue.Create<{elementTypeDisplayString}>({targetVariableName});");
+        targetVariableName = postLoopVariableName;
+    }
+
+    private static void AppendImmutableStackPostLoop(
+        PrettyCode.StringBuilder stringBuilder,
+        MappaBuilderContext context,
+        ITypeSymbol targetTypeSymbol,
+        ref string targetVariableName)
+    {
+        var postLoopVariableName = context.NextTemporary();
+        stringBuilder.AppendEmptyLine();
+        string elementTypeDisplayString = targetTypeSymbol.GetElementType().ToDisplayString();
+        stringBuilder.AppendLine($"global::{targetTypeSymbol.ToDisplayString()} {postLoopVariableName} = System.Collections.Immutable.ImmutableStack.Create<{elementTypeDisplayString}>({targetVariableName});");
+        targetVariableName = postLoopVariableName;
     }
 
     private static void AppendTargetVariable(
@@ -224,283 +542,401 @@ internal sealed class CollectionToCollectionMapStrategyBuilder(CollectionToColle
         out string? variableToAccessFrom,
         out bool usedGrowableBuffer)
     {
-        targetVariableName = context.NextTemporary();
-        counterVariableName = null;
-        interfaceMethodAccessMode = InterfaceMethodAccessMode.None;
-        interfaceToAccessFrom = string.Empty;
-        variableToAccessFrom = null;
-        usedGrowableBuffer = false;
+        var state = new TargetVariableAppendState(context.NextTemporary());
+        var dispatchContext = new AppendTargetVariableContext(
+            stringBuilder,
+            source,
+            context,
+            methodSymbol,
+            targetTypeSymbol,
+            sourceTypeSymbol,
+            fastCollections,
+            containerCapacityConstructors,
+            preventEnumerableCount,
+            enumerableConcreteType,
+            state);
 
+        foreach (var entry in TargetVariableDispatchEntries)
+        {
+            if (!entry.Matches(dispatchContext))
+            {
+                continue;
+            }
+
+            entry.Append(dispatchContext);
+            targetVariableName = state.TargetVariableName;
+            insertionMethod = state.InsertionMethod;
+            counterVariableName = state.CounterVariableName;
+            interfaceMethodAccessMode = state.InterfaceMethodAccessMode;
+            interfaceToAccessFrom = state.InterfaceToAccessFrom;
+            variableToAccessFrom = state.VariableToAccessFrom;
+            usedGrowableBuffer = state.UsedGrowableBuffer;
+            return;
+        }
+
+        throw new MappaGeneratorException($"Unsupported target type {targetTypeSymbol.ToDisplayString()} during generation of collection to collection mapping.");
+    }
+
+    private static void AppendArrayEnumerableInterfaceTarget(AppendTargetVariableContext context)
+    {
+        var targetVariableNameForArray = context.State.TargetVariableName;
+        AppendArrayTargetVariable(
+            context.StringBuilder,
+            context.Source,
+            context.BuilderContext,
+            context.TargetTypeSymbol,
+            context.SourceTypeSymbol,
+            context.FastCollections,
+            context.PreventEnumerableCount,
+            context.EnumerableConcreteType,
+            ref targetVariableNameForArray,
+            out var arrayInsertionMethod,
+            out var arrayCounterVariableName,
+            out var arrayVariableToAccessFrom,
+            out var arrayUsedGrowableBuffer);
+        context.State.TargetVariableName = targetVariableNameForArray;
+        context.State.InsertionMethod = arrayInsertionMethod;
+        context.State.CounterVariableName = arrayCounterVariableName;
+        context.State.VariableToAccessFrom = arrayVariableToAccessFrom;
+        context.State.UsedGrowableBuffer = arrayUsedGrowableBuffer;
+    }
+
+    private static bool IsFastCollectionArrayTarget(
+        BooleanSetting fastCollections,
+        ITypeSymbol sourceTypeSymbol,
+        ITypeSymbol targetTypeSymbol,
+        Compilation compilation)
+    {
         var isFastCollectionOnSource = fastCollections is BooleanSetting.Enable
-            && (sourceTypeSymbol.IsList(context.Compilation) || sourceTypeSymbol.IsArray());
+            && (sourceTypeSymbol.IsList(compilation) || sourceTypeSymbol.IsArray());
+        return isFastCollectionOnSource && targetTypeSymbol.IsArray();
+    }
 
-        if (isFastCollectionOnSource && targetTypeSymbol.IsArray())
-        {
-            insertionMethod = InsertionMethod.Indexer;
-            var capacity = GetLengthExpression(source, sourceTypeSymbol, context.Compilation);
-            variableToAccessFrom = context.NextTemporary();
-            stringBuilder.AppendLine($"{targetTypeSymbol.GetElementType().ToDisplayString()}[] {targetVariableName} = new {targetTypeSymbol.GetElementType().ToDisplayString()}[{capacity}];");
-            stringBuilder.AppendLine($"global::System.Span<{targetTypeSymbol.GetElementType().ToDisplayString()}> {variableToAccessFrom} = {targetVariableName}.AsSpan();");
-        }
-        else if (targetTypeSymbol.IsArray()
-                  || targetTypeSymbol.IsSpan(context.Compilation)
-                  || targetTypeSymbol.IsReadOnlySpan(context.Compilation)
-                  || targetTypeSymbol.IsMemory(context.Compilation)
-                  || targetTypeSymbol.IsReadOnlyMemory(context.Compilation)
-                  || targetTypeSymbol.IsIImmutableQueue(context.Compilation)
-                  || targetTypeSymbol.IsImmutableQueue(context.Compilation)
-                  || targetTypeSymbol.IsIImmutableStack(context.Compilation)
-                  || targetTypeSymbol.IsImmutableStack(context.Compilation))
-        {
-            if (ShouldUseGrowableBuffer(
-                    preventEnumerableCount,
-                    source,
-                    sourceTypeSymbol,
-                    targetTypeSymbol,
-                    enumerableConcreteType,
-                    context.Compilation))
-            {
-                AppendGrowableListTargetVariable(stringBuilder, targetTypeSymbol, ref targetVariableName, out insertionMethod);
-                usedGrowableBuffer = true;
-            }
-            else
-            {
-                // Array need indexers.
-                insertionMethod = InsertionMethod.Indexer;
+    private static bool MatchesAnyPredicate(ITypeSymbol typeSymbol, Compilation compilation, Func<ITypeSymbol, Compilation, bool>[] predicates)
+        => predicates.Any(predicate => predicate(typeSymbol, compilation));
 
-                // Capacity is always mandatory for arrays.
-                // In some scenarios it might mean we invoke the Enumerable.Count() extension method which
-                // might results in enumerations being executed twice.
-                var capacity = GetLengthExpression(source, sourceTypeSymbol, context.Compilation);
-                stringBuilder.AppendLine($"{targetTypeSymbol.GetElementType().ToDisplayString()}[] {targetVariableName} = new {targetTypeSymbol.GetElementType().ToDisplayString()}[{capacity}];");
+    private static bool IsArraySpanMemoryOrImmutableQueueStackTarget(ITypeSymbol targetTypeSymbol, Compilation compilation)
+        => MatchesAnyPredicate(targetTypeSymbol, compilation, ArraySpanMemoryOrImmutableQueueStackPredicates);
 
-                // If source does not have an indexer we need to create a new counter variable
-                // this for instance is used when mapping generic IEnumerable<TSource> to TTarget[].
-                if (!HasIndexer(context, sourceTypeSymbol))
-                {
-                    counterVariableName = context.NextTemporary();
-                    stringBuilder.AppendLine($"int {counterVariableName} = 0;");
-                }
-            }
-        }
-        else if (targetTypeSymbol.IsISet(context.Compilation)
-                 || targetTypeSymbol.IsIReadOnlySet(context.Compilation)
-                 || targetTypeSymbol.IsHashSet(context.Compilation)
-                 || targetTypeSymbol.IsReadOnlySet(context.Compilation))
-        {
-            // We are going to always use an HashSet so Add method is best here.
-            insertionMethod = InsertionMethod.Add;
-            TryGetLengthExpressionFromProperty(source, sourceTypeSymbol, context.Compilation, out var capacity);
-            stringBuilder.AppendLine($"global::System.Collections.Generic.HashSet<{targetTypeSymbol.GetElementType().ToDisplayString()}> {targetVariableName} = new global::System.Collections.Generic.HashSet<{targetTypeSymbol.GetElementType().ToDisplayString()}>({capacity});");
-        }
-        else if (targetTypeSymbol.IsOrDerivedFromStack(context.Compilation))
-        {
-            insertionMethod = InsertionMethod.Push;
-            var capacity = string.Empty;
+    private static bool IsHashSetLikeTarget(ITypeSymbol targetTypeSymbol, Compilation compilation)
+        => targetTypeSymbol.IsISet(compilation)
+           || targetTypeSymbol.IsIReadOnlySet(compilation)
+           || targetTypeSymbol.IsHashSet(compilation)
+           || targetTypeSymbol.IsReadOnlySet(compilation);
 
-            if (targetTypeSymbol.IsStack(context.Compilation))
-            {
-                TryGetLengthExpressionFromProperty(source, sourceTypeSymbol, context.Compilation, out capacity);
-            }
-            else if (containerCapacityConstructors is BooleanSetting.Enable &&
-                      targetTypeSymbol.HasSymbolAccessibleSingleIntegerParametersConstructor(context.Compilation, methodSymbol))
-            {
-                if (!targetTypeSymbol.HasSymbolAccessibleZeroParametersConstructor(context.Compilation, methodSymbol))
-                {
-                    // Since only the constructor with one integer parameter exists the capacity MUST be used.
-                    capacity = GetLengthExpression(source, sourceTypeSymbol, context.Compilation);
-                }
-                else
-                {
-                    TryGetLengthExpressionFromProperty(source, sourceTypeSymbol, context.Compilation, out capacity);
-                }
-            }
+    private static bool IsBlockingCollectionOrConcurrentBagTarget(ITypeSymbol targetTypeSymbol, Compilation compilation)
+        => targetTypeSymbol.IsOrDerivedFromBlockingCollection(compilation)
+           || targetTypeSymbol.IsOrDerivedFromConcurrentBag(compilation);
 
-            stringBuilder.AppendLine($"global::{targetTypeSymbol.ToDisplayString()} {targetVariableName} = new global::{targetTypeSymbol.ToDisplayString()}({capacity});");
-        }
-        else if (targetTypeSymbol.IsOrDerivedFromConcurrentStack(context.Compilation))
-        {
-            // NOTE: ConcurrentStack{T} does not have a constructor accepting a capacity.
-            insertionMethod = InsertionMethod.Push;
-            stringBuilder.AppendLine($"global::{targetTypeSymbol.ToDisplayString()} {targetVariableName} = new global::{targetTypeSymbol.ToDisplayString()}();");
-        }
-        else if (targetTypeSymbol.IsOrDerivedFromQueue(context.Compilation))
-        {
-            insertionMethod = InsertionMethod.Enqueue;
-            var capacity = string.Empty;
+    private static bool IsListLikeEnumerableTarget(ITypeSymbol targetTypeSymbol, Compilation compilation)
+        => MatchesAnyPredicate(targetTypeSymbol, compilation, ListLikeEnumerableTargetPredicates);
 
-            if (targetTypeSymbol.IsQueue(context.Compilation))
-            {
-                TryGetLengthExpressionFromProperty(source, sourceTypeSymbol, context.Compilation, out capacity);
-            }
-            else if (containerCapacityConstructors is BooleanSetting.Enable &&
-                     targetTypeSymbol.HasSymbolAccessibleSingleIntegerParametersConstructor(context.Compilation, methodSymbol))
-            {
-                if (!targetTypeSymbol.HasSymbolAccessibleZeroParametersConstructor(context.Compilation, methodSymbol))
-                {
-                    // Since only the constructor with one integer parameter exists the capacity MUST be used.
-                    capacity = GetLengthExpression(source, sourceTypeSymbol, context.Compilation);
-                }
-                else
-                {
-                    TryGetLengthExpressionFromProperty(source, sourceTypeSymbol, context.Compilation, out capacity);
-                }
-            }
+    private static void AppendFastCollectionArrayTarget(
+        PrettyCode.StringBuilder stringBuilder,
+        string source,
+        MappaBuilderContext context,
+        ITypeSymbol targetTypeSymbol,
+        ITypeSymbol sourceTypeSymbol,
+        TargetVariableAppendState state)
+    {
+        state.InsertionMethod = InsertionMethod.Indexer;
+        var capacity = GetLengthExpression(source, sourceTypeSymbol, context.Compilation);
+        state.VariableToAccessFrom = context.NextTemporary();
+        stringBuilder.AppendLine($"{targetTypeSymbol.GetElementType().ToDisplayString()}[] {state.TargetVariableName} = new {targetTypeSymbol.GetElementType().ToDisplayString()}[{capacity}];");
+        stringBuilder.AppendLine($"global::System.Span<{targetTypeSymbol.GetElementType().ToDisplayString()}> {state.VariableToAccessFrom} = {state.TargetVariableName}.AsSpan();");
+    }
 
-            stringBuilder.AppendLine($"global::{targetTypeSymbol.ToDisplayString()} {targetVariableName} = new global::{targetTypeSymbol.ToDisplayString()}({capacity});");
-        }
-        else if (targetTypeSymbol.IsOrImplementConcurrentQueue(context.Compilation))
-        {
-            // NOTE: ConcurrentQueue{T} does not have a constructor accepting a capacity.
-            insertionMethod = InsertionMethod.Enqueue;
-            stringBuilder.AppendLine($"global::{targetTypeSymbol.ToDisplayString()} {targetVariableName} = new global::{targetTypeSymbol.ToDisplayString()}();");
-        }
-        else if (targetTypeSymbol.IsOrDerivedFromBlockingCollection(context.Compilation)
-                 || targetTypeSymbol.IsOrDerivedFromConcurrentBag(context.Compilation))
-        {
-            insertionMethod = InsertionMethod.Add;
-            var capacity = string.Empty;
-
-            // NOTE: ConcurrentBag does not have a constructor accepting a capacity.
-            if (targetTypeSymbol.IsBlockingCollection(context.Compilation))
-            {
-                TryGetLengthExpressionFromProperty(source, sourceTypeSymbol, context.Compilation, out capacity);
-            }
-            else if (containerCapacityConstructors is BooleanSetting.Enable &&
-                     targetTypeSymbol.IsDerivedFromBlockingCollection(context.Compilation) &&
-                     targetTypeSymbol.HasSymbolAccessibleSingleIntegerParametersConstructor(context.Compilation, methodSymbol))
-            {
-                if (!targetTypeSymbol.HasSymbolAccessibleZeroParametersConstructor(context.Compilation, methodSymbol))
-                {
-                    // Since only the constructor with one integer parameter exists the capacity MUST be used.
-                    capacity = GetLengthExpression(source, sourceTypeSymbol, context.Compilation);
-                }
-                else
-                {
-                    TryGetLengthExpressionFromProperty(source, sourceTypeSymbol, context.Compilation, out capacity);
-                }
-            }
-
-            stringBuilder.AppendLine($"global::{targetTypeSymbol.ToDisplayString()} {targetVariableName} = new global::{targetTypeSymbol.ToDisplayString()}({capacity});");
-        }
-        else if (ShouldUseArrayForEnumerableInterfaceTarget(targetTypeSymbol, enumerableConcreteType))
-        {
-            AppendArrayTargetVariable(
-                stringBuilder,
-                source,
-                context,
-                targetTypeSymbol,
-                sourceTypeSymbol,
-                fastCollections,
+    private static void AppendArraySpanMemoryOrImmutableQueueStackTarget(
+        PrettyCode.StringBuilder stringBuilder,
+        string source,
+        MappaBuilderContext context,
+        ITypeSymbol targetTypeSymbol,
+        ITypeSymbol sourceTypeSymbol,
+        BooleanSetting preventEnumerableCount,
+        EnumerableConcreteTypeSetting enumerableConcreteType,
+        TargetVariableAppendState state)
+    {
+        if (ShouldUseGrowableBuffer(
                 preventEnumerableCount,
+                source,
+                sourceTypeSymbol,
+                targetTypeSymbol,
                 enumerableConcreteType,
-                ref targetVariableName,
-                out insertionMethod,
-                out counterVariableName,
-                out variableToAccessFrom,
-                out usedGrowableBuffer);
-        }
-        else if (targetTypeSymbol.IsIEnumerable()
-            || targetTypeSymbol.IsList(context.Compilation)
-            || targetTypeSymbol.IsIList()
-            || targetTypeSymbol.IsIReadOnlyList()
-            || targetTypeSymbol.IsICollection()
-            || targetTypeSymbol.IsIReadOnlyCollection()
-            || targetTypeSymbol.IsReadOnlyCollection(context.Compilation)
-            || targetTypeSymbol.IsFrozenSet(context.Compilation)
-            || targetTypeSymbol.IsIImmutableSet(context.Compilation)
-            || targetTypeSymbol.IsImmutableHashSet(context.Compilation)
-            || targetTypeSymbol.IsImmutableSortedSet(context.Compilation)
-            || targetTypeSymbol.IsIImmutableList(context.Compilation)
-            || targetTypeSymbol.IsImmutableArray(context.Compilation)
-            || targetTypeSymbol.IsImmutableList(context.Compilation))
+                context.Compilation))
         {
-            // We are going to always use a list, so Add method is best here.
-            insertionMethod = InsertionMethod.Add;
-
-            // Note: even if we set capacity, the list would be empty so we cannot invoke an indexer, but only Add.
-            // (having an initial capacity is anyway an improvement on the performances).
-            TryGetLengthExpressionFromProperty(source, sourceTypeSymbol, context.Compilation, out var capacity);
-            stringBuilder.AppendLine($"global::System.Collections.Generic.List<{targetTypeSymbol.GetElementType().ToDisplayString()}> {targetVariableName} = new global::System.Collections.Generic.List<{targetTypeSymbol.GetElementType().ToDisplayString()}>({capacity});");
+            var targetVariableNameForGrowable = state.TargetVariableName;
+            AppendGrowableListTargetVariable(stringBuilder, targetTypeSymbol, ref targetVariableNameForGrowable, out var growableInsertionMethod);
+            state.TargetVariableName = targetVariableNameForGrowable;
+            state.InsertionMethod = growableInsertionMethod;
+            state.UsedGrowableBuffer = true;
+            return;
         }
-        else if (targetTypeSymbol.IsIProducerConsumerCollection(context.Compilation))
+
+        // Array need indexers.
+        state.InsertionMethod = InsertionMethod.Indexer;
+
+        // Capacity is always mandatory for arrays.
+        // In some scenarios it might mean we invoke the Enumerable.Count() extension method which
+        // might results in enumerations being executed twice.
+        var capacity = GetLengthExpression(source, sourceTypeSymbol, context.Compilation);
+        stringBuilder.AppendLine($"{targetTypeSymbol.GetElementType().ToDisplayString()}[] {state.TargetVariableName} = new {targetTypeSymbol.GetElementType().ToDisplayString()}[{capacity}];");
+
+        // If source does not have an indexer we need to create a new counter variable
+        // this for instance is used when mapping generic IEnumerable<TSource> to TTarget[].
+        if (!HasIndexer(context, sourceTypeSymbol))
         {
-            // We are going to always use a concurrent bag, so Add method is best here.
-            insertionMethod = InsertionMethod.Add;
-            stringBuilder.AppendLine($"global::System.Collections.Concurrent.ConcurrentBag<{targetTypeSymbol.GetElementType().ToDisplayString()}> {targetVariableName} = new global::System.Collections.Concurrent.ConcurrentBag<{targetTypeSymbol.GetElementType().ToDisplayString()}>();");
+            state.CounterVariableName = context.NextTemporary();
+            stringBuilder.AppendLine($"int {state.CounterVariableName} = 0;");
         }
-        else if (targetTypeSymbol.ImplementISet(context.Compilation))
+    }
+
+    private static void AppendHashSetLikeTarget(
+        PrettyCode.StringBuilder stringBuilder,
+        string source,
+        MappaBuilderContext context,
+        ITypeSymbol targetTypeSymbol,
+        ITypeSymbol sourceTypeSymbol,
+        TargetVariableAppendState state)
+    {
+        // We are going to always use an HashSet so Add method is best here.
+        state.InsertionMethod = InsertionMethod.Add;
+        TryGetLengthExpressionFromProperty(source, sourceTypeSymbol, context.Compilation, out var capacity);
+        stringBuilder.AppendLine($"global::System.Collections.Generic.HashSet<{targetTypeSymbol.GetElementType().ToDisplayString()}> {state.TargetVariableName} = new global::System.Collections.Generic.HashSet<{targetTypeSymbol.GetElementType().ToDisplayString()}>({capacity});");
+    }
+
+    private static void AppendStackTarget(
+        PrettyCode.StringBuilder stringBuilder,
+        string source,
+        MappaBuilderContext context,
+        IMethodSymbol? methodSymbol,
+        ITypeSymbol targetTypeSymbol,
+        ITypeSymbol sourceTypeSymbol,
+        BooleanSetting containerCapacityConstructors,
+        TargetVariableAppendState state)
+    {
+        state.InsertionMethod = InsertionMethod.Push;
+        var capacity = ResolveContainerCapacity(
+            source,
+            sourceTypeSymbol,
+            targetTypeSymbol,
+            context.Compilation,
+            methodSymbol,
+            containerCapacityConstructors,
+            usePropertyLengthOnly: targetTypeSymbol.IsStack(context.Compilation),
+            allowOptionalIntegerConstructor: true);
+        stringBuilder.AppendLine($"global::{targetTypeSymbol.ToDisplayString()} {state.TargetVariableName} = new global::{targetTypeSymbol.ToDisplayString()}({capacity});");
+    }
+
+    private static void AppendConcurrentStackTarget(
+        PrettyCode.StringBuilder stringBuilder,
+        ITypeSymbol targetTypeSymbol,
+        TargetVariableAppendState state)
+    {
+        // NOTE: ConcurrentStack{T} does not have a constructor accepting a capacity.
+        state.InsertionMethod = InsertionMethod.Push;
+        stringBuilder.AppendLine($"global::{targetTypeSymbol.ToDisplayString()} {state.TargetVariableName} = new global::{targetTypeSymbol.ToDisplayString()}();");
+    }
+
+    private static void AppendQueueTarget(
+        PrettyCode.StringBuilder stringBuilder,
+        string source,
+        MappaBuilderContext context,
+        IMethodSymbol? methodSymbol,
+        ITypeSymbol targetTypeSymbol,
+        ITypeSymbol sourceTypeSymbol,
+        BooleanSetting containerCapacityConstructors,
+        TargetVariableAppendState state)
+    {
+        state.InsertionMethod = InsertionMethod.Enqueue;
+        var capacity = ResolveContainerCapacity(
+            source,
+            sourceTypeSymbol,
+            targetTypeSymbol,
+            context.Compilation,
+            methodSymbol,
+            containerCapacityConstructors,
+            usePropertyLengthOnly: targetTypeSymbol.IsQueue(context.Compilation),
+            allowOptionalIntegerConstructor: true);
+        stringBuilder.AppendLine($"global::{targetTypeSymbol.ToDisplayString()} {state.TargetVariableName} = new global::{targetTypeSymbol.ToDisplayString()}({capacity});");
+    }
+
+    private static void AppendConcurrentQueueTarget(
+        PrettyCode.StringBuilder stringBuilder,
+        ITypeSymbol targetTypeSymbol,
+        TargetVariableAppendState state)
+    {
+        // NOTE: ConcurrentQueue{T} does not have a constructor accepting a capacity.
+        state.InsertionMethod = InsertionMethod.Enqueue;
+        stringBuilder.AppendLine($"global::{targetTypeSymbol.ToDisplayString()} {state.TargetVariableName} = new global::{targetTypeSymbol.ToDisplayString()}();");
+    }
+
+    private static void AppendBlockingCollectionOrConcurrentBagTarget(
+        PrettyCode.StringBuilder stringBuilder,
+        string source,
+        MappaBuilderContext context,
+        IMethodSymbol? methodSymbol,
+        ITypeSymbol targetTypeSymbol,
+        ITypeSymbol sourceTypeSymbol,
+        BooleanSetting containerCapacityConstructors,
+        TargetVariableAppendState state)
+    {
+        state.InsertionMethod = InsertionMethod.Add;
+
+        // NOTE: ConcurrentBag does not have a constructor accepting a capacity.
+        var capacity = ResolveContainerCapacity(
+            source,
+            sourceTypeSymbol,
+            targetTypeSymbol,
+            context.Compilation,
+            methodSymbol,
+            containerCapacityConstructors,
+            usePropertyLengthOnly: targetTypeSymbol.IsBlockingCollection(context.Compilation),
+            allowOptionalIntegerConstructor: targetTypeSymbol.IsDerivedFromBlockingCollection(context.Compilation));
+        stringBuilder.AppendLine($"global::{targetTypeSymbol.ToDisplayString()} {state.TargetVariableName} = new global::{targetTypeSymbol.ToDisplayString()}({capacity});");
+    }
+
+    private static void AppendListLikeEnumerableTarget(
+        PrettyCode.StringBuilder stringBuilder,
+        string source,
+        MappaBuilderContext context,
+        ITypeSymbol targetTypeSymbol,
+        ITypeSymbol sourceTypeSymbol,
+        TargetVariableAppendState state)
+    {
+        // We are going to always use a list, so Add method is best here.
+        state.InsertionMethod = InsertionMethod.Add;
+
+        // Note: even if we set capacity, the list would be empty so we cannot invoke an indexer, but only Add.
+        // (having an initial capacity is anyway an improvement on the performances).
+        TryGetLengthExpressionFromProperty(source, sourceTypeSymbol, context.Compilation, out var capacity);
+        stringBuilder.AppendLine($"global::System.Collections.Generic.List<{targetTypeSymbol.GetElementType().ToDisplayString()}> {state.TargetVariableName} = new global::System.Collections.Generic.List<{targetTypeSymbol.GetElementType().ToDisplayString()}>({capacity});");
+    }
+
+    private static void AppendProducerConsumerCollectionTarget(
+        PrettyCode.StringBuilder stringBuilder,
+        ITypeSymbol targetTypeSymbol,
+        TargetVariableAppendState state)
+    {
+        // We are going to always use a concurrent bag, so Add method is best here.
+        state.InsertionMethod = InsertionMethod.Add;
+        stringBuilder.AppendLine($"global::System.Collections.Concurrent.ConcurrentBag<{targetTypeSymbol.GetElementType().ToDisplayString()}> {state.TargetVariableName} = new global::System.Collections.Concurrent.ConcurrentBag<{targetTypeSymbol.GetElementType().ToDisplayString()}>();");
+    }
+
+    private static void AppendImplementISetTarget(
+        PrettyCode.StringBuilder stringBuilder,
+        string source,
+        MappaBuilderContext context,
+        IMethodSymbol? methodSymbol,
+        ITypeSymbol targetTypeSymbol,
+        ITypeSymbol sourceTypeSymbol,
+        BooleanSetting containerCapacityConstructors,
+        TargetVariableAppendState state)
+    {
+        state.InsertionMethod = InsertionMethod.Add;
+        var elementType = targetTypeSymbol.GetElementType();
+
+        // Use ICollection because ISet derive the Add from ICollection
+        state.InterfaceToAccessFrom = $"System.Collections.Generic.ICollection<{TypeSymbolExtensions.NormalizeType(elementType.ToDisplayString())}>";
+        state.InterfaceMethodAccessMode = targetTypeSymbol.GetInterfaceMethodAccessMode(
+            "Add",
+            "System.Collections.Generic.ICollection",
+            TypeSymbolExtensions.NormalizeType(elementType.ToDisplayString()),
+            returnType => returnType.IsVoid(),
+            [elementType]);
+
+        var capacity = ResolveContainerCapacity(
+            source,
+            sourceTypeSymbol,
+            targetTypeSymbol,
+            context.Compilation,
+            methodSymbol,
+            containerCapacityConstructors,
+            usePropertyLengthOnly: false,
+            allowOptionalIntegerConstructor: targetTypeSymbol.TypeKind != TypeKind.Interface);
+        stringBuilder.AppendLine($"global::{targetTypeSymbol} {state.TargetVariableName} = new global::{targetTypeSymbol}({capacity});");
+    }
+
+    private static void AppendImplementICollectionTarget(
+        PrettyCode.StringBuilder stringBuilder,
+        string source,
+        MappaBuilderContext context,
+        IMethodSymbol? methodSymbol,
+        ITypeSymbol targetTypeSymbol,
+        ITypeSymbol sourceTypeSymbol,
+        BooleanSetting containerCapacityConstructors,
+        TargetVariableAppendState state)
+    {
+        // Here we handle the scenario of a concrete type implementing ICollection<T>.
+        // We are sure that is concrete because ICollection<T> is addressed in a different branch
+        // and we re also sure it has a constructor with 0 or 1 arguments that can be used.
+        // And if it is one argument is must be an integer (and the ContainerCapacityConstructors
+        // must be enabled too).
+        state.InsertionMethod = InsertionMethod.Add;
+
+        var elementType = targetTypeSymbol.GetElementType();
+        state.InterfaceToAccessFrom = $"System.Collections.Generic.ICollection<{TypeSymbolExtensions.NormalizeType(elementType.ToDisplayString())}>";
+        state.InterfaceMethodAccessMode = targetTypeSymbol.GetInterfaceMethodAccessMode(
+            "Add",
+            "System.Collections.Generic.ICollection",
+            TypeSymbolExtensions.NormalizeType(elementType.ToDisplayString()),
+            returnType => returnType.IsVoid(),
+            [elementType]);
+
+        var capacity = ResolveContainerCapacity(
+            source,
+            sourceTypeSymbol,
+            targetTypeSymbol,
+            context.Compilation,
+            methodSymbol,
+            containerCapacityConstructors,
+            usePropertyLengthOnly: false,
+            allowOptionalIntegerConstructor: targetTypeSymbol.TypeKind != TypeKind.Interface);
+        stringBuilder.AppendLine($"global::{targetTypeSymbol.ToDisplayString()} {state.TargetVariableName} = new global::{targetTypeSymbol.ToDisplayString()}({capacity});");
+    }
+
+    /// <summary>
+    /// Resolves capacity for collection constructors that optionally accept an integer capacity.
+    /// </summary>
+    /// <param name="source">The source expression.</param>
+    /// <param name="sourceTypeSymbol">The source type.</param>
+    /// <param name="targetTypeSymbol">The target type.</param>
+    /// <param name="compilation">The compilation.</param>
+    /// <param name="methodSymbol">The method symbol used for accessibility checks.</param>
+    /// <param name="containerCapacityConstructors">Whether capacity constructors are enabled.</param>
+    /// <param name="usePropertyLengthOnly">When <see langword="true"/>, only a property-based length is used.</param>
+    /// <param name="allowOptionalIntegerConstructor">When <see langword="true"/>, optional integer constructors may be used.</param>
+    /// <returns>The capacity expression, or an empty string when capacity is omitted.</returns>
+    private static string ResolveContainerCapacity(
+        string source,
+        ITypeSymbol sourceTypeSymbol,
+        ITypeSymbol targetTypeSymbol,
+        Compilation compilation,
+        IMethodSymbol? methodSymbol,
+        BooleanSetting containerCapacityConstructors,
+        bool usePropertyLengthOnly,
+        bool allowOptionalIntegerConstructor)
+    {
+        if (usePropertyLengthOnly)
         {
-            insertionMethod = InsertionMethod.Add;
-            var elementType = targetTypeSymbol.GetElementType();
-
-            // Use ICollection because ISet derive the Add from ICollection
-            interfaceToAccessFrom = $"System.Collections.Generic.ICollection<{TypeSymbolExtensions.NormalizeType(elementType.ToDisplayString())}>";
-            interfaceMethodAccessMode = targetTypeSymbol.GetInterfaceMethodAccessMode(
-                "Add",
-                "System.Collections.Generic.ICollection",
-                TypeSymbolExtensions.NormalizeType(elementType.ToDisplayString()),
-                returnType => returnType.IsVoid(),
-                [elementType]);
-
-            var capacity = string.Empty;
-            if (targetTypeSymbol.TypeKind != TypeKind.Interface &&
-                containerCapacityConstructors is BooleanSetting.Enable &&
-                targetTypeSymbol.HasSymbolAccessibleSingleIntegerParametersConstructor(context.Compilation, methodSymbol))
-            {
-                if (!targetTypeSymbol.HasSymbolAccessibleZeroParametersConstructor(context.Compilation, methodSymbol))
-                {
-                    // Since only the constructor with one integer parameter exists the capacity MUST be used.
-                    capacity = GetLengthExpression(source, sourceTypeSymbol, context.Compilation);
-                }
-                else
-                {
-                    TryGetLengthExpressionFromProperty(source, sourceTypeSymbol, context.Compilation, out capacity);
-                }
-            }
-
-            stringBuilder.AppendLine($"global::{targetTypeSymbol} {targetVariableName} = new global::{targetTypeSymbol}({capacity});");
+            TryGetLengthExpressionFromProperty(source, sourceTypeSymbol, compilation, out var capacity);
+            return capacity;
         }
-        else if (targetTypeSymbol.ImplementICollection())
+
+        if (!allowOptionalIntegerConstructor
+            || containerCapacityConstructors is not BooleanSetting.Enable
+            || !targetTypeSymbol.HasSymbolAccessibleSingleIntegerParametersConstructor(compilation, methodSymbol))
         {
-            // Here we handle the scenario of a concrete type implementing ICollection<T>.
-            // We are sure that is concrete because ICollection<T> is addressed in a different branch
-            // and we re also sure it has a constructor with 0 or 1 arguments that can be used.
-            // And if it is one argument is must be an integer (and the ContainerCapacityConstructors
-            // must be enabled too).
-            insertionMethod = InsertionMethod.Add;
-
-            var elementType = targetTypeSymbol.GetElementType();
-            interfaceToAccessFrom = $"System.Collections.Generic.ICollection<{TypeSymbolExtensions.NormalizeType(elementType.ToDisplayString())}>";
-            interfaceMethodAccessMode = targetTypeSymbol.GetInterfaceMethodAccessMode(
-                "Add",
-                "System.Collections.Generic.ICollection",
-                TypeSymbolExtensions.NormalizeType(elementType.ToDisplayString()),
-                returnType => returnType.IsVoid(),
-                [elementType]);
-
-            var capacity = string.Empty;
-            if (targetTypeSymbol.TypeKind != TypeKind.Interface &&
-                containerCapacityConstructors is BooleanSetting.Enable &&
-                targetTypeSymbol.HasSymbolAccessibleSingleIntegerParametersConstructor(context.Compilation, methodSymbol))
-            {
-                if (!targetTypeSymbol.HasSymbolAccessibleZeroParametersConstructor(context.Compilation, methodSymbol))
-                {
-                    // Since only the constructor with one integer parameter exists the capacity MUST be used.
-                    capacity = GetLengthExpression(source, sourceTypeSymbol, context.Compilation);
-                }
-                else
-                {
-                    TryGetLengthExpressionFromProperty(source, sourceTypeSymbol, context.Compilation, out capacity);
-                }
-            }
-
-            stringBuilder.AppendLine($"global::{targetTypeSymbol.ToDisplayString()} {targetVariableName} = new global::{targetTypeSymbol.ToDisplayString()}({capacity});");
+            return string.Empty;
         }
-        else
+
+        if (!targetTypeSymbol.HasSymbolAccessibleZeroParametersConstructor(compilation, methodSymbol))
         {
-            throw new MappaGeneratorException($"Unsupported target type {targetTypeSymbol.ToDisplayString()} during generation of collection to collection mapping.");
+            // Since only the constructor with one integer parameter exists the capacity MUST be used.
+            return GetLengthExpression(source, sourceTypeSymbol, compilation);
         }
+
+        TryGetLengthExpressionFromProperty(source, sourceTypeSymbol, compilation, out var capacityFromProperty);
+        return capacityFromProperty;
     }
 
     private static bool ShouldUseArrayForEnumerableInterfaceTarget(
@@ -682,50 +1118,222 @@ internal sealed class CollectionToCollectionMapStrategyBuilder(CollectionToColle
         out string loopVariableName,
         out string? countingVariableName)
     {
-        // For array, Span<T> or anything implementing IList we can use a for loop
-        // this way we can also use Span<> for ever better performances.
-        string? spanTemporary = null;
-        string? lengthExpression = null;
-        if (HasIndexer(context, sourceTypeSymbol))
+        if (!HasIndexer(context, sourceTypeSymbol))
         {
-            // For Memory<T> or ReadOnlyMemory<T> we need to access the Span<T>/ReadOnlySpan<T> instance via the Span property.
-            if (sourceTypeSymbol.IsMemory(context.Compilation))
-            {
-                spanTemporary = context.NextTemporary();
-                stringBuilder.AppendLine($"global::System.Span<{sourceTypeSymbol.GetElementType().ToDisplayString()}> {spanTemporary} = {source}.Span;");
-            }
-            else if (sourceTypeSymbol.IsReadOnlyMemory(context.Compilation))
-            {
-                spanTemporary = context.NextTemporary();
-                stringBuilder.AppendLine($"global::System.ReadOnlySpan<{sourceTypeSymbol.GetElementType().ToDisplayString()}> {spanTemporary} = {source}.Span;");
-            }
-
-            // For arrays and list we can use Spans when the FastCollection settings is enabled.
-            else if (fastCollections is BooleanSetting.Enable && sourceTypeSymbol.IsArray())
-            {
-                spanTemporary = context.NextTemporary();
-                stringBuilder.AppendLine($"global::System.Span<{sourceTypeSymbol.GetElementType().ToDisplayString()}> {spanTemporary} = {source}.AsSpan();");
-            }
-            else if (fastCollections is BooleanSetting.Enable && sourceTypeSymbol.IsList(context.Compilation))
-            {
-                spanTemporary = context.NextTemporary();
-                lengthExpression = $"{spanTemporary}.Length"; // Force using length, GetLengthExpression uses the original type which usually is correct but not in this context.
-                stringBuilder.AppendLine($"global::System.Span<{sourceTypeSymbol.GetElementType().ToDisplayString()}> {spanTemporary} = global::System.Runtime.InteropServices.CollectionsMarshal.AsSpan<{sourceTypeSymbol.GetElementType().ToDisplayString()}>({source});");
-            }
-
-            countingVariableName = context.NextTemporary();
-            loopVariableName = context.NextTemporary();
-
-            stringBuilder.AppendLine($"for (int {countingVariableName} = 0; {countingVariableName} < {lengthExpression ?? GetLengthExpression(spanTemporary ?? source, sourceTypeSymbol, context.Compilation)}; ++{countingVariableName})");
-            var block = stringBuilder.CurlyBracesBlock();
-            stringBuilder.AppendLine($"{sourceTypeSymbol.GetElementType().ToDisplayString()} {loopVariableName} = {spanTemporary ?? source}[{countingVariableName}];");
-            return block;
+            return AppendForeachLoopBlock(stringBuilder, source, context, sourceTypeSymbol, out loopVariableName, out countingVariableName);
         }
 
-        // Let's use a generic foreach loop (therefore without a counter)!
+        var spanTemporary = TryAppendSpanTemporaryForIndexerLoop(
+            stringBuilder,
+            source,
+            context,
+            sourceTypeSymbol,
+            fastCollections,
+            out var lengthExpression);
+
+        countingVariableName = context.NextTemporary();
+        loopVariableName = context.NextTemporary();
+
+        stringBuilder.AppendLine($"for (int {countingVariableName} = 0; {countingVariableName} < {lengthExpression ?? GetLengthExpression(spanTemporary ?? source, sourceTypeSymbol, context.Compilation)}; ++{countingVariableName})");
+        var block = stringBuilder.CurlyBracesBlock();
+        stringBuilder.AppendLine($"{sourceTypeSymbol.GetElementType().ToDisplayString()} {loopVariableName} = {spanTemporary ?? source}[{countingVariableName}];");
+        return block;
+    }
+
+    private static IDisposable AppendForeachLoopBlock(
+        PrettyCode.StringBuilder stringBuilder,
+        string source,
+        MappaBuilderContext context,
+        ITypeSymbol sourceTypeSymbol,
+        out string loopVariableName,
+        out string? countingVariableName)
+    {
         countingVariableName = null;
         loopVariableName = context.NextTemporary();
         stringBuilder.AppendLine($"foreach ({sourceTypeSymbol.GetElementType().ToDisplayString()} {loopVariableName} in {source})");
         return stringBuilder.CurlyBracesBlock();
+    }
+
+    private static string? TryAppendSpanTemporaryForIndexerLoop(
+        PrettyCode.StringBuilder stringBuilder,
+        string source,
+        MappaBuilderContext context,
+        ITypeSymbol sourceTypeSymbol,
+        BooleanSetting fastCollections,
+        out string? lengthExpression)
+    {
+        lengthExpression = null;
+        var compilation = context.Compilation;
+        var elementTypeDisplay = sourceTypeSymbol.GetElementType().ToDisplayString();
+
+        if (sourceTypeSymbol.IsMemory(compilation))
+        {
+            var spanTemporary = context.NextTemporary();
+            stringBuilder.AppendLine($"global::System.Span<{elementTypeDisplay}> {spanTemporary} = {source}.Span;");
+            return spanTemporary;
+        }
+
+        if (sourceTypeSymbol.IsReadOnlyMemory(compilation))
+        {
+            var spanTemporary = context.NextTemporary();
+            stringBuilder.AppendLine($"global::System.ReadOnlySpan<{elementTypeDisplay}> {spanTemporary} = {source}.Span;");
+            return spanTemporary;
+        }
+
+        if (fastCollections is BooleanSetting.Enable && sourceTypeSymbol.IsArray())
+        {
+            var spanTemporary = context.NextTemporary();
+            stringBuilder.AppendLine($"global::System.Span<{elementTypeDisplay}> {spanTemporary} = {source}.AsSpan();");
+            return spanTemporary;
+        }
+
+        if (fastCollections is BooleanSetting.Enable && sourceTypeSymbol.IsList(compilation))
+        {
+            var spanTemporary = context.NextTemporary();
+            lengthExpression = $"{spanTemporary}.Length";
+            stringBuilder.AppendLine($"global::System.Span<{elementTypeDisplay}> {spanTemporary} = global::System.Runtime.InteropServices.CollectionsMarshal.AsSpan<{elementTypeDisplay}>({source});");
+            return spanTemporary;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Inputs shared while dispatching target variable append branches.
+    /// </summary>
+    private sealed class AppendTargetVariableContext
+    {
+        internal AppendTargetVariableContext(
+            PrettyCode.StringBuilder stringBuilder,
+            string source,
+            MappaBuilderContext builderContext,
+            IMethodSymbol? methodSymbol,
+            ITypeSymbol targetTypeSymbol,
+            ITypeSymbol sourceTypeSymbol,
+            BooleanSetting fastCollections,
+            BooleanSetting containerCapacityConstructors,
+            BooleanSetting preventEnumerableCount,
+            EnumerableConcreteTypeSetting enumerableConcreteType,
+            TargetVariableAppendState state)
+        {
+            this.StringBuilder = stringBuilder;
+            this.Source = source;
+            this.BuilderContext = builderContext;
+            this.MethodSymbol = methodSymbol;
+            this.TargetTypeSymbol = targetTypeSymbol;
+            this.SourceTypeSymbol = sourceTypeSymbol;
+            this.FastCollections = fastCollections;
+            this.ContainerCapacityConstructors = containerCapacityConstructors;
+            this.PreventEnumerableCount = preventEnumerableCount;
+            this.EnumerableConcreteType = enumerableConcreteType;
+            this.State = state;
+        }
+
+        internal PrettyCode.StringBuilder StringBuilder { get; }
+
+        internal string Source { get; }
+
+        internal MappaBuilderContext BuilderContext { get; }
+
+        internal IMethodSymbol? MethodSymbol { get; }
+
+        internal ITypeSymbol TargetTypeSymbol { get; }
+
+        internal ITypeSymbol SourceTypeSymbol { get; }
+
+        internal BooleanSetting FastCollections { get; }
+
+        internal BooleanSetting ContainerCapacityConstructors { get; }
+
+        internal BooleanSetting PreventEnumerableCount { get; }
+
+        internal EnumerableConcreteTypeSetting EnumerableConcreteType { get; }
+
+        internal TargetVariableAppendState State { get; }
+    }
+
+    /// <summary>
+    /// Mutable state collected while appending the target collection variable.
+    /// </summary>
+    private sealed class TargetVariableAppendState
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TargetVariableAppendState"/> class.
+        /// </summary>
+        /// <param name="targetVariableName">The target variable name.</param>
+        public TargetVariableAppendState(string targetVariableName)
+        {
+            this.TargetVariableName = targetVariableName;
+            this.InterfaceToAccessFrom = string.Empty;
+        }
+
+        /// <summary>
+        /// Gets or sets the target variable name.
+        /// </summary>
+        public string TargetVariableName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the insertion method.
+        /// </summary>
+        public InsertionMethod InsertionMethod { get; set; }
+
+        /// <summary>
+        /// Gets or sets the counter variable name.
+        /// </summary>
+        public string? CounterVariableName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the interface method access mode.
+        /// </summary>
+        public InterfaceMethodAccessMode InterfaceMethodAccessMode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the interface used for explicit method access.
+        /// </summary>
+        public string InterfaceToAccessFrom { get; set; }
+
+        /// <summary>
+        /// Gets or sets the variable used for indexer access.
+        /// </summary>
+        public string? VariableToAccessFrom { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether a growable buffer was used.
+        /// </summary>
+        public bool UsedGrowableBuffer { get; set; }
+    }
+
+    private sealed class PostLoopDispatchEntry
+    {
+        internal PostLoopDispatchEntry(
+            Func<ITypeSymbol, Compilation, bool> matches,
+            PostLoopAppendAction append,
+            bool stopAfterMatch)
+        {
+            this.Matches = matches;
+            this.Append = append;
+            this.StopAfterMatch = stopAfterMatch;
+        }
+
+        internal Func<ITypeSymbol, Compilation, bool> Matches { get; }
+
+        internal PostLoopAppendAction Append { get; }
+
+        internal bool StopAfterMatch { get; }
+    }
+
+    private sealed class TargetVariableDispatchEntry
+    {
+        internal TargetVariableDispatchEntry(
+            Func<AppendTargetVariableContext, bool> matches,
+            TargetVariableBranchAppender append)
+        {
+            this.Matches = matches;
+            this.Append = append;
+        }
+
+        internal Func<AppendTargetVariableContext, bool> Matches { get; }
+
+        internal TargetVariableBranchAppender Append { get; }
     }
 }

--- a/Mappa.Generator/Builders/Strategies/InvokeConstructorMapStrategyBuilder.cs
+++ b/Mappa.Generator/Builders/Strategies/InvokeConstructorMapStrategyBuilder.cs
@@ -35,60 +35,14 @@ internal sealed class InvokeConstructorMapStrategyBuilder
 
         using (context.PushCurrentCompositeTypeSourceName(source))
         {
-            // Handle arguments mappings
-            var parametersVariableNames = new List<string>();
-            foreach (var parameterMapStrategy in this.strategy.ParametersMapStrategies)
-            {
-                var (parameterTargetTemporary, parameterCode) = parameterMapStrategy.GetBuilder().BuildSource(source, context, mappaGlobalOptions);
-                if (!string.IsNullOrWhiteSpace(parameterCode))
-                {
-                    builder.AppendLine(parameterCode);
-                }
-
-                parametersVariableNames.Add(parameterTargetTemporary);
-            }
-
-            // Object initializers are only valid on object-creation expressions. Inaccessible
-            // setters and unsafe-accessor constructor invocations assign after construction.
-            // When reference reusing is active, map all initializers after construction so the
-            // target can be registered before nested mappings (including cycles) run.
-            PropertyMapStrategy[] objectInitializerStrategies;
-            PropertyMapStrategy[] postConstructorStrategies;
-            var deferInitializersForReferenceReusing = ReferenceHandlingCodeGenerator.ShouldRegisterReferencePairEarly(
-                context,
+            var parametersVariableNames = BuildParameterMappings(source, context, mappaGlobalOptions, builder, this.strategy.ParametersMapStrategies);
+            var (objectInitializerStrategies, postConstructorStrategies) = this.PartitionConstructorInitializers(context, source);
+            var propertyInitializersMappings = BuildObjectInitializerMappings(
                 source,
-                this.strategy.TargetType,
-                this.strategy.SourceType);
-            if (this.strategy.RequiresUnsafeAccessorOnConstructor || deferInitializersForReferenceReusing)
-            {
-                objectInitializerStrategies = [];
-                postConstructorStrategies = [.. this.strategy.InitializerStrategies];
-            }
-            else
-            {
-                objectInitializerStrategies = this.strategy.InitializerStrategies
-                    .Where(propertyMapStrategy => !propertyMapStrategy.PostConstructorInitializer
-                                                  && !propertyMapStrategy.RequiresUnsafeAccessorOnTarget)
-                    .ToArray();
-                postConstructorStrategies = this.strategy.InitializerStrategies
-                    .Where(propertyMapStrategy => propertyMapStrategy.PostConstructorInitializer
-                                                  || propertyMapStrategy.RequiresUnsafeAccessorOnTarget)
-                    .ToArray();
-            }
-
-            var propertyInitializersMappings = new List<(IPropertySymbol TargetProperty, string TemporaryName, bool RequiresUnsafeAccessorOnTarget)>();
-            foreach (var propertyMapStrategy in objectInitializerStrategies)
-            {
-                var (initializerPropertyTargetTemporary, initializerPropertyCode) = propertyMapStrategy.GetBuilder().BuildSource(source, context, mappaGlobalOptions);
-                propertyInitializersMappings.Add((
-                    propertyMapStrategy.TargetProperty,
-                    initializerPropertyTargetTemporary,
-                    propertyMapStrategy.RequiresUnsafeAccessorOnTarget));
-                if (!string.IsNullOrWhiteSpace(initializerPropertyCode))
-                {
-                    builder.AppendLine(initializerPropertyCode);
-                }
-            }
+                context,
+                mappaGlobalOptions,
+                builder,
+                objectInitializerStrategies);
 
             var hasPropertyInitializers = propertyInitializersMappings.Count > 0;
             var constructionExpression = InaccessibleMemberAccessHelper.BuildConstructorInvocationExpression(
@@ -98,66 +52,202 @@ internal sealed class InvokeConstructorMapStrategyBuilder
                 context);
 
             resultTemporary = context.NextTemporary();
-            if (hasPropertyInitializers)
-            {
-                builder.AppendLine($"{this.strategy.TargetType.ToDisplayString()} {resultTemporary} = {constructionExpression}");
-                using (builder.CurlyBracesBlock(trailingSemicolon: true))
-                {
-                    foreach (var propertyInitializersMapping in propertyInitializersMappings)
-                    {
-                        builder.AppendLine($"{propertyInitializersMapping.TargetProperty.Name} = {propertyInitializersMapping.TemporaryName},");
-                    }
-                }
-            }
-            else
-            {
-                builder.AppendLine($"{this.strategy.TargetType.ToDisplayString()} {resultTemporary} = {constructionExpression};");
-            }
-
-            var earlyAddReferencePair = ReferenceHandlingCodeGenerator.BuildEarlyAddReferencePairStatement(
-                context,
+            this.AppendConstructionWithOptionalObjectInitializer(
+                builder,
                 resultTemporary,
+                constructionExpression,
+                propertyInitializersMappings,
+                hasPropertyInitializers);
+
+            AppendEarlyReferencePair(context, builder, resultTemporary, source, this.strategy.TargetType, this.strategy.SourceType);
+            AppendPostConstructorInitializers(
                 source,
-                this.strategy.TargetType,
-                this.strategy.SourceType);
-            if (earlyAddReferencePair is not null)
-            {
-                builder.AppendLine(earlyAddReferencePair);
-            }
-
-            // Initialise properties after the constructor has been created.
-            using (context.PushCurrentCompositeTypeTargetName(resultTemporary))
-            {
-                foreach (var propertyMapStrategy in postConstructorStrategies)
-                {
-                    var (initializerPropertyTargetTemporary, initializerPropertyCode) = propertyMapStrategy.GetBuilder().BuildSource(source, context, mappaGlobalOptions);
-                    if (!string.IsNullOrWhiteSpace(initializerPropertyCode))
-                    {
-                        builder.AppendLine(initializerPropertyCode);
-                    }
-
-                    // Setter mappings moved out of the object initializer need an explicit assignment.
-                    if (!propertyMapStrategy.PostConstructorInitializer)
-                    {
-                        builder.AppendLine(InaccessibleMemberAccessHelper.BuildPropertyAssignmentStatement(
-                            resultTemporary,
-                            propertyMapStrategy.TargetProperty,
-                            initializerPropertyTargetTemporary,
-                            propertyMapStrategy.RequiresUnsafeAccessorOnTarget,
-                            context));
-                    }
-                }
-            }
-
-            if (this.strategy.AssignToContextEntries.Length > 0 && this.strategy.ContextParameterName is not null)
-            {
-                foreach (var assignToContextEntry in this.strategy.AssignToContextEntries)
-                {
-                    builder.AppendLine($"{this.strategy.ContextParameterName}[{CSharpLiteralHelper.ToStringLiteral(assignToContextEntry.ContextKey)}] = {PropertyPathExpressionBuilder.BuildTargetMemberAccessExpression(resultTemporary, assignToContextEntry.MemberName)};");
-                }
-            }
+                context,
+                mappaGlobalOptions,
+                builder,
+                resultTemporary,
+                postConstructorStrategies);
+            AppendAssignToContextEntries(builder, resultTemporary, this.strategy.AssignToContextEntries, this.strategy.ContextParameterName);
         }
 
         return (resultTemporary, builder.ToString());
     }
+
+    private static List<string> BuildParameterMappings(
+        string source,
+        MappaBuilderContext context,
+        MappaGlobalOptions mappaGlobalOptions,
+        PrettyCode.StringBuilder builder,
+        IReadOnlyList<ParameterMapStrategy> parametersMapStrategies)
+    {
+        var parametersVariableNames = new List<string>();
+        foreach (var parameterMapStrategy in parametersMapStrategies)
+        {
+            var (parameterTargetTemporary, parameterCode) = parameterMapStrategy.GetBuilder().BuildSource(source, context, mappaGlobalOptions);
+            if (!string.IsNullOrWhiteSpace(parameterCode))
+            {
+                builder.AppendLine(parameterCode);
+            }
+
+            parametersVariableNames.Add(parameterTargetTemporary);
+        }
+
+        return parametersVariableNames;
+    }
+
+    private static List<(IPropertySymbol TargetProperty, string TemporaryName, bool RequiresUnsafeAccessorOnTarget)> BuildObjectInitializerMappings(
+        string source,
+        MappaBuilderContext context,
+        MappaGlobalOptions mappaGlobalOptions,
+        PrettyCode.StringBuilder builder,
+        PropertyMapStrategy[] objectInitializerStrategies)
+    {
+        var propertyInitializersMappings = new List<(IPropertySymbol TargetProperty, string TemporaryName, bool RequiresUnsafeAccessorOnTarget)>();
+        foreach (var propertyMapStrategy in objectInitializerStrategies)
+        {
+            var (initializerPropertyTargetTemporary, initializerPropertyCode) = propertyMapStrategy.GetBuilder().BuildSource(source, context, mappaGlobalOptions);
+            propertyInitializersMappings.Add((
+                propertyMapStrategy.TargetProperty,
+                initializerPropertyTargetTemporary,
+                propertyMapStrategy.RequiresUnsafeAccessorOnTarget));
+            if (!string.IsNullOrWhiteSpace(initializerPropertyCode))
+            {
+                builder.AppendLine(initializerPropertyCode);
+            }
+        }
+
+        return propertyInitializersMappings;
+    }
+
+    private static void AppendConstructionWithOptionalObjectInitializer(
+        PrettyCode.StringBuilder builder,
+        string resultTemporary,
+        string constructionExpression,
+        List<(IPropertySymbol TargetProperty, string TemporaryName, bool RequiresUnsafeAccessorOnTarget)> propertyInitializersMappings,
+        bool hasPropertyInitializers,
+        ITypeSymbol targetType)
+    {
+        if (hasPropertyInitializers)
+        {
+            builder.AppendLine($"{targetType.ToDisplayString()} {resultTemporary} = {constructionExpression}");
+            using (builder.CurlyBracesBlock(trailingSemicolon: true))
+            {
+                foreach (var propertyInitializersMapping in propertyInitializersMappings)
+                {
+                    builder.AppendLine($"{propertyInitializersMapping.TargetProperty.Name} = {propertyInitializersMapping.TemporaryName},");
+                }
+            }
+
+            return;
+        }
+
+        builder.AppendLine($"{targetType.ToDisplayString()} {resultTemporary} = {constructionExpression};");
+    }
+
+    private static void AppendEarlyReferencePair(
+        MappaBuilderContext context,
+        PrettyCode.StringBuilder builder,
+        string resultTemporary,
+        string source,
+        ITypeSymbol targetType,
+        ITypeSymbol sourceType)
+    {
+        var earlyAddReferencePair = ReferenceHandlingCodeGenerator.BuildEarlyAddReferencePairStatement(
+            context,
+            resultTemporary,
+            source,
+            targetType,
+            sourceType);
+        if (earlyAddReferencePair is not null)
+        {
+            builder.AppendLine(earlyAddReferencePair);
+        }
+    }
+
+    private static void AppendPostConstructorInitializers(
+        string source,
+        MappaBuilderContext context,
+        MappaGlobalOptions mappaGlobalOptions,
+        PrettyCode.StringBuilder builder,
+        string resultTemporary,
+        PropertyMapStrategy[] postConstructorStrategies)
+    {
+        using (context.PushCurrentCompositeTypeTargetName(resultTemporary))
+        {
+            foreach (var propertyMapStrategy in postConstructorStrategies)
+            {
+                var (initializerPropertyTargetTemporary, initializerPropertyCode) = propertyMapStrategy.GetBuilder().BuildSource(source, context, mappaGlobalOptions);
+                if (!string.IsNullOrWhiteSpace(initializerPropertyCode))
+                {
+                    builder.AppendLine(initializerPropertyCode);
+                }
+
+                if (!propertyMapStrategy.PostConstructorInitializer)
+                {
+                    builder.AppendLine(InaccessibleMemberAccessHelper.BuildPropertyAssignmentStatement(
+                        resultTemporary,
+                        propertyMapStrategy.TargetProperty,
+                        initializerPropertyTargetTemporary,
+                        propertyMapStrategy.RequiresUnsafeAccessorOnTarget,
+                        context));
+                }
+            }
+        }
+    }
+
+    private static void AppendAssignToContextEntries(
+        PrettyCode.StringBuilder builder,
+        string resultTemporary,
+        MappaAssignToContextEntry[] assignToContextEntries,
+        string? contextParameterName)
+    {
+        if (assignToContextEntries.Length == 0 || contextParameterName is null)
+        {
+            return;
+        }
+
+        foreach (var assignToContextEntry in assignToContextEntries)
+        {
+            builder.AppendLine($"{contextParameterName}[{CSharpLiteralHelper.ToStringLiteral(assignToContextEntry.ContextKey)}] = {PropertyPathExpressionBuilder.BuildTargetMemberAccessExpression(resultTemporary, assignToContextEntry.MemberName)};");
+        }
+    }
+
+    private (PropertyMapStrategy[] ObjectInitializers, PropertyMapStrategy[] PostConstructor) PartitionConstructorInitializers(
+        MappaBuilderContext context,
+        string source)
+    {
+        var deferInitializersForReferenceReusing = ReferenceHandlingCodeGenerator.ShouldRegisterReferencePairEarly(
+            context,
+            source,
+            this.strategy.TargetType,
+            this.strategy.SourceType);
+        if (this.strategy.RequiresUnsafeAccessorOnConstructor || deferInitializersForReferenceReusing)
+        {
+            return ([], [.. this.strategy.InitializerStrategies]);
+        }
+
+        var objectInitializerStrategies = this.strategy.InitializerStrategies
+            .Where(propertyMapStrategy => !propertyMapStrategy.PostConstructorInitializer
+                                          && !propertyMapStrategy.RequiresUnsafeAccessorOnTarget)
+            .ToArray();
+        var postConstructorStrategies = this.strategy.InitializerStrategies
+            .Where(propertyMapStrategy => propertyMapStrategy.PostConstructorInitializer
+                                          || propertyMapStrategy.RequiresUnsafeAccessorOnTarget)
+            .ToArray();
+        return (objectInitializerStrategies, postConstructorStrategies);
+    }
+
+    private void AppendConstructionWithOptionalObjectInitializer(
+        PrettyCode.StringBuilder builder,
+        string resultTemporary,
+        string constructionExpression,
+        List<(IPropertySymbol TargetProperty, string TemporaryName, bool RequiresUnsafeAccessorOnTarget)> propertyInitializersMappings,
+        bool hasPropertyInitializers)
+        => AppendConstructionWithOptionalObjectInitializer(
+            builder,
+            resultTemporary,
+            constructionExpression,
+            propertyInitializersMappings,
+            hasPropertyInitializers,
+            this.strategy.TargetType);
 }

--- a/Mappa.Generator/Builders/Strategies/InvokeObjectFactoryMapStrategyBuilder.cs
+++ b/Mappa.Generator/Builders/Strategies/InvokeObjectFactoryMapStrategyBuilder.cs
@@ -37,105 +37,34 @@ internal sealed class InvokeObjectFactoryMapStrategyBuilder
 
         using (context.PushCurrentCompositeTypeSourceName(source))
         {
-            var parametersVariableNames = new List<string>();
-            foreach (var parameterMapStrategy in this.strategy.ParametersMapStrategies)
-            {
-                var (parameterTargetTemporary, parameterCode) = parameterMapStrategy.GetBuilder().BuildSource(source, context, mappaGlobalOptions);
-                if (!string.IsNullOrWhiteSpace(parameterCode))
-                {
-                    builder.AppendLine(parameterCode);
-                }
-
-                parametersVariableNames.Add(parameterTargetTemporary);
-            }
-
-            var propertyInitializersMappings = new List<(IPropertySymbol TargetProperty, string TemporaryName, bool RequiresUnsafeAccessorOnTarget)>();
-            var deferInitializersForReferenceReusing = ReferenceHandlingCodeGenerator.ShouldRegisterReferencePairEarly(
-                context,
+            var parametersVariableNames = this.BuildParameterMappings(source, context, mappaGlobalOptions, builder);
+            var (preConstructionInitializers, postConstructionInitializers, deferInitializersForReferenceReusing) =
+                this.PartitionInitializerStrategies(context, source);
+            var propertyInitializersMappings = BuildPreConstructionInitializerMappings(
                 source,
-                this.strategy.TargetType,
-                this.strategy.SourceType);
-            var preConstructionInitializers = deferInitializersForReferenceReusing
-                ? Array.Empty<PropertyMapStrategy>()
-                : this.strategy.InitializerStrategies.Where(propertyMapStrategy => !propertyMapStrategy.PostConstructorInitializer).ToArray();
-            var postConstructionInitializers = deferInitializersForReferenceReusing
-                ? this.strategy.InitializerStrategies
-                : this.strategy.InitializerStrategies.Where(propertyMapStrategy => propertyMapStrategy.PostConstructorInitializer).ToArray();
-            foreach (var propertyMapStrategy in preConstructionInitializers)
-            {
-                var (initializerPropertyTargetTemporary, initializerPropertyCode) = propertyMapStrategy.GetBuilder().BuildSource(source, context, mappaGlobalOptions);
-                propertyInitializersMappings.Add((
-                    propertyMapStrategy.TargetProperty,
-                    initializerPropertyTargetTemporary,
-                    propertyMapStrategy.RequiresUnsafeAccessorOnTarget));
-                if (!string.IsNullOrWhiteSpace(initializerPropertyCode))
-                {
-                    builder.AppendLine(initializerPropertyCode);
-                }
-            }
+                context,
+                mappaGlobalOptions,
+                builder,
+                preConstructionInitializers);
 
             var hasPropertyInitializers = propertyInitializersMappings.Count > 0;
             var accessor = GetAccessor(this.strategy.ObjectFactory);
             var invocationArguments = this.GetInvocationArguments(source, context, parametersVariableNames);
             resultTemporary = context.NextTemporary();
 
-            // Object initializers are only valid on object-creation expressions. Factory
-            // invocations therefore assign properties with post-call statements instead.
             builder.AppendLine($"{this.strategy.TargetType.ToDisplayString()} {resultTemporary} = {accessor}{this.strategy.ObjectFactory.Method.Name}({invocationArguments});");
 
-            var earlyAddReferencePair = ReferenceHandlingCodeGenerator.BuildEarlyAddReferencePairStatement(
-                context,
-                resultTemporary,
+            this.AppendEarlyReferencePair(context, builder, resultTemporary, source);
+            AppendPropertyInitializerAssignments(context, builder, resultTemporary, propertyInitializersMappings, hasPropertyInitializers);
+            AppendPostConstructionInitializers(
                 source,
-                this.strategy.TargetType,
-                this.strategy.SourceType);
-            if (earlyAddReferencePair is not null)
-            {
-                builder.AppendLine(earlyAddReferencePair);
-            }
-
-            if (hasPropertyInitializers)
-            {
-                foreach (var propertyInitializersMapping in propertyInitializersMappings)
-                {
-                    builder.AppendLine(InaccessibleMemberAccessHelper.BuildPropertyAssignmentStatement(
-                        resultTemporary,
-                        propertyInitializersMapping.TargetProperty,
-                        propertyInitializersMapping.TemporaryName,
-                        propertyInitializersMapping.RequiresUnsafeAccessorOnTarget,
-                        context));
-                }
-            }
-
-            using (context.PushCurrentCompositeTypeTargetName(resultTemporary))
-            {
-                foreach (var propertyMapStrategy in postConstructionInitializers)
-                {
-                    var (initializerPropertyTargetTemporary, initializerPropertyCode) = propertyMapStrategy.GetBuilder().BuildSource(source, context, mappaGlobalOptions);
-                    if (!string.IsNullOrWhiteSpace(initializerPropertyCode))
-                    {
-                        builder.AppendLine(initializerPropertyCode);
-                    }
-
-                    if (deferInitializersForReferenceReusing && !propertyMapStrategy.PostConstructorInitializer)
-                    {
-                        builder.AppendLine(InaccessibleMemberAccessHelper.BuildPropertyAssignmentStatement(
-                            resultTemporary,
-                            propertyMapStrategy.TargetProperty,
-                            initializerPropertyTargetTemporary,
-                            propertyMapStrategy.RequiresUnsafeAccessorOnTarget,
-                            context));
-                    }
-                }
-            }
-
-            if (this.strategy.AssignToContextEntries.Length > 0 && this.strategy.ContextParameterName is not null)
-            {
-                foreach (var assignToContextEntry in this.strategy.AssignToContextEntries)
-                {
-                    builder.AppendLine($"{this.strategy.ContextParameterName}[{CSharpLiteralHelper.ToStringLiteral(assignToContextEntry.ContextKey)}] = {PropertyPathExpressionBuilder.BuildTargetMemberAccessExpression(resultTemporary, assignToContextEntry.MemberName)};");
-                }
-            }
+                context,
+                mappaGlobalOptions,
+                builder,
+                resultTemporary,
+                postConstructionInitializers,
+                deferInitializersForReferenceReusing);
+            this.AppendAssignToContextEntries(builder, resultTemporary);
         }
 
         return (resultTemporary, builder.ToString());
@@ -170,6 +99,151 @@ internal sealed class InvokeObjectFactoryMapStrategyBuilder
             IPropertySymbol property => property.Type,
             _ => throw new MappaGeneratorException($"Unexpected symbol kind '{fieldOrProperty.Kind}' for field or property '{fieldOrProperty.Name}'."),
         };
+
+    private static List<(IPropertySymbol TargetProperty, string TemporaryName, bool RequiresUnsafeAccessorOnTarget)> BuildPreConstructionInitializerMappings(
+        string source,
+        MappaBuilderContext context,
+        MappaGlobalOptions mappaGlobalOptions,
+        PrettyCode.StringBuilder builder,
+        PropertyMapStrategy[] preConstructionInitializers)
+    {
+        var propertyInitializersMappings = new List<(IPropertySymbol TargetProperty, string TemporaryName, bool RequiresUnsafeAccessorOnTarget)>();
+        foreach (var propertyMapStrategy in preConstructionInitializers)
+        {
+            var (initializerPropertyTargetTemporary, initializerPropertyCode) = propertyMapStrategy.GetBuilder().BuildSource(source, context, mappaGlobalOptions);
+            propertyInitializersMappings.Add((
+                propertyMapStrategy.TargetProperty,
+                initializerPropertyTargetTemporary,
+                propertyMapStrategy.RequiresUnsafeAccessorOnTarget));
+            if (!string.IsNullOrWhiteSpace(initializerPropertyCode))
+            {
+                builder.AppendLine(initializerPropertyCode);
+            }
+        }
+
+        return propertyInitializersMappings;
+    }
+
+    private static void AppendPropertyInitializerAssignments(
+        MappaBuilderContext context,
+        PrettyCode.StringBuilder builder,
+        string resultTemporary,
+        List<(IPropertySymbol TargetProperty, string TemporaryName, bool RequiresUnsafeAccessorOnTarget)> propertyInitializersMappings,
+        bool hasPropertyInitializers)
+    {
+        if (!hasPropertyInitializers)
+        {
+            return;
+        }
+
+        foreach (var propertyInitializersMapping in propertyInitializersMappings)
+        {
+            builder.AppendLine(InaccessibleMemberAccessHelper.BuildPropertyAssignmentStatement(
+                resultTemporary,
+                propertyInitializersMapping.TargetProperty,
+                propertyInitializersMapping.TemporaryName,
+                propertyInitializersMapping.RequiresUnsafeAccessorOnTarget,
+                context));
+        }
+    }
+
+    private static void AppendPostConstructionInitializers(
+        string source,
+        MappaBuilderContext context,
+        MappaGlobalOptions mappaGlobalOptions,
+        PrettyCode.StringBuilder builder,
+        string resultTemporary,
+        PropertyMapStrategy[] postConstructionInitializers,
+        bool deferInitializersForReferenceReusing)
+    {
+        using (context.PushCurrentCompositeTypeTargetName(resultTemporary))
+        {
+            foreach (var propertyMapStrategy in postConstructionInitializers)
+            {
+                var (initializerPropertyTargetTemporary, initializerPropertyCode) = propertyMapStrategy.GetBuilder().BuildSource(source, context, mappaGlobalOptions);
+                if (!string.IsNullOrWhiteSpace(initializerPropertyCode))
+                {
+                    builder.AppendLine(initializerPropertyCode);
+                }
+
+                if (deferInitializersForReferenceReusing && !propertyMapStrategy.PostConstructorInitializer)
+                {
+                    builder.AppendLine(InaccessibleMemberAccessHelper.BuildPropertyAssignmentStatement(
+                        resultTemporary,
+                        propertyMapStrategy.TargetProperty,
+                        initializerPropertyTargetTemporary,
+                        propertyMapStrategy.RequiresUnsafeAccessorOnTarget,
+                        context));
+                }
+            }
+        }
+    }
+
+    private List<string> BuildParameterMappings(
+        string source,
+        MappaBuilderContext context,
+        MappaGlobalOptions mappaGlobalOptions,
+        PrettyCode.StringBuilder builder)
+    {
+        var parametersVariableNames = new List<string>();
+        foreach (var parameterMapStrategy in this.strategy.ParametersMapStrategies)
+        {
+            var (parameterTargetTemporary, parameterCode) = parameterMapStrategy.GetBuilder().BuildSource(source, context, mappaGlobalOptions);
+            if (!string.IsNullOrWhiteSpace(parameterCode))
+            {
+                builder.AppendLine(parameterCode);
+            }
+
+            parametersVariableNames.Add(parameterTargetTemporary);
+        }
+
+        return parametersVariableNames;
+    }
+
+    private (PropertyMapStrategy[] PreConstruction, PropertyMapStrategy[] PostConstruction, bool DeferForReferenceReusing) PartitionInitializerStrategies(
+        MappaBuilderContext context,
+        string source)
+    {
+        var deferInitializersForReferenceReusing = ReferenceHandlingCodeGenerator.ShouldRegisterReferencePairEarly(
+            context,
+            source,
+            this.strategy.TargetType,
+            this.strategy.SourceType);
+        var preConstructionInitializers = deferInitializersForReferenceReusing
+            ? Array.Empty<PropertyMapStrategy>()
+            : this.strategy.InitializerStrategies.Where(propertyMapStrategy => !propertyMapStrategy.PostConstructorInitializer).ToArray();
+        var postConstructionInitializers = deferInitializersForReferenceReusing
+            ? this.strategy.InitializerStrategies
+            : this.strategy.InitializerStrategies.Where(propertyMapStrategy => propertyMapStrategy.PostConstructorInitializer).ToArray();
+        return (preConstructionInitializers, postConstructionInitializers, deferInitializersForReferenceReusing);
+    }
+
+    private void AppendEarlyReferencePair(MappaBuilderContext context, PrettyCode.StringBuilder builder, string resultTemporary, string source)
+    {
+        var earlyAddReferencePair = ReferenceHandlingCodeGenerator.BuildEarlyAddReferencePairStatement(
+            context,
+            resultTemporary,
+            source,
+            this.strategy.TargetType,
+            this.strategy.SourceType);
+        if (earlyAddReferencePair is not null)
+        {
+            builder.AppendLine(earlyAddReferencePair);
+        }
+    }
+
+    private void AppendAssignToContextEntries(PrettyCode.StringBuilder builder, string resultTemporary)
+    {
+        if (this.strategy.AssignToContextEntries.Length == 0 || this.strategy.ContextParameterName is null)
+        {
+            return;
+        }
+
+        foreach (var assignToContextEntry in this.strategy.AssignToContextEntries)
+        {
+            builder.AppendLine($"{this.strategy.ContextParameterName}[{CSharpLiteralHelper.ToStringLiteral(assignToContextEntry.ContextKey)}] = {PropertyPathExpressionBuilder.BuildTargetMemberAccessExpression(resultTemporary, assignToContextEntry.MemberName)};");
+        }
+    }
 
     private string GetInvocationArguments(
         string source,

--- a/Mappa.Generator/Builders/Strategies/MappaAssignFromConstantAttributeStrategyBuilder.cs
+++ b/Mappa.Generator/Builders/Strategies/MappaAssignFromConstantAttributeStrategyBuilder.cs
@@ -18,6 +18,20 @@ namespace Mappa.Generator.Builders.Strategies;
 internal sealed class MappaAssignFromConstantAttributeStrategyBuilder
     : IMappaStrategyBuilder
 {
+    private static readonly HashSet<Type> NumericPrimitiveTypes =
+    [
+        typeof(sbyte),
+        typeof(byte),
+        typeof(short),
+        typeof(ushort),
+        typeof(int),
+        typeof(uint),
+        typeof(long),
+        typeof(ulong),
+        typeof(float),
+        typeof(double),
+    ];
+
     private readonly MappaAssignFromConstantAttributeStrategy strategy;
 
     /// <summary>
@@ -46,52 +60,76 @@ internal sealed class MappaAssignFromConstantAttributeStrategyBuilder
             return "null";
         }
 
-        return value switch
+        if (value is string stringValue)
         {
-            string s => CSharpLiteralHelper.ToStringLiteral(s),
-            sbyte or byte or short or ushort or int or uint or long or ulong or float or double => $"{value}",
-            bool b => b ? "true" : "false",
-            char c => CSharpLiteralHelper.ToCharLiteral(c),
-            TypedConstant typedConstant when
-                typedConstant.Kind is TypedConstantKind.Enum &&
+            return CSharpLiteralHelper.ToStringLiteral(stringValue);
+        }
+
+        if (value is bool boolValue)
+        {
+            return boolValue ? "true" : "false";
+        }
+
+        if (value is char charValue)
+        {
+            return CSharpLiteralHelper.ToCharLiteral(charValue);
+        }
+
+        if (IsNumericPrimitive(value))
+        {
+            return $"{value}";
+        }
+
+        if (value is TypedConstant typedConstant)
+        {
+            return TypedConstantToCode(typedConstant);
+        }
+
+        throw new MappaGeneratorException("Unexpected MappaAssignFromConstant attribute value.");
+    }
+
+    private static bool IsNumericPrimitive(object value)
+        => NumericPrimitiveTypes.Contains(value.GetType());
+
+    private static string TypedConstantToCode(TypedConstant typedConstant) =>
+        typedConstant.Kind switch
+        {
+            TypedConstantKind.Primitive => ValueToCode(typedConstant.Value),
+            TypedConstantKind.Array => GetCodeForArrays(typedConstant),
+            TypedConstantKind.Type when typedConstant.Value is ITypeSymbol typeSymbol =>
+                $"typeof({typeSymbol.ToDisplayString()})",
+            TypedConstantKind.Enum when
                 typedConstant.Value is not null &&
                 typedConstant.Type is not null &&
-                typedConstant.Type.IsEnum() => GetCodeForEnum(typedConstant.Type, typedConstant.Value),
-            TypedConstant typedConstant when
-                typedConstant.Kind is TypedConstantKind.Primitive => ValueToCode(typedConstant.Value),
-            TypedConstant typedConstant when
-                typedConstant.Kind is TypedConstantKind.Array => GetCodeForArrays(typedConstant),
-            TypedConstant typedConstant when
-                typedConstant.Kind is TypedConstantKind.Type &&
-                typedConstant.Value is ITypeSymbol typeSymbol => $"typeof({typeSymbol.ToDisplayString()})",
+                typedConstant.Type.IsEnum() =>
+                GetCodeForEnum(typedConstant.Type, typedConstant.Value),
             _ => throw new MappaGeneratorException("Unexpected MappaAssignFromConstant attribute value."),
         };
 
-        static string GetCodeForEnum(ITypeSymbol typeSymbol, object integerEnumValue)
+    private static string GetCodeForEnum(ITypeSymbol typeSymbol, object integerEnumValue)
+    {
+        #pragma warning disable S3267 // Loops should be simplified using the "Where" method
+        foreach (var enumValue in typeSymbol.GetEnumValues())
+        #pragma warning restore S3267 // Loops should be simplified using the "Where" method
         {
-            #pragma warning disable S3267 // Loops should be simplified using the "Where" method
-            foreach (var enumValue in typeSymbol.GetEnumValues())
-            #pragma warning restore S3267 // Loops should be simplified using the "Where" method
+            if (enumValue.Value is not null && integerEnumValue.Equals(enumValue.Value))
             {
-                if (enumValue.Value is not null && integerEnumValue.Equals(enumValue.Value))
-                {
-                    return $"{typeSymbol.ToDisplayString()}.{enumValue.Name}";
-                }
+                return $"{typeSymbol.ToDisplayString()}.{enumValue.Name}";
             }
-
-            throw new MappaGeneratorException("Unexpected enumeration value");
         }
 
-        static string GetCodeForArrays(TypedConstant array)
-        {
-            var arrayValues = array.Values;
-            var valuesAsCode = new string[arrayValues.Length];
-            for (var i = 0; i < arrayValues.Length; i++)
-            {
-                valuesAsCode[i] = ValueToCode(arrayValues[i]);
-            }
+        throw new MappaGeneratorException("Unexpected enumeration value");
+    }
 
-            return $"new {array.Type?.ToDisplayString()}{{ {string.Join(", ", valuesAsCode)} }}";
+    private static string GetCodeForArrays(TypedConstant array)
+    {
+        var arrayValues = array.Values;
+        var valuesAsCode = new string[arrayValues.Length];
+        for (var i = 0; i < arrayValues.Length; i++)
+        {
+            valuesAsCode[i] = ValueToCode(arrayValues[i]);
         }
+
+        return $"new {array.Type?.ToDisplayString()}{{ {string.Join(", ", valuesAsCode)} }}";
     }
 }

--- a/Mappa.Generator/Builders/Strategies/MappaInvokeMethodAttributeStrategyBuilder.cs
+++ b/Mappa.Generator/Builders/Strategies/MappaInvokeMethodAttributeStrategyBuilder.cs
@@ -7,6 +7,8 @@ using Mappa.Generator.Extensions;
 using Mappa.Generator.Models;
 using Mappa.Generator.Models.Strategies;
 
+using Microsoft.CodeAnalysis;
+
 namespace Mappa.Generator.Builders.Strategies;
 
 /// <summary>
@@ -63,52 +65,62 @@ internal sealed class MappaInvokeMethodAttributeStrategyBuilder
         var method = this.strategy.Method;
         var compositeSource = context.GetCompositeTypeSourceName();
 
-        switch (method.Parameters.Length)
+        return method.Parameters.Length switch
         {
-            case 0:
-                return string.Empty;
+            0 => string.Empty,
+            1 => this.GetParametersForSingleArgumentMethod(compilation, source, compositeSource),
+            2 => this.GetParametersForTwoArgumentMethod(compilation, source, compositeSource),
+            3 => $"{compositeSource}, {source}, {this.GetContextArgument()}",
+            _ => throw new MappaGeneratorException("Unexpected parameter type"),
+        };
+    }
 
-            case 3:
-                return $"{compositeSource}, {source}, {this.GetContextArgument()}";
+    private string GetParametersForSingleArgumentMethod(Compilation compilation, string source, string compositeSource)
+    {
+        var method = this.strategy.Method;
+        if (method.ParameterIsMappaContext(compilation, 0))
+        {
+            return this.GetContextArgument();
+        }
 
-            case 2:
-                if (method.ParameterIsMappaContext(compilation, 1))
-                {
-                    if (method.Parameters[0].Type.IsEqualTo(this.strategy.SourceType, this.strategy.IsNullableEnabled) ||
-                        compilation.HasImplicitConversion(this.strategy.SourceType, method.Parameters[0].Type))
-                    {
-                        return $"{compositeSource}, {this.GetContextArgument()}";
-                    }
+        if (this.ParameterAcceptsCompositeSource(method.Parameters[0].Type, compilation))
+        {
+            return compositeSource;
+        }
 
-                    return $"{source}, {this.GetContextArgument()}";
-                }
-
-                return $"{compositeSource}, {source}";
-
-            case 1:
-                if (method.ParameterIsMappaContext(compilation, 0))
-                {
-                    return this.GetContextArgument();
-                }
-
-                if (method.Parameters[0].Type.IsEqualTo(this.strategy.SourceType, this.strategy.IsNullableEnabled) ||
-                    compilation.HasImplicitConversion(this.strategy.SourceType, method.Parameters[0].Type))
-                {
-                    return compositeSource;
-                }
-
-                if (this.strategy.SourceProperty is not null &&
-                    (method.Parameters[0].Type.IsEqualTo(this.strategy.SourceProperty.Type, this.strategy.IsNullableEnabled) ||
-                    compilation.HasImplicitConversion(this.strategy.SourceProperty.Type, method.Parameters[0].Type)))
-                {
-                    return source;
-                }
-
-                break;
+        if (this.strategy.SourceProperty is not null &&
+            this.ParameterAcceptsPropertyType(method.Parameters[0].Type, compilation))
+        {
+            return source;
         }
 
         throw new MappaGeneratorException("Unexpected parameter type");
     }
+
+    private string GetParametersForTwoArgumentMethod(Compilation compilation, string source, string compositeSource)
+    {
+        var method = this.strategy.Method;
+        if (method.ParameterIsMappaContext(compilation, 1))
+        {
+            if (this.ParameterAcceptsCompositeSource(method.Parameters[0].Type, compilation))
+            {
+                return $"{compositeSource}, {this.GetContextArgument()}";
+            }
+
+            return $"{source}, {this.GetContextArgument()}";
+        }
+
+        return $"{compositeSource}, {source}";
+    }
+
+    private bool ParameterAcceptsCompositeSource(ITypeSymbol parameterType, Compilation compilation)
+        => parameterType.IsEqualTo(this.strategy.SourceType, this.strategy.IsNullableEnabled) ||
+           compilation.HasImplicitConversion(this.strategy.SourceType, parameterType);
+
+    private bool ParameterAcceptsPropertyType(ITypeSymbol parameterType, Compilation compilation)
+        => this.strategy.SourceProperty is not null &&
+           (parameterType.IsEqualTo(this.strategy.SourceProperty.Type, this.strategy.IsNullableEnabled) ||
+            compilation.HasImplicitConversion(this.strategy.SourceProperty.Type, parameterType));
 
     private string GetContextArgument()
         => this.strategy.ContextParameterName

--- a/Mappa.Generator/Builders/Strategies/MethodParameterMapStrategyBuilder.cs
+++ b/Mappa.Generator/Builders/Strategies/MethodParameterMapStrategyBuilder.cs
@@ -48,48 +48,13 @@ internal sealed class MethodParameterMapStrategyBuilder
             return ($"return {strategySource};", JoinHeader(maxRuntimeDepthInitialization, header));
         }
 
-        var code = new List<string>();
-        if (maxRuntimeDepthInitialization is not null)
-        {
-            code.Add(maxRuntimeDepthInitialization);
-        }
-
-        var strategyInput = source;
-        if (beforeMapHooks.Any(hook => RequiresMappedValue(hook, context.Compilation)) &&
-            context.GetMapMethod().GetSourceParameterRefKind() is RefKind.In)
-        {
-            strategyInput = context.NextTemporary();
-            code.Add($"{this.MethodParameterMapStrategy.SourceType.ToDisplayString()} {strategyInput} = {source};");
-        }
-
-        foreach (var hook in beforeMapHooks)
-        {
-            code.Add(BuildHookInvocation(hook, strategyInput, context));
-        }
-
-        var (mappedValue, mappingCode) = ReferenceHandlingCodeGenerator.BuildRootSource(
-            this.MethodParameterMapStrategy.Strategy,
-            strategyInput,
+        return this.BuildSourceWithMapHooks(
+            source,
             context,
-            mappaGlobalOptions);
-        if (!string.IsNullOrWhiteSpace(mappingCode))
-        {
-            code.Add(mappingCode);
-        }
-
-        if (afterMapHooks.Count == 0)
-        {
-            return ($"return {mappedValue};", string.Join("\n", code));
-        }
-
-        var targetTemporary = context.NextTemporary();
-        code.Add($"{this.MethodParameterMapStrategy.TargetType.ToDisplayString()} {targetTemporary} = {mappedValue};");
-        foreach (var hook in afterMapHooks)
-        {
-            code.Add(BuildHookInvocation(hook, targetTemporary, context));
-        }
-
-        return ($"return {targetTemporary};", string.Join("\n", code));
+            mappaGlobalOptions,
+            maxRuntimeDepthInitialization,
+            beforeMapHooks,
+            afterMapHooks);
     }
 
     private static string JoinHeader(string? maxRuntimeDepthInitialization, string header)
@@ -166,4 +131,71 @@ internal sealed class MethodParameterMapStrategyBuilder
             IPropertySymbol property => property.Type,
             _ => throw new MappaGeneratorException($"Unexpected symbol kind '{fieldOrProperty.Kind}' for field or property '{fieldOrProperty.Name}'."),
         };
+
+    private (string VariableName, string Code) BuildSourceWithMapHooks(
+        string source,
+        MappaBuilderContext context,
+        MappaGlobalOptions mappaGlobalOptions,
+        string? maxRuntimeDepthInitialization,
+        IReadOnlyList<MapHook> beforeMapHooks,
+        IReadOnlyList<MapHook> afterMapHooks)
+    {
+        var code = new List<string>();
+        if (maxRuntimeDepthInitialization is not null)
+        {
+            code.Add(maxRuntimeDepthInitialization);
+        }
+
+        var strategyInput = this.ResolveStrategyInputForBeforeMapHooks(source, context, beforeMapHooks, code);
+
+        foreach (var hook in beforeMapHooks)
+        {
+            code.Add(BuildHookInvocation(hook, strategyInput, context));
+        }
+
+        var (mappedValue, mappingCode) = ReferenceHandlingCodeGenerator.BuildRootSource(
+            this.MethodParameterMapStrategy.Strategy,
+            strategyInput,
+            context,
+            mappaGlobalOptions);
+        if (!string.IsNullOrWhiteSpace(mappingCode))
+        {
+            code.Add(mappingCode);
+        }
+
+        if (afterMapHooks.Count == 0)
+        {
+            return ($"return {mappedValue};", string.Join("\n", code));
+        }
+
+        var targetTemporary = context.NextTemporary();
+        code.Add($"{this.MethodParameterMapStrategy.TargetType.ToDisplayString()} {targetTemporary} = {mappedValue};");
+        foreach (var hook in afterMapHooks)
+        {
+            code.Add(BuildHookInvocation(hook, targetTemporary, context));
+        }
+
+        return ($"return {targetTemporary};", string.Join("\n", code));
+    }
+
+    private string ResolveStrategyInputForBeforeMapHooks(
+        string source,
+        MappaBuilderContext context,
+        IReadOnlyList<MapHook> beforeMapHooks,
+        List<string> code)
+    {
+        if (!beforeMapHooks.Any(hook => RequiresMappedValue(hook, context.Compilation)))
+        {
+            return source;
+        }
+
+        if (context.GetMapMethod().GetSourceParameterRefKind() is not RefKind.In)
+        {
+            return source;
+        }
+
+        var strategyInput = context.NextTemporary();
+        code.Add($"{this.MethodParameterMapStrategy.SourceType.ToDisplayString()} {strategyInput} = {source};");
+        return strategyInput;
+    }
 }

--- a/Mappa.Generator/Builders/Strategies/NullableStrategyBuilder.cs
+++ b/Mappa.Generator/Builders/Strategies/NullableStrategyBuilder.cs
@@ -31,80 +31,91 @@ internal sealed class NullableStrategyBuilder
     /// <inheritdoc/>
     public (string VariableName, string Code) BuildSource(string source, MappaBuilderContext context, MappaGlobalOptions mappaGlobalOptions)
     {
-        // TTargetType target
-        // if ( source.HasValue OR source is not null )
-        // begin
-        //   -> Mapping
-        //   target := mapped
-        // end else begin
-        //   target.IsNullable -> mapped := null
-        //  !target.IsNullable -> throw NullReference
-        // end.
         PrettyCode.StringBuilder stringBuilder = new();
         var targetTemporary = context.NextTemporary();
         var originalSourceTemporary = source;
 
         stringBuilder.AppendLine($"{this.strategy.TargetType.ToDisplayString()} {targetTemporary};");
-
-        // if block.
         stringBuilder.AppendLine(this.strategy.SourceType.IsReferenceType
             ? $"if ({source} is not null)"
             : $"if ({source}.HasValue)");
         using (stringBuilder.CurlyBracesBlock())
         {
-            source = context.NextTemporary();
-
-            if (this.strategy.SourceType.IsValueType)
-            {
-                stringBuilder.AppendLine($"{this.strategy.SourceType.GetTypeInsideNullable()} {source} = {originalSourceTemporary}.Value;");
-            }
-            else
-            {
-                var type = this.strategy.SourceType.ToDisplayString();
-                if (type.EndsWith("?", StringComparison.Ordinal))
-                {
-                    type = type.Substring(0, type.Length - 1);
-                }
-
-                stringBuilder.AppendLine($"{type} {source} = {originalSourceTemporary};");
-            }
-
-            var (elementTemporary, elementCode) = ReferenceHandlingCodeGenerator.BuildNestedSource(
-                this.strategy.ElementStrategy,
-                source,
-                context,
-                mappaGlobalOptions);
-            if (!string.IsNullOrEmpty(elementCode))
-            {
-                stringBuilder.AppendEmptyLine();
-                stringBuilder.AppendLine(elementCode);
-            }
-
-            stringBuilder.AppendLine($"{targetTemporary} = {elementTemporary};");
+            this.AppendNullableIfBlock(stringBuilder, context, mappaGlobalOptions, originalSourceTemporary, targetTemporary, ref source);
         }
 
-        // else block
         stringBuilder.AppendLine("else");
         using (stringBuilder.CurlyBracesBlock())
         {
-            // If target nullability is None, but we are working in a nullable-enabled context
-            // and the target type is a reference type, then we need to use <c>null!</c> and not just <c>null</c>
-            // to avoid the CS8600 warning.
-            var @suppressNullableWarningNull = string.Empty;
-            if (context.GetMapMethod().NullableEnabled && this.strategy.TargetType is
-                {
-                    IsReferenceType: true,
-                    NullableAnnotation: NullableAnnotation.None,
-                })
-            {
-                suppressNullableWarningNull = "!";
-            }
-
-            stringBuilder.AppendLine(this.strategy.TargetType.IsNullable()
-                ? $"{targetTemporary} = ({this.strategy.TargetType.ToDisplayString()}) null{suppressNullableWarningNull};"
-                : $"throw new System.NullReferenceException(\"\\\"{originalSourceTemporary}\\\" is null.\");");
+            this.AppendNullableElseBlock(stringBuilder, context, originalSourceTemporary, targetTemporary);
         }
 
         return (targetTemporary, stringBuilder.ToString());
+    }
+
+    private static string GetNullableSuppressSuffix(MappaBuilderContext context, ITypeSymbol targetType)
+    {
+        if (!context.GetMapMethod().NullableEnabled)
+        {
+            return string.Empty;
+        }
+
+        if (targetType is not { IsReferenceType: true, NullableAnnotation: NullableAnnotation.None })
+        {
+            return string.Empty;
+        }
+
+        return "!";
+    }
+
+    private void AppendNullableIfBlock(
+        PrettyCode.StringBuilder stringBuilder,
+        MappaBuilderContext context,
+        MappaGlobalOptions mappaGlobalOptions,
+        string originalSourceTemporary,
+        string targetTemporary,
+        ref string source)
+    {
+        source = context.NextTemporary();
+
+        if (this.strategy.SourceType.IsValueType)
+        {
+            stringBuilder.AppendLine($"{this.strategy.SourceType.GetTypeInsideNullable()} {source} = {originalSourceTemporary}.Value;");
+        }
+        else
+        {
+            var type = this.strategy.SourceType.ToDisplayString();
+            if (type.EndsWith("?", StringComparison.Ordinal))
+            {
+                type = type.Substring(0, type.Length - 1);
+            }
+
+            stringBuilder.AppendLine($"{type} {source} = {originalSourceTemporary};");
+        }
+
+        var (elementTemporary, elementCode) = ReferenceHandlingCodeGenerator.BuildNestedSource(
+            this.strategy.ElementStrategy,
+            source,
+            context,
+            mappaGlobalOptions);
+        if (!string.IsNullOrEmpty(elementCode))
+        {
+            stringBuilder.AppendEmptyLine();
+            stringBuilder.AppendLine(elementCode);
+        }
+
+        stringBuilder.AppendLine($"{targetTemporary} = {elementTemporary};");
+    }
+
+    private void AppendNullableElseBlock(
+        PrettyCode.StringBuilder stringBuilder,
+        MappaBuilderContext context,
+        string originalSourceTemporary,
+        string targetTemporary)
+    {
+        var suppressNullableWarningNull = GetNullableSuppressSuffix(context, this.strategy.TargetType);
+        stringBuilder.AppendLine(this.strategy.TargetType.IsNullable()
+            ? $"{targetTemporary} = ({this.strategy.TargetType.ToDisplayString()}) null{suppressNullableWarningNull};"
+            : $"throw new System.NullReferenceException(\"\\\"{originalSourceTemporary}\\\" is null.\");");
     }
 }

--- a/Mappa.Generator/Builders/Strategies/PolymorphismMapStrategyBuilder.cs
+++ b/Mappa.Generator/Builders/Strategies/PolymorphismMapStrategyBuilder.cs
@@ -86,118 +86,172 @@ internal sealed class PolymorphismMapStrategyBuilder(PolymorphismMapStrategy str
             case MappaTypeMappingDefaultBehavior.Undefined:
                 throw new MappaGeneratorException("Unexpected undefined behavior while generating default branch for type mapping.");
             case MappaTypeMappingDefaultBehavior.Throw:
-
-                var exceptionToThrow = attribute.Type is { } exceptionType
-                    ? (exceptionType.FullName ?? throw new MappaGeneratorException("Cannot obtain exception type name"))
-                    : "System.ArgumentOutOfRangeException";
-
-                var exceptionSymbol = context.Compilation.GetTypeByMetadataName(exceptionToThrow)
-                    ?? throw new MappaGeneratorException("Cannot obtain exception type by name");
-                var parameters = string.Empty;
-
-                if (exceptionSymbol.HasNamedTypeSymbolAccessibleSingleStringParametersConstructor(context.Compilation))
-                {
-                    parameters = $"nameof({source})";
-                }
-                else if (!exceptionSymbol.HasNamedTypeSymbolAccessibleZeroParametersConstructor(context.Compilation))
-                {
-                    throw new MappaGeneratorException("Cannot identify a suitable constructor to generate the exception");
-                }
-
-                builder.AppendLine($"throw new global::{exceptionToThrow}({parameters});");
+                AppendThrowDefaultCode(attribute, source, context, builder);
                 break;
             case MappaTypeMappingDefaultBehavior.Default:
-                builder.AppendLine($"{targetTemporary} = default;");
-                builder.AppendLine("break;");
+                AppendAssignDefaultAndBreak(targetTemporary, builder);
                 break;
             case MappaTypeMappingDefaultBehavior.Null:
-                builder.AppendLine($"{targetTemporary} = null;");
-                builder.AppendLine("break;");
+                AppendAssignNullAndBreak(targetTemporary, builder);
                 break;
             case MappaTypeMappingDefaultBehavior.MapSourceType:
-                var (defaultVariable, defaultCode) = ReferenceHandlingCodeGenerator.BuildNestedSource(
-                    defaultBehaviorStrategy,
+                AppendMapSourceTypeDefaultCode(
                     source,
+                    targetTemporary,
+                    defaultBehaviorStrategy,
+                    builder,
                     context,
                     mappaGlobalOptions);
-                if (!string.IsNullOrWhiteSpace(defaultCode))
-                {
-                    builder.AppendLine(defaultCode);
-                }
-
-                builder.AppendLine($"{targetTemporary} = {defaultVariable};");
-                builder.AppendLine("break;");
                 break;
             case MappaTypeMappingDefaultBehavior.InvokeMethod:
-                if (defaultInvokeMethod is null)
-                {
-                    throw new MappaGeneratorException("Cannot identify the method to be invoked.");
-                }
-
-                var invokeMethodTypeSymbol =
-                    (attribute.Type is { } invokingType && !string.IsNullOrWhiteSpace(invokingType.FullName))
-                        ? context.Compilation.GetTypeByMetadataName(invokingType.FullName)
-                        : context.GetMapMethod().ContainingType as ITypeSymbol;
-                if (invokeMethodTypeSymbol is null)
-                {
-                    throw new MappaGeneratorException("Cannot identify the type on which the method is being invoked on.");
-                }
-
-                var methodInvocationCode = BuildMethodInvocationCode(
-                    context.GetMapMethod().ContainingType,
-                    invokeMethodTypeSymbol,
-                    defaultInvokeMethod,
+                AppendInvokeMethodDefaultCode(
+                    attribute,
                     source,
-                    contextParameterName);
-                builder.AppendLine($"{targetTemporary} = {methodInvocationCode};");
-                builder.AppendLine("break;");
+                    targetTemporary,
+                    defaultInvokeMethod,
+                    contextParameterName,
+                    builder,
+                    context);
                 break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(attribute));
         }
+    }
 
-        static string BuildMethodInvocationCode(
-            ITypeSymbol mapMethodTypeSymbol,
-            ITypeSymbol? typeSymbol,
-            IMethodSymbol method,
-            string source,
-            string? contextParameterName)
+    private static void AppendThrowDefaultCode(
+        MappaTypeMappingDefaultAttribute attribute,
+        string source,
+        MappaBuilderContext context,
+        PrettyCode.StringBuilder builder)
+    {
+        var exceptionToThrow = attribute.Type is { } exceptionType
+            ? (exceptionType.FullName ?? throw new MappaGeneratorException("Cannot obtain exception type name"))
+            : "System.ArgumentOutOfRangeException";
+
+        var exceptionSymbol = context.Compilation.GetTypeByMetadataName(exceptionToThrow)
+            ?? throw new MappaGeneratorException("Cannot obtain exception type by name");
+        var parameters = string.Empty;
+
+        if (exceptionSymbol.HasNamedTypeSymbolAccessibleSingleStringParametersConstructor(context.Compilation))
         {
-            var head = string.Empty;
-            if (typeSymbol is not null && !SymbolEqualityComparer.Default.Equals(typeSymbol, mapMethodTypeSymbol))
-            {
-                head = $"global::{typeSymbol.ToDisplayString()}.";
-            }
-            else if (!method.IsStatic)
-            {
-                head = "this.";
-            }
-
-            string parameters;
-            switch (method.Parameters.Length)
-            {
-                case 0:
-                    parameters = string.Empty;
-                    break;
-
-                case 1:
-                    parameters = source;
-                    break;
-
-                case 2:
-                    if (string.IsNullOrWhiteSpace(contextParameterName))
-                    {
-                        throw new MappaGeneratorException("Default mapping method requires to parameters but context on original mapping is not provided.");
-                    }
-
-                    parameters = $"{source}, {contextParameterName}";
-                    break;
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(method), $@"Unexpected number of parameters for method '{method.Name}'.");
-            }
-
-            return $"{head}{method.Name}({parameters})";
+            parameters = $"nameof({source})";
         }
+        else if (!exceptionSymbol.HasNamedTypeSymbolAccessibleZeroParametersConstructor(context.Compilation))
+        {
+            throw new MappaGeneratorException("Cannot identify a suitable constructor to generate the exception");
+        }
+
+        builder.AppendLine($"throw new global::{exceptionToThrow}({parameters});");
+    }
+
+    private static void AppendAssignDefaultAndBreak(string targetTemporary, PrettyCode.StringBuilder builder)
+    {
+        builder.AppendLine($"{targetTemporary} = default;");
+        builder.AppendLine("break;");
+    }
+
+    private static void AppendAssignNullAndBreak(string targetTemporary, PrettyCode.StringBuilder builder)
+    {
+        builder.AppendLine($"{targetTemporary} = null;");
+        builder.AppendLine("break;");
+    }
+
+    private static void AppendMapSourceTypeDefaultCode(
+        string source,
+        string targetTemporary,
+        MapStrategy defaultBehaviorStrategy,
+        PrettyCode.StringBuilder builder,
+        MappaBuilderContext context,
+        MappaGlobalOptions mappaGlobalOptions)
+    {
+        var (defaultVariable, defaultCode) = ReferenceHandlingCodeGenerator.BuildNestedSource(
+            defaultBehaviorStrategy,
+            source,
+            context,
+            mappaGlobalOptions);
+        if (!string.IsNullOrWhiteSpace(defaultCode))
+        {
+            builder.AppendLine(defaultCode);
+        }
+
+        builder.AppendLine($"{targetTemporary} = {defaultVariable};");
+        builder.AppendLine("break;");
+    }
+
+    private static void AppendInvokeMethodDefaultCode(
+        MappaTypeMappingDefaultAttribute attribute,
+        string source,
+        string targetTemporary,
+        IMethodSymbol? defaultInvokeMethod,
+        string? contextParameterName,
+        PrettyCode.StringBuilder builder,
+        MappaBuilderContext context)
+    {
+        if (defaultInvokeMethod is null)
+        {
+            throw new MappaGeneratorException("Cannot identify the method to be invoked.");
+        }
+
+        var invokeMethodTypeSymbol =
+            (attribute.Type is { } invokingType && !string.IsNullOrWhiteSpace(invokingType.FullName))
+                ? context.Compilation.GetTypeByMetadataName(invokingType.FullName)
+                : context.GetMapMethod().ContainingType as ITypeSymbol;
+        if (invokeMethodTypeSymbol is null)
+        {
+            throw new MappaGeneratorException("Cannot identify the type on which the method is being invoked on.");
+        }
+
+        var methodInvocationCode = BuildMethodInvocationCode(
+            context.GetMapMethod().ContainingType,
+            invokeMethodTypeSymbol,
+            defaultInvokeMethod,
+            source,
+            contextParameterName);
+        builder.AppendLine($"{targetTemporary} = {methodInvocationCode};");
+        builder.AppendLine("break;");
+    }
+
+    private static string BuildMethodInvocationCode(
+        ITypeSymbol mapMethodTypeSymbol,
+        ITypeSymbol? typeSymbol,
+        IMethodSymbol method,
+        string source,
+        string? contextParameterName)
+    {
+        var head = string.Empty;
+        if (typeSymbol is not null && !SymbolEqualityComparer.Default.Equals(typeSymbol, mapMethodTypeSymbol))
+        {
+            head = $"global::{typeSymbol.ToDisplayString()}.";
+        }
+        else if (!method.IsStatic)
+        {
+            head = "this.";
+        }
+
+        string parameters;
+        switch (method.Parameters.Length)
+        {
+            case 0:
+                parameters = string.Empty;
+                break;
+
+            case 1:
+                parameters = source;
+                break;
+
+            case 2:
+                if (string.IsNullOrWhiteSpace(contextParameterName))
+                {
+                    throw new MappaGeneratorException("Default mapping method requires to parameters but context on original mapping is not provided.");
+                }
+
+                parameters = $"{source}, {contextParameterName}";
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(method), $@"Unexpected number of parameters for method '{method.Name}'.");
+        }
+
+        return $"{head}{method.Name}({parameters})";
     }
 }

--- a/Mappa.Generator/Builders/Strategies/PropertyMapStrategyBuilder.cs
+++ b/Mappa.Generator/Builders/Strategies/PropertyMapStrategyBuilder.cs
@@ -31,65 +31,7 @@ internal sealed class PropertyMapStrategyBuilder
     public (string VariableName, string Code) BuildSource(string source, MappaBuilderContext context, MappaGlobalOptions mappaGlobalOptions)
     {
         var builder = new PrettyCode.StringBuilder();
-
-        var sourcePropertyTemporary = string.Empty;
-        if (this.strategy.ChainedSourcePropertyPath is not null)
-        {
-            var chainedSourcePropertyPath = this.strategy.ChainedSourcePropertyPath;
-            var chainSource = source;
-            var rootParameterName = context.GetMapMethod().SourceParameterName;
-            var receiverPathPrefix = chainedSourcePropertyPath.ReceiverPathPrefix;
-
-            // Only rewrite to the root parameter when the chain is intentionally rooted there.
-            // Empty prefix means read remaining segments from the current nested source receiver.
-            if (!string.IsNullOrWhiteSpace(receiverPathPrefix)
-                && (receiverPathPrefix.Equals(rootParameterName, StringComparison.Ordinal)
-                    || receiverPathPrefix.StartsWith($"{rootParameterName}.", StringComparison.Ordinal)))
-            {
-                chainSource = rootParameterName;
-            }
-
-            var accessExpression = PropertyPathExpressionBuilder.BuildChainedAccessExpression(
-                chainSource,
-                receiverPathPrefix,
-                chainedSourcePropertyPath.RemainingSourceSegments,
-                chainedSourcePropertyPath.StartingSourceType,
-                context.GetMapMethod().NullableEnabled,
-                this.strategy.TargetProperty.Type,
-                out var resolvedProperties,
-                chainedSourcePropertyPath.OriginalSourcePath);
-
-            ITypeSymbol innermostSourceType;
-            if (resolvedProperties.Length > 0)
-            {
-                innermostSourceType = resolvedProperties[resolvedProperties.Length - 1].Type;
-            }
-            else if (PropertyPathSymbolResolver.TryGetReceiverTypeForPathPrefix(
-                         chainedSourcePropertyPath.StartingSourceType,
-                         chainSource,
-                         string.IsNullOrWhiteSpace(receiverPathPrefix) ? chainSource : receiverPathPrefix,
-                         out var receiverType))
-            {
-                innermostSourceType = receiverType;
-            }
-            else
-            {
-                innermostSourceType = chainedSourcePropertyPath.StartingSourceType;
-            }
-
-            sourcePropertyTemporary = context.NextTemporary();
-            builder.AppendLine($"{innermostSourceType.ToDisplayString()} {sourcePropertyTemporary} = {accessExpression};");
-        }
-        else if (this.strategy.SourceProperty is not null)
-        {
-            sourcePropertyTemporary = context.NextTemporary();
-            var sourceReadExpression = InaccessibleMemberAccessHelper.BuildPropertyReadExpression(
-                source,
-                this.strategy.SourceProperty,
-                this.strategy.RequiresUnsafeAccessorOnSource,
-                context);
-            builder.AppendLine($"{this.strategy.SourceProperty.Type.ToDisplayString()} {sourcePropertyTemporary} = {sourceReadExpression};");
-        }
+        var sourcePropertyTemporary = this.BuildSourcePropertyTemporary(builder, source, context);
 
         string targetTemporary;
         string code;
@@ -111,5 +53,100 @@ internal sealed class PropertyMapStrategyBuilder
         }
 
         return (targetTemporary, builder.ToString());
+    }
+
+    private static ITypeSymbol ResolveInnermostChainedSourceType(
+        ChainedSourcePropertyPathInfo chainedSourcePropertyPath,
+        string chainSource,
+        string receiverPathPrefix,
+        IPropertySymbol[] resolvedProperties)
+    {
+        if (resolvedProperties.Length > 0)
+        {
+            return resolvedProperties[resolvedProperties.Length - 1].Type;
+        }
+
+        if (PropertyPathSymbolResolver.TryGetReceiverTypeForPathPrefix(
+                chainedSourcePropertyPath.StartingSourceType,
+                chainSource,
+                string.IsNullOrWhiteSpace(receiverPathPrefix) ? chainSource : receiverPathPrefix,
+                out var receiverType))
+        {
+            return receiverType;
+        }
+
+        return chainedSourcePropertyPath.StartingSourceType;
+    }
+
+    private string BuildSourcePropertyTemporary(PrettyCode.StringBuilder builder, string source, MappaBuilderContext context)
+    {
+        if (this.strategy.ChainedSourcePropertyPath is not null)
+        {
+            return this.AppendChainedSourcePropertyRead(builder, source, context);
+        }
+
+        if (this.strategy.SourceProperty is not null)
+        {
+            return this.AppendDirectSourcePropertyRead(builder, source, context);
+        }
+
+        return string.Empty;
+    }
+
+    private string AppendChainedSourcePropertyRead(PrettyCode.StringBuilder builder, string source, MappaBuilderContext context)
+    {
+        var chainedSourcePropertyPath = this.strategy.ChainedSourcePropertyPath;
+        if (chainedSourcePropertyPath is null)
+        {
+            return string.Empty;
+        }
+
+        var chainSource = source;
+        var rootParameterName = context.GetMapMethod().SourceParameterName;
+        var receiverPathPrefix = chainedSourcePropertyPath.ReceiverPathPrefix;
+
+        if (!string.IsNullOrWhiteSpace(receiverPathPrefix)
+            && (receiverPathPrefix.Equals(rootParameterName, StringComparison.Ordinal)
+                || receiverPathPrefix.StartsWith($"{rootParameterName}.", StringComparison.Ordinal)))
+        {
+            chainSource = rootParameterName;
+        }
+
+        var accessExpression = PropertyPathExpressionBuilder.BuildChainedAccessExpression(
+            chainSource,
+            receiverPathPrefix,
+            chainedSourcePropertyPath.RemainingSourceSegments,
+            chainedSourcePropertyPath.StartingSourceType,
+            context.GetMapMethod().NullableEnabled,
+            this.strategy.TargetProperty.Type,
+            out var resolvedProperties,
+            chainedSourcePropertyPath.OriginalSourcePath);
+
+        var innermostSourceType = ResolveInnermostChainedSourceType(
+            chainedSourcePropertyPath,
+            chainSource,
+            receiverPathPrefix,
+            resolvedProperties);
+
+        var sourcePropertyTemporary = context.NextTemporary();
+        builder.AppendLine($"{innermostSourceType.ToDisplayString()} {sourcePropertyTemporary} = {accessExpression};");
+        return sourcePropertyTemporary;
+    }
+
+    private string AppendDirectSourcePropertyRead(PrettyCode.StringBuilder builder, string source, MappaBuilderContext context)
+    {
+        if (this.strategy.SourceProperty is not { } sourceProperty)
+        {
+            return string.Empty;
+        }
+
+        var sourcePropertyTemporary = context.NextTemporary();
+        var sourceReadExpression = InaccessibleMemberAccessHelper.BuildPropertyReadExpression(
+            source,
+            sourceProperty,
+            this.strategy.RequiresUnsafeAccessorOnSource,
+            context);
+        builder.AppendLine($"{sourceProperty.Type.ToDisplayString()} {sourcePropertyTemporary} = {sourceReadExpression};");
+        return sourcePropertyTemporary;
     }
 }

--- a/Mappa.Generator/Extensions/AttributeDataExtensions.cs
+++ b/Mappa.Generator/Extensions/AttributeDataExtensions.cs
@@ -44,6 +44,346 @@ internal static class AttributeDataExtensions
     private const string MappaAttributeFullName = "Mappa.Attributes.MappaAttribute";
     private const string MappaDependencyInjectionAttributeFullName = "Mappa.Attributes.MappaDependencyInjectionAttribute";
 
+    private static readonly Dictionary<string, Action<MappaSettingsAttribute, TypedConstant>> MappaSettingsNamedArgumentApplicators =
+        new(StringComparer.Ordinal)
+        {
+            [nameof(MappaSettingsAttribute.DateTimeFormat)] = static (attribute, constant) =>
+            {
+                if (constant.Value is string value)
+                {
+                    attribute.DateTimeFormat = value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.DateTimeOffsetFormat)] = static (attribute, constant) =>
+            {
+                if (constant.Value is string value)
+                {
+                    attribute.DateTimeOffsetFormat = value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.DateOnlyFormat)] = static (attribute, constant) =>
+            {
+                if (constant.Value is string value)
+                {
+                    attribute.DateOnlyFormat = value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.TimeOnlyFormat)] = static (attribute, constant) =>
+            {
+                if (constant.Value is string value)
+                {
+                    attribute.TimeOnlyFormat = value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.DateTimeStyle)] = static (attribute, constant) =>
+                attribute.DateTimeStyle = ReadDateTimeStyles(constant),
+            [nameof(MappaSettingsAttribute.DateTimeOffsetStyle)] = static (attribute, constant) =>
+                attribute.DateTimeOffsetStyle = ReadDateTimeStyles(constant),
+            [nameof(MappaSettingsAttribute.DateOnlyStyle)] = static (attribute, constant) =>
+                attribute.DateOnlyStyle = ReadDateTimeStyles(constant),
+            [nameof(MappaSettingsAttribute.TimeOnlyStyle)] = static (attribute, constant) =>
+                attribute.TimeOnlyStyle = ReadDateTimeStyles(constant),
+            [nameof(MappaSettingsAttribute.GlobalDateTimeStyle)] = static (attribute, constant) =>
+                attribute.GlobalDateTimeStyle = ReadDateTimeStyles(constant),
+            [nameof(MappaSettingsAttribute.TimeSpanFormat)] = static (attribute, constant) =>
+            {
+                if (constant.Value is string value)
+                {
+                    attribute.TimeSpanFormat = value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.GuidFormat)] = static (attribute, constant) =>
+            {
+                if (constant.Value is string value)
+                {
+                    attribute.GuidFormat = value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.ByteFormat)] = static (attribute, constant) =>
+            {
+                if (constant.Value is string value)
+                {
+                    attribute.ByteFormat = value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.SByteFormat)] = static (attribute, constant) =>
+            {
+                if (constant.Value is string value)
+                {
+                    attribute.SByteFormat = value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.ShortFormat)] = static (attribute, constant) =>
+            {
+                if (constant.Value is string value)
+                {
+                    attribute.ShortFormat = value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.UShortFormat)] = static (attribute, constant) =>
+            {
+                if (constant.Value is string value)
+                {
+                    attribute.UShortFormat = value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.IntFormat)] = static (attribute, constant) =>
+            {
+                if (constant.Value is string value)
+                {
+                    attribute.IntFormat = value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.UIntFormat)] = static (attribute, constant) =>
+            {
+                if (constant.Value is string value)
+                {
+                    attribute.UIntFormat = value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.LongFormat)] = static (attribute, constant) =>
+            {
+                if (constant.Value is string value)
+                {
+                    attribute.LongFormat = value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.ULongFormat)] = static (attribute, constant) =>
+            {
+                if (constant.Value is string value)
+                {
+                    attribute.ULongFormat = value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.DecimalFormat)] = static (attribute, constant) =>
+            {
+                if (constant.Value is string value)
+                {
+                    attribute.DecimalFormat = value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.FloatFormat)] = static (attribute, constant) =>
+            {
+                if (constant.Value is string value)
+                {
+                    attribute.FloatFormat = value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.DoubleFormat)] = static (attribute, constant) =>
+            {
+                if (constant.Value is string value)
+                {
+                    attribute.DoubleFormat = value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.ByteStyle)] = static (attribute, constant) =>
+                attribute.ByteStyle = ReadNumberStyles(constant),
+            [nameof(MappaSettingsAttribute.SByteStyle)] = static (attribute, constant) =>
+                attribute.SByteStyle = ReadNumberStyles(constant),
+            [nameof(MappaSettingsAttribute.ShortStyle)] = static (attribute, constant) =>
+                attribute.ShortStyle = ReadNumberStyles(constant),
+            [nameof(MappaSettingsAttribute.UShortStyle)] = static (attribute, constant) =>
+                attribute.UShortStyle = ReadNumberStyles(constant),
+            [nameof(MappaSettingsAttribute.IntStyle)] = static (attribute, constant) =>
+                attribute.IntStyle = ReadNumberStyles(constant),
+            [nameof(MappaSettingsAttribute.UIntStyle)] = static (attribute, constant) =>
+                attribute.UIntStyle = ReadNumberStyles(constant),
+            [nameof(MappaSettingsAttribute.LongStyle)] = static (attribute, constant) =>
+                attribute.LongStyle = ReadNumberStyles(constant),
+            [nameof(MappaSettingsAttribute.ULongStyle)] = static (attribute, constant) =>
+                attribute.ULongStyle = ReadNumberStyles(constant),
+            [nameof(MappaSettingsAttribute.DecimalStyle)] = static (attribute, constant) =>
+                attribute.DecimalStyle = ReadNumberStyles(constant),
+            [nameof(MappaSettingsAttribute.FloatStyle)] = static (attribute, constant) =>
+                attribute.FloatStyle = ReadNumberStyles(constant),
+            [nameof(MappaSettingsAttribute.DoubleStyle)] = static (attribute, constant) =>
+                attribute.DoubleStyle = ReadNumberStyles(constant),
+            [nameof(MappaSettingsAttribute.GlobalNumberStyle)] = static (attribute, constant) =>
+                attribute.GlobalNumberStyle = ReadNumberStyles(constant),
+            [nameof(MappaSettingsAttribute.CultureName)] = static (attribute, constant) =>
+            {
+                if (constant.Value is string value)
+                {
+                    attribute.CultureName = value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.CultureInfoSetting)] = static (attribute, constant) =>
+            {
+                if (constant.Value is int value)
+                {
+                    attribute.CultureInfoSetting = (CultureInfoSetting)value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.ProtobufOptional)] = static (attribute, constant) =>
+            {
+                if (constant.Value is int value)
+                {
+                    attribute.ProtobufOptional = (BooleanSetting)value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.PragmaWarning)] = static (attribute, constant) =>
+            {
+                if (constant.Value is int value)
+                {
+                    attribute.PragmaWarning = (PragmaWarningSetting)value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.FastCollections)] = static (attribute, constant) =>
+            {
+                if (constant.Value is int value)
+                {
+                    attribute.FastCollections = (BooleanSetting)value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.ContainerCapacityConstructors)] = static (attribute, constant) =>
+            {
+                if (constant.Value is int value)
+                {
+                    attribute.ContainerCapacityConstructors = (BooleanSetting)value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.PreventEnumerableCount)] = static (attribute, constant) =>
+            {
+                if (constant.Value is int value)
+                {
+                    attribute.PreventEnumerableCount = (BooleanSetting)value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.PolymorphicMapMethodWithMatchingDefaultAttribute)] = static (attribute, constant) =>
+            {
+                if (constant.Value is int value)
+                {
+                    attribute.PolymorphicMapMethodWithMatchingDefaultAttribute = (BooleanSetting)value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.CompatibleMapMethod)] = static (attribute, constant) =>
+            {
+                if (constant.Value is int value)
+                {
+                    attribute.CompatibleMapMethod = (BooleanSetting)value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.CaseInsensitivePropertyMap)] = static (attribute, constant) =>
+            {
+                if (constant.Value is int value)
+                {
+                    attribute.CaseInsensitivePropertyMap = (BooleanSetting)value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.IgnoreUnderscoreForPropertyMap)] = static (attribute, constant) =>
+            {
+                if (constant.Value is int value)
+                {
+                    attribute.IgnoreUnderscoreForPropertyMap = (BooleanSetting)value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.CaseInsensitiveEnumMap)] = static (attribute, constant) =>
+            {
+                if (constant.Value is int value)
+                {
+                    attribute.CaseInsensitiveEnumMap = (BooleanSetting)value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.EnumStringMapSetting)] = static (attribute, constant) =>
+            {
+                if (constant.Value is int value)
+                {
+                    attribute.EnumStringMapSetting = (EnumStringMapSetting)value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.EnumToEnumMapSetting)] = static (attribute, constant) =>
+            {
+                if (constant.Value is int value)
+                {
+                    attribute.EnumToEnumMapSetting = (EnumToEnumMapSetting)value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.IdentityMapDeepCopy)] = static (attribute, constant) =>
+            {
+                if (constant.Value is int value)
+                {
+                    attribute.IdentityMapDeepCopy = (IdentityMapDeepCopySetting)value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.EnumerableConcreteType)] = static (attribute, constant) =>
+            {
+                if (constant.Value is int value)
+                {
+                    attribute.EnumerableConcreteType = (EnumerableConcreteTypeSetting)value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.DictionaryAssignment)] = static (attribute, constant) =>
+            {
+                if (constant.Value is int value)
+                {
+                    attribute.DictionaryAssignment = (DictionaryAssignmentSetting)value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.ReferenceReusing)] = static (attribute, constant) =>
+            {
+                if (constant.Value is int value)
+                {
+                    attribute.ReferenceReusing = (BooleanSetting)value;
+                }
+            },
+            [nameof(MappaSettingsAttribute.MaxRuntimeDepth)] = static (attribute, constant) =>
+                attribute.MaxRuntimeDepth = ReadDepth(constant),
+            [nameof(MappaSettingsAttribute.MaxCompileTimeDepth)] = static (attribute, constant) =>
+                attribute.MaxCompileTimeDepth = ReadDepth(constant),
+            [nameof(MappaSettingsAttribute.BreakCompileTimeCycles)] = static (attribute, constant) =>
+            {
+                if (constant.Value is int value)
+                {
+                    attribute.BreakCompileTimeCycles = (BooleanSetting)value;
+                }
+            },
+        };
+
+    private static readonly Dictionary<string, Action<MappaDependencyInjectionNamedArgumentValues, TypedConstant>>
+        MappaDependencyInjectionNamedArgumentApplicators =
+            new(StringComparer.Ordinal)
+            {
+                [nameof(MappaDependencyInjectionAttribute.ExtensionMethod)] = static (values, constant) =>
+                {
+                    if (constant.Value is bool extensionMethodValue)
+                    {
+                        values.ExtensionMethod = extensionMethodValue;
+                    }
+                },
+                [nameof(MappaDependencyInjectionAttribute.MethodName)] = static (values, constant) =>
+                {
+                    if (constant.Value is string methodNameValue)
+                    {
+                        values.MethodName = methodNameValue;
+                    }
+                },
+                [nameof(MappaDependencyInjectionAttribute.Accessibility)] = static (values, constant) =>
+                {
+                    if (TryReadEnum(constant, out MappaDependencyInjectionMethodAccessibility accessibilityValue))
+                    {
+                        values.Accessibility = accessibilityValue;
+                    }
+                },
+                [nameof(MappaDependencyInjectionAttribute.ServiceLifetime)] = static (values, constant) =>
+                {
+                    if (TryReadEnum(constant, out MappaDependencyInjectionServiceLifetime serviceLifetimeValue))
+                    {
+                        values.ServiceLifetime = serviceLifetimeValue;
+                    }
+                },
+                [nameof(MappaDependencyInjectionAttribute.InjectInterfaces)] = static (values, constant) =>
+                {
+                    if (TryReadEnum(constant, out MappaDependencyInjectionInjectInterfaces injectInterfacesValue))
+                    {
+                        values.InjectInterfaces = injectInterfacesValue;
+                    }
+                },
+                [nameof(MappaDependencyInjectionAttribute.IgnoreType)] = static (values, constant) =>
+                    values.IgnoreTypes = ReadNamedTypeArray(constant),
+                [nameof(MappaDependencyInjectionAttribute.InjectFromAssemblies)] = static (values, constant) =>
+                    values.InjectFromAssemblies = ReadNamedTypeArray(constant),
+            };
+
     /// <summary>
     /// Gets the <see cref="MappaMapEnumMemberAttribute{TEnum}"/> and
     /// <see cref="MappaMapEnumMemberAttribute{TEnum, TOtherEnum}"/> declarations applied to the method.
@@ -59,44 +399,12 @@ internal static class AttributeDataExtensions
 
         foreach (var attributeData in attributes)
         {
-            if (attributeData.AttributeClass is not { } attributeClass
-                || attributeData.ConstructorArguments.Length != 2)
+            if (TryParseEnumMapMemberAttribute(
+                    attributeData,
+                    enumMemberAttributeSymbol,
+                    enumMemberToEnumAttributeSymbol) is { } enumMapMember)
             {
-                continue;
-            }
-
-            var constructorArguments = attributeData.ConstructorArguments;
-            if (IsAttribute(attributeClass, enumMemberAttributeSymbol)
-                && GetEnumTypeArgument(attributeClass, 1, 0) is { } enumType
-                && GetEnumMemberName(constructorArguments[0]) is { } enumMemberName)
-            {
-                switch (constructorArguments[1].Value)
-                {
-                    case string stringValue:
-                        results.Add(new EnumMapMemberInfoAttribute(enumType, enumMemberName, null, stringValue, null, null));
-                        break;
-
-                    case int integerValue:
-                        results.Add(new EnumMapMemberInfoAttribute(enumType, enumMemberName, integerValue, null, null, null));
-                        break;
-                }
-
-                continue;
-            }
-
-            if (IsAttribute(attributeClass, enumMemberToEnumAttributeSymbol)
-                && GetEnumTypeArgument(attributeClass, 2, 0) is { } firstEnumType
-                && GetEnumTypeArgument(attributeClass, 2, 1) is { } secondEnumType
-                && GetEnumMemberName(constructorArguments[0]) is { } firstEnumMemberName
-                && GetEnumMemberName(constructorArguments[1]) is { } secondEnumMemberName)
-            {
-                results.Add(new EnumMapMemberInfoAttribute(
-                    firstEnumType,
-                    firstEnumMemberName,
-                    null,
-                    null,
-                    secondEnumType,
-                    secondEnumMemberName));
+                results.Add(enumMapMember);
             }
         }
 
@@ -144,47 +452,9 @@ internal static class AttributeDataExtensions
 
         foreach (var attributeData in attributes)
         {
-            if (attributeData.AttributeClass is not { } attributeClass
-                || !IsAttribute(attributeClass, enumDefaultAttributeSymbol)
-                || GetEnumTypeArgument(attributeClass, 1, 0) is not { } enumType)
+            if (TryParseEnumMapDefaultAttribute(attributeData, enumDefaultAttributeSymbol) is { } enumMapDefault)
             {
-                continue;
-            }
-
-            var constructorArguments = attributeData.ConstructorArguments;
-            if (constructorArguments.Length == 0
-                || constructorArguments[0].Value is not int behaviorValue)
-            {
-                continue;
-            }
-
-            var behavior = (MappaMapEnumDefaultBehavior)behaviorValue;
-            if (constructorArguments.Length == 1)
-            {
-                results.Add(new EnumMapDefaultInfoAttribute(enumType, behavior, null, null, null));
-                continue;
-            }
-
-            var defaultValue = constructorArguments[1];
-            if (defaultValue.Type is INamedTypeSymbol { TypeKind: TypeKind.Enum })
-            {
-                if (GetEnumMemberName(defaultValue) is { } enumDefaultMemberName)
-                {
-                    results.Add(new EnumMapDefaultInfoAttribute(enumType, behavior, enumDefaultMemberName, null, null));
-                }
-
-                continue;
-            }
-
-            switch (defaultValue.Value)
-            {
-                case string stringDefaultValue:
-                    results.Add(new EnumMapDefaultInfoAttribute(enumType, behavior, null, null, stringDefaultValue));
-                    break;
-
-                case int integerDefaultValue:
-                    results.Add(new EnumMapDefaultInfoAttribute(enumType, behavior, null, integerDefaultValue, null));
-                    break;
+                results.Add(enumMapDefault);
             }
         }
 
@@ -224,19 +494,7 @@ internal static class AttributeDataExtensions
                 continue;
             }
 
-            var constructorArguments = attributeData.ConstructorArguments;
-            attribute = constructorArguments.Length switch
-            {
-                1 when constructorArguments[0].Value is string methodName
-                    => new MappaTypeMappingDefaultAttribute(methodName),
-                1 when constructorArguments[0].Value is int behavior
-                    => new MappaTypeMappingDefaultAttribute((MappaTypeMappingDefaultBehavior)behavior),
-                2 when constructorArguments[0].Value is INamedTypeSymbol invokeType && constructorArguments[1].Value is string methodName
-                    => new MappaTypeMappingDefaultAttribute(new FakeType(invokeType.ToDisplayString()), methodName),
-                2 when constructorArguments[0].Value is int behavior && constructorArguments[1].Value is INamedTypeSymbol type
-                    => new MappaTypeMappingDefaultAttribute((MappaTypeMappingDefaultBehavior)behavior, new FakeType(type.ToDisplayString())),
-                _ => null,
-            };
+            attribute = CreateMappaTypeMappingDefaultFromConstructorArguments(attributeData.ConstructorArguments);
         }
 
         return attribute;
@@ -256,32 +514,12 @@ internal static class AttributeDataExtensions
 
         foreach (var attributeData in attributes)
         {
-            if (attributeData.AttributeClass is not { } attributeClass)
+            if (TryParseTypeMappingAttribute(
+                    attributeData,
+                    mappaTypeMappingAttributeSymbol,
+                    mappaTypeMappingAttributeOfTSymbol) is { } typeMapping)
             {
-                continue;
-            }
-
-            if (IsAttribute(attributeClass, mappaTypeMappingAttributeOfTSymbol)
-                && GetEnumTypeArgument(attributeClass, 2, 0) is { } genericTargetType
-                && GetEnumTypeArgument(attributeClass, 2, 1) is { } genericSourceType)
-            {
-                results.Add(new MappaTypeMappingAttribute(
-                    new FakeType(genericTargetType.ToDisplayString()),
-                    new FakeType(genericSourceType.ToDisplayString())));
-                continue;
-            }
-
-            if (!SymbolEqualityComparer.Default.Equals(attributeClass, mappaTypeMappingAttributeSymbol))
-            {
-                continue;
-            }
-
-            var constructorArguments = attributeData.ConstructorArguments;
-            if (constructorArguments.Length == 2
-                && constructorArguments[0].Value is INamedTypeSymbol targetType
-                && constructorArguments[1].Value is INamedTypeSymbol sourceType)
-            {
-                results.Add(new MappaTypeMappingAttribute(new FakeType(targetType.ToDisplayString()), new FakeType(sourceType.ToDisplayString())));
+                results.Add(typeMapping);
             }
         }
 
@@ -301,50 +539,9 @@ internal static class AttributeDataExtensions
         foreach (var attributeData in attributes
                      .Where(attribute => SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, mappaInvokeMethodAttributeSymbol)))
         {
-            MappaInvokeMethodAttribute? attribute = null;
-            var constructorArguments = attributeData.ConstructorArguments;
-            switch (constructorArguments.Length)
-            {
-                case 2: // (targetPropertyName, methodName)
-                    {
-                        if (constructorArguments[0].Value is string targetParameterName &&
-                            constructorArguments[1].Value is string methodName)
-                        {
-                            attribute = new MappaInvokeMethodAttribute(targetParameterName, methodName);
-                        }
-                    }
-
-                    break;
-
-                case 3: // (targetPropertyName, classType, methodName) or (targetPropertyName, fieldName, methodName)
-                    {
-                        if (constructorArguments[0].Value is string targetParameterName &&
-                            constructorArguments[2].Value is string methodName)
-                        {
-                            attribute = constructorArguments[1].Value switch
-                            {
-                                string fieldName => new MappaInvokeMethodAttribute(targetParameterName, fieldName, methodName),
-                                INamedTypeSymbol classType => new MappaInvokeMethodAttribute(targetParameterName, new FakeType(classType.ToDisplayString()), methodName),
-                                _ => null,
-                            };
-                        }
-                    }
-
-                    break;
-            }
-
-            if (attribute is null)
+            if (TryCreateInvokeMethodAttribute(attributeData) is not { } attribute)
             {
                 continue;
-            }
-
-            foreach (var namedArgument in attributeData.NamedArguments)
-            {
-                if (namedArgument.Key == nameof(MappaInvokeMethodAttribute.SourcePropertyName) &&
-                    namedArgument.Value.Value is string sourcePropertyName)
-                {
-                    attribute.SourcePropertyName = sourcePropertyName;
-                }
             }
 
             results.Add(attribute);
@@ -393,42 +590,9 @@ internal static class AttributeDataExtensions
         foreach (var attributeData in attributes
                      .Where(attribute => SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, attributeSymbol)))
         {
-            var constructorArguments = attributeData.ConstructorArguments;
-            var location = attributeData.ApplicationSyntaxReference?.GetSyntax().GetLocation();
-            if (constructorArguments.Length == 2 &&
-                constructorArguments[0].Value is INamedTypeSymbol targetType &&
-                constructorArguments[1].Value is string methodName)
+            if (TryCreateMappaObjectFactoryAttributeData(attributeData) is { } factoryAttribute)
             {
-                results.Add(new MappaObjectFactoryAttributeData(
-                    targetType,
-                    methodName,
-                    null,
-                    null,
-                    location));
-            }
-            else if (constructorArguments.Length == 3 &&
-                     constructorArguments[0].Value is INamedTypeSymbol factoryTargetType &&
-                     constructorArguments[2].Value is string factoryMethodName)
-            {
-                switch (constructorArguments[1].Value)
-                {
-                    case string fieldName:
-                        results.Add(new MappaObjectFactoryAttributeData(
-                            factoryTargetType,
-                            factoryMethodName,
-                            null,
-                            fieldName,
-                            location));
-                        break;
-                    case INamedTypeSymbol classType:
-                        results.Add(new MappaObjectFactoryAttributeData(
-                            factoryTargetType,
-                            factoryMethodName,
-                            new FakeType(classType.ToDisplayString()),
-                            null,
-                            location));
-                        break;
-                }
+                results.Add(factoryAttribute);
             }
         }
 
@@ -554,265 +718,10 @@ internal static class AttributeDataExtensions
         var attribute = new MappaSettingsAttribute();
         foreach (var namedArgument in attributeData.NamedArguments)
         {
-            switch (namedArgument.Key)
-            {
-                case nameof(MappaSettingsAttribute.DateTimeFormat) when namedArgument.Value.Value is string value:
-                    attribute.DateTimeFormat = value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.DateTimeOffsetFormat) when namedArgument.Value.Value is string value:
-                    attribute.DateTimeOffsetFormat = value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.DateOnlyFormat) when namedArgument.Value.Value is string value:
-                    attribute.DateOnlyFormat = value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.TimeOnlyFormat) when namedArgument.Value.Value is string value:
-                    attribute.TimeOnlyFormat = value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.DateTimeStyle):
-                    attribute.DateTimeStyle = ReadDateTimeStyles(namedArgument.Value);
-                    break;
-
-                case nameof(MappaSettingsAttribute.DateTimeOffsetStyle):
-                    attribute.DateTimeOffsetStyle = ReadDateTimeStyles(namedArgument.Value);
-                    break;
-
-                case nameof(MappaSettingsAttribute.DateOnlyStyle):
-                    attribute.DateOnlyStyle = ReadDateTimeStyles(namedArgument.Value);
-                    break;
-
-                case nameof(MappaSettingsAttribute.TimeOnlyStyle):
-                    attribute.TimeOnlyStyle = ReadDateTimeStyles(namedArgument.Value);
-                    break;
-
-                case nameof(MappaSettingsAttribute.GlobalDateTimeStyle):
-                    attribute.GlobalDateTimeStyle = ReadDateTimeStyles(namedArgument.Value);
-                    break;
-
-                case nameof(MappaSettingsAttribute.TimeSpanFormat) when namedArgument.Value.Value is string value:
-                    attribute.TimeSpanFormat = value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.GuidFormat) when namedArgument.Value.Value is string value:
-                    attribute.GuidFormat = value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.ByteFormat) when namedArgument.Value.Value is string value:
-                    attribute.ByteFormat = value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.SByteFormat) when namedArgument.Value.Value is string value:
-                    attribute.SByteFormat = value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.ShortFormat) when namedArgument.Value.Value is string value:
-                    attribute.ShortFormat = value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.UShortFormat) when namedArgument.Value.Value is string value:
-                    attribute.UShortFormat = value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.IntFormat) when namedArgument.Value.Value is string value:
-                    attribute.IntFormat = value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.UIntFormat) when namedArgument.Value.Value is string value:
-                    attribute.UIntFormat = value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.LongFormat) when namedArgument.Value.Value is string value:
-                    attribute.LongFormat = value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.ULongFormat) when namedArgument.Value.Value is string value:
-                    attribute.ULongFormat = value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.DecimalFormat) when namedArgument.Value.Value is string value:
-                    attribute.DecimalFormat = value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.FloatFormat) when namedArgument.Value.Value is string value:
-                    attribute.FloatFormat = value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.DoubleFormat) when namedArgument.Value.Value is string value:
-                    attribute.DoubleFormat = value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.ByteStyle):
-                    attribute.ByteStyle = ReadNumberStyles(namedArgument.Value);
-                    break;
-
-                case nameof(MappaSettingsAttribute.SByteStyle):
-                    attribute.SByteStyle = ReadNumberStyles(namedArgument.Value);
-                    break;
-
-                case nameof(MappaSettingsAttribute.ShortStyle):
-                    attribute.ShortStyle = ReadNumberStyles(namedArgument.Value);
-                    break;
-
-                case nameof(MappaSettingsAttribute.UShortStyle):
-                    attribute.UShortStyle = ReadNumberStyles(namedArgument.Value);
-                    break;
-
-                case nameof(MappaSettingsAttribute.IntStyle):
-                    attribute.IntStyle = ReadNumberStyles(namedArgument.Value);
-                    break;
-
-                case nameof(MappaSettingsAttribute.UIntStyle):
-                    attribute.UIntStyle = ReadNumberStyles(namedArgument.Value);
-                    break;
-
-                case nameof(MappaSettingsAttribute.LongStyle):
-                    attribute.LongStyle = ReadNumberStyles(namedArgument.Value);
-                    break;
-
-                case nameof(MappaSettingsAttribute.ULongStyle):
-                    attribute.ULongStyle = ReadNumberStyles(namedArgument.Value);
-                    break;
-
-                case nameof(MappaSettingsAttribute.DecimalStyle):
-                    attribute.DecimalStyle = ReadNumberStyles(namedArgument.Value);
-                    break;
-
-                case nameof(MappaSettingsAttribute.FloatStyle):
-                    attribute.FloatStyle = ReadNumberStyles(namedArgument.Value);
-                    break;
-
-                case nameof(MappaSettingsAttribute.DoubleStyle):
-                    attribute.DoubleStyle = ReadNumberStyles(namedArgument.Value);
-                    break;
-
-                case nameof(MappaSettingsAttribute.GlobalNumberStyle):
-                    attribute.GlobalNumberStyle = ReadNumberStyles(namedArgument.Value);
-                    break;
-
-                case nameof(MappaSettingsAttribute.CultureName) when namedArgument.Value.Value is string value:
-                    attribute.CultureName = value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.CultureInfoSetting) when namedArgument.Value.Value is int value:
-                    attribute.CultureInfoSetting = (CultureInfoSetting)value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.ProtobufOptional) when namedArgument.Value.Value is int value:
-                    attribute.ProtobufOptional = (BooleanSetting)value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.PragmaWarning) when namedArgument.Value.Value is int value:
-                    attribute.PragmaWarning = (PragmaWarningSetting)value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.FastCollections) when namedArgument.Value.Value is int value:
-                    attribute.FastCollections = (BooleanSetting)value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.ContainerCapacityConstructors) when namedArgument.Value.Value is int value:
-                    attribute.ContainerCapacityConstructors = (BooleanSetting)value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.PreventEnumerableCount) when namedArgument.Value.Value is int value:
-                    attribute.PreventEnumerableCount = (BooleanSetting)value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.PolymorphicMapMethodWithMatchingDefaultAttribute) when namedArgument.Value.Value is int value:
-                    attribute.PolymorphicMapMethodWithMatchingDefaultAttribute = (BooleanSetting)value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.CompatibleMapMethod) when namedArgument.Value.Value is int value:
-                    attribute.CompatibleMapMethod = (BooleanSetting)value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.CaseInsensitivePropertyMap) when namedArgument.Value.Value is int value:
-                    attribute.CaseInsensitivePropertyMap = (BooleanSetting)value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.IgnoreUnderscoreForPropertyMap) when namedArgument.Value.Value is int value:
-                    attribute.IgnoreUnderscoreForPropertyMap = (BooleanSetting)value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.CaseInsensitiveEnumMap) when namedArgument.Value.Value is int value:
-                    attribute.CaseInsensitiveEnumMap = (BooleanSetting)value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.EnumStringMapSetting) when namedArgument.Value.Value is int value:
-                    attribute.EnumStringMapSetting = (EnumStringMapSetting)value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.EnumToEnumMapSetting) when namedArgument.Value.Value is int value:
-                    attribute.EnumToEnumMapSetting = (EnumToEnumMapSetting)value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.IdentityMapDeepCopy) when namedArgument.Value.Value is int value:
-                    attribute.IdentityMapDeepCopy = (IdentityMapDeepCopySetting)value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.EnumerableConcreteType) when namedArgument.Value.Value is int value:
-                    attribute.EnumerableConcreteType = (EnumerableConcreteTypeSetting)value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.DictionaryAssignment) when namedArgument.Value.Value is int value:
-                    attribute.DictionaryAssignment = (DictionaryAssignmentSetting)value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.ReferenceReusing) when namedArgument.Value.Value is int value:
-                    attribute.ReferenceReusing = (BooleanSetting)value;
-                    break;
-
-                case nameof(MappaSettingsAttribute.MaxRuntimeDepth):
-                    attribute.MaxRuntimeDepth = ReadDepth(namedArgument.Value);
-                    break;
-
-                case nameof(MappaSettingsAttribute.MaxCompileTimeDepth):
-                    attribute.MaxCompileTimeDepth = ReadDepth(namedArgument.Value);
-                    break;
-
-                case nameof(MappaSettingsAttribute.BreakCompileTimeCycles) when namedArgument.Value.Value is int value:
-                    attribute.BreakCompileTimeCycles = (BooleanSetting)value;
-                    break;
-            }
+            ApplyMappaSettingsNamedArgument(attribute, namedArgument);
         }
 
         return attribute;
-
-        static DateTimeStyles ReadDateTimeStyles(TypedConstant typedConstant)
-        {
-            return typedConstant.Value switch
-            {
-                null => MappaSettingsAttribute.UndefinedDateTimeStyle,
-                int intValue => (DateTimeStyles)intValue,
-                DateTimeStyles dateTimeStyles => dateTimeStyles,
-                _ => MappaSettingsAttribute.UndefinedDateTimeStyle,
-            };
-        }
-
-        static NumberStyles ReadNumberStyles(TypedConstant typedConstant)
-        {
-            return typedConstant.Value switch
-            {
-                null => MappaSettingsAttribute.UndefinedNumberStyle,
-                int intValue => (NumberStyles)intValue,
-                NumberStyles numberStyles => numberStyles,
-                _ => MappaSettingsAttribute.UndefinedNumberStyle,
-            };
-        }
-
-        static short ReadDepth(TypedConstant typedConstant)
-        {
-            return typedConstant.Value switch
-            {
-                null => MappaSettingsAttribute.UndefinedDepth,
-                short shortValue => shortValue,
-                int intValue => (short)intValue,
-                long longValue => (short)longValue,
-                _ => MappaSettingsAttribute.UndefinedDepth,
-            };
-        }
     }
 
     /// <summary>
@@ -1035,64 +944,434 @@ internal static class AttributeDataExtensions
             constructorMethodName = constructorName;
         }
 
-        var extensionMethod = true;
-        string? methodName = null;
-        var accessibility = MappaDependencyInjectionMethodAccessibility.Public;
-        var serviceLifetime = MappaDependencyInjectionServiceLifetime.Singleton;
-        var injectInterfaces = MappaDependencyInjectionInjectInterfaces.ClassOnly;
-        var ignoreTypes = ImmutableArray<INamedTypeSymbol>.Empty;
-        var injectFromAssemblies = ImmutableArray<INamedTypeSymbol>.Empty;
-
+        var namedArgumentValues = new MappaDependencyInjectionNamedArgumentValues();
         foreach (var namedArgument in attributeData.NamedArguments)
         {
-            switch (namedArgument.Key)
-            {
-                case nameof(MappaDependencyInjectionAttribute.ExtensionMethod)
-                    when namedArgument.Value.Value is bool extensionMethodValue:
-                    extensionMethod = extensionMethodValue;
-                    break;
-
-                case nameof(MappaDependencyInjectionAttribute.MethodName)
-                    when namedArgument.Value.Value is string methodNameValue:
-                    methodName = methodNameValue;
-                    break;
-
-                case nameof(MappaDependencyInjectionAttribute.Accessibility)
-                    when TryReadEnum(namedArgument.Value, out MappaDependencyInjectionMethodAccessibility accessibilityValue):
-                    accessibility = accessibilityValue;
-                    break;
-
-                case nameof(MappaDependencyInjectionAttribute.ServiceLifetime)
-                    when TryReadEnum(namedArgument.Value, out MappaDependencyInjectionServiceLifetime serviceLifetimeValue):
-                    serviceLifetime = serviceLifetimeValue;
-                    break;
-
-                case nameof(MappaDependencyInjectionAttribute.InjectInterfaces)
-                    when TryReadEnum(namedArgument.Value, out MappaDependencyInjectionInjectInterfaces injectInterfacesValue):
-                    injectInterfaces = injectInterfacesValue;
-                    break;
-
-                case nameof(MappaDependencyInjectionAttribute.IgnoreType):
-                    ignoreTypes = ReadNamedTypeArray(namedArgument.Value);
-                    break;
-
-                case nameof(MappaDependencyInjectionAttribute.InjectFromAssemblies):
-                    injectFromAssemblies = ReadNamedTypeArray(namedArgument.Value);
-                    break;
-            }
+            ApplyMappaDependencyInjectionNamedArgument(namedArgumentValues, namedArgument);
         }
 
         var location = attributeData.ApplicationSyntaxReference?.GetSyntax().GetLocation();
         return new MappaDependencyInjectionAttributeData(
             constructorMethodName,
-            methodName,
-            extensionMethod,
-            accessibility,
-            serviceLifetime,
-            injectInterfaces,
-            ignoreTypes,
-            injectFromAssemblies,
+            namedArgumentValues.MethodName,
+            namedArgumentValues.ExtensionMethod,
+            namedArgumentValues.Accessibility,
+            namedArgumentValues.ServiceLifetime,
+            namedArgumentValues.InjectInterfaces,
+            namedArgumentValues.IgnoreTypes,
+            namedArgumentValues.InjectFromAssemblies,
             location);
+    }
+
+    private static void ApplyMappaSettingsNamedArgument(
+        MappaSettingsAttribute attribute,
+        KeyValuePair<string, TypedConstant> namedArgument)
+    {
+        if (MappaSettingsNamedArgumentApplicators.TryGetValue(namedArgument.Key, out var apply))
+        {
+            apply(attribute, namedArgument.Value);
+        }
+    }
+
+    private static void ApplyMappaDependencyInjectionNamedArgument(
+        MappaDependencyInjectionNamedArgumentValues values,
+        KeyValuePair<string, TypedConstant> namedArgument)
+    {
+        if (MappaDependencyInjectionNamedArgumentApplicators.TryGetValue(namedArgument.Key, out var apply))
+        {
+            apply(values, namedArgument.Value);
+        }
+    }
+
+    private static EnumMapMemberInfoAttribute? TryParseEnumMapMemberAttribute(
+        AttributeData attributeData,
+        INamedTypeSymbol? enumMemberAttributeSymbol,
+        INamedTypeSymbol? enumMemberToEnumAttributeSymbol)
+    {
+        if (attributeData.AttributeClass is not { } attributeClass
+            || attributeData.ConstructorArguments.Length != 2)
+        {
+            return null;
+        }
+
+        var constructorArguments = attributeData.ConstructorArguments;
+        var singleEnumResult = TryParseSingleEnumMapMemberAttribute(
+            attributeClass,
+            enumMemberAttributeSymbol,
+            constructorArguments);
+        if (singleEnumResult is not null)
+        {
+            return singleEnumResult;
+        }
+
+        return TryParseEnumToEnumMapMemberAttribute(
+            attributeClass,
+            enumMemberToEnumAttributeSymbol,
+            constructorArguments);
+    }
+
+    private static EnumMapMemberInfoAttribute? TryParseSingleEnumMapMemberAttribute(
+        INamedTypeSymbol attributeClass,
+        INamedTypeSymbol? enumMemberAttributeSymbol,
+        ImmutableArray<TypedConstant> constructorArguments)
+    {
+        if (!IsAttribute(attributeClass, enumMemberAttributeSymbol)
+            || GetEnumTypeArgument(attributeClass, 1, 0) is not { } enumType
+            || GetEnumMemberName(constructorArguments[0]) is not { } enumMemberName)
+        {
+            return null;
+        }
+
+        return CreateSingleEnumMapMemberAttribute(enumType, enumMemberName, constructorArguments[1]);
+    }
+
+    private static EnumMapMemberInfoAttribute? TryParseEnumToEnumMapMemberAttribute(
+        INamedTypeSymbol attributeClass,
+        INamedTypeSymbol? enumMemberToEnumAttributeSymbol,
+        ImmutableArray<TypedConstant> constructorArguments)
+    {
+        if (!IsAttribute(attributeClass, enumMemberToEnumAttributeSymbol)
+            || GetEnumTypeArgument(attributeClass, 2, 0) is not { } firstEnumType
+            || GetEnumTypeArgument(attributeClass, 2, 1) is not { } secondEnumType
+            || GetEnumMemberName(constructorArguments[0]) is not { } firstEnumMemberName
+            || GetEnumMemberName(constructorArguments[1]) is not { } secondEnumMemberName)
+        {
+            return null;
+        }
+
+        return new EnumMapMemberInfoAttribute(
+            firstEnumType,
+            firstEnumMemberName,
+            null,
+            null,
+            secondEnumType,
+            secondEnumMemberName);
+    }
+
+    private static EnumMapMemberInfoAttribute? CreateSingleEnumMapMemberAttribute(
+        INamedTypeSymbol enumType,
+        string enumMemberName,
+        TypedConstant secondArgument)
+    {
+        return secondArgument.Value switch
+        {
+            string stringValue => new EnumMapMemberInfoAttribute(enumType, enumMemberName, null, stringValue, null, null),
+            int integerValue => new EnumMapMemberInfoAttribute(enumType, enumMemberName, integerValue, null, null, null),
+            _ => null,
+        };
+    }
+
+    private static EnumMapDefaultInfoAttribute? TryParseEnumMapDefaultAttribute(
+        AttributeData attributeData,
+        INamedTypeSymbol? enumDefaultAttributeSymbol)
+    {
+        if (attributeData.AttributeClass is not { } attributeClass
+            || !IsAttribute(attributeClass, enumDefaultAttributeSymbol)
+            || GetEnumTypeArgument(attributeClass, 1, 0) is not { } enumType)
+        {
+            return null;
+        }
+
+        var constructorArguments = attributeData.ConstructorArguments;
+        if (constructorArguments.Length == 0
+            || constructorArguments[0].Value is not int behaviorValue)
+        {
+            return null;
+        }
+
+        var behavior = (MappaMapEnumDefaultBehavior)behaviorValue;
+        if (constructorArguments.Length == 1)
+        {
+            return new EnumMapDefaultInfoAttribute(enumType, behavior, null, null, null);
+        }
+
+        return CreateEnumMapDefaultWithExplicitDefault(enumType, behavior, constructorArguments[1]);
+    }
+
+    private static EnumMapDefaultInfoAttribute? CreateEnumMapDefaultWithExplicitDefault(
+        INamedTypeSymbol enumType,
+        MappaMapEnumDefaultBehavior behavior,
+        TypedConstant defaultValue)
+    {
+        if (defaultValue.Type is INamedTypeSymbol { TypeKind: TypeKind.Enum }
+            && GetEnumMemberName(defaultValue) is { } enumDefaultMemberName)
+        {
+            return new EnumMapDefaultInfoAttribute(enumType, behavior, enumDefaultMemberName, null, null);
+        }
+
+        return defaultValue.Value switch
+        {
+            string stringDefaultValue => new EnumMapDefaultInfoAttribute(enumType, behavior, null, null, stringDefaultValue),
+            int integerDefaultValue => new EnumMapDefaultInfoAttribute(enumType, behavior, null, integerDefaultValue, null),
+            _ => null,
+        };
+    }
+
+    private static MappaTypeMappingDefaultAttribute? CreateMappaTypeMappingDefaultFromConstructorArguments(
+        ImmutableArray<TypedConstant> constructorArguments)
+    {
+        return constructorArguments.Length switch
+        {
+            1 => CreateMappaTypeMappingDefaultFromSingleConstructorArgument(constructorArguments[0]),
+            2 => CreateMappaTypeMappingDefaultFromTwoConstructorArguments(constructorArguments[0], constructorArguments[1]),
+            _ => null,
+        };
+    }
+
+    private static MappaTypeMappingDefaultAttribute? CreateMappaTypeMappingDefaultFromSingleConstructorArgument(
+        TypedConstant argument)
+    {
+        return argument.Value switch
+        {
+            string methodName => new MappaTypeMappingDefaultAttribute(methodName),
+            int behavior => new MappaTypeMappingDefaultAttribute((MappaTypeMappingDefaultBehavior)behavior),
+            _ => null,
+        };
+    }
+
+    private static MappaTypeMappingDefaultAttribute? CreateMappaTypeMappingDefaultFromTwoConstructorArguments(
+        TypedConstant firstArgument,
+        TypedConstant secondArgument)
+    {
+        if (firstArgument.Value is INamedTypeSymbol invokeType && secondArgument.Value is string methodName)
+        {
+            return new MappaTypeMappingDefaultAttribute(new FakeType(invokeType.ToDisplayString()), methodName);
+        }
+
+        if (firstArgument.Value is int behavior && secondArgument.Value is INamedTypeSymbol type)
+        {
+            return new MappaTypeMappingDefaultAttribute((MappaTypeMappingDefaultBehavior)behavior, new FakeType(type.ToDisplayString()));
+        }
+
+        return null;
+    }
+
+    private static MappaTypeMappingAttribute? TryParseTypeMappingAttribute(
+        AttributeData attributeData,
+        INamedTypeSymbol? mappaTypeMappingAttributeSymbol,
+        INamedTypeSymbol? mappaTypeMappingAttributeOfTSymbol)
+    {
+        if (attributeData.AttributeClass is not { } attributeClass)
+        {
+            return null;
+        }
+
+        var genericResult = TryParseGenericTypeMappingAttribute(attributeClass, mappaTypeMappingAttributeOfTSymbol);
+        if (genericResult is not null)
+        {
+            return genericResult;
+        }
+
+        return TryParseNonGenericTypeMappingAttribute(attributeClass, mappaTypeMappingAttributeSymbol, attributeData.ConstructorArguments);
+    }
+
+    private static MappaTypeMappingAttribute? TryParseGenericTypeMappingAttribute(
+        INamedTypeSymbol attributeClass,
+        INamedTypeSymbol? mappaTypeMappingAttributeOfTSymbol)
+    {
+        if (!IsAttribute(attributeClass, mappaTypeMappingAttributeOfTSymbol)
+            || GetEnumTypeArgument(attributeClass, 2, 0) is not { } genericTargetType
+            || GetEnumTypeArgument(attributeClass, 2, 1) is not { } genericSourceType)
+        {
+            return null;
+        }
+
+        return new MappaTypeMappingAttribute(
+            new FakeType(genericTargetType.ToDisplayString()),
+            new FakeType(genericSourceType.ToDisplayString()));
+    }
+
+    private static MappaTypeMappingAttribute? TryParseNonGenericTypeMappingAttribute(
+        INamedTypeSymbol attributeClass,
+        INamedTypeSymbol? mappaTypeMappingAttributeSymbol,
+        ImmutableArray<TypedConstant> constructorArguments)
+    {
+        if (!SymbolEqualityComparer.Default.Equals(attributeClass, mappaTypeMappingAttributeSymbol)
+            || constructorArguments.Length != 2
+            || constructorArguments[0].Value is not INamedTypeSymbol targetType
+            || constructorArguments[1].Value is not INamedTypeSymbol sourceType)
+        {
+            return null;
+        }
+
+        return new MappaTypeMappingAttribute(
+            new FakeType(targetType.ToDisplayString()),
+            new FakeType(sourceType.ToDisplayString()));
+    }
+
+    private static MappaInvokeMethodAttribute? TryCreateInvokeMethodAttribute(AttributeData attributeData)
+    {
+        var constructorArguments = attributeData.ConstructorArguments;
+        MappaInvokeMethodAttribute? attribute = constructorArguments.Length switch
+        {
+            2 when constructorArguments[0].Value is string targetParameterNameTwo
+                 && constructorArguments[1].Value is string methodNameTwo
+                => new MappaInvokeMethodAttribute(targetParameterNameTwo, methodNameTwo),
+            3 when constructorArguments[0].Value is string targetParameterNameThree
+                 && constructorArguments[2].Value is string methodNameThree
+                => CreateInvokeMethodAttributeWithMiddleArgument(
+                    targetParameterNameThree,
+                    constructorArguments[1],
+                    methodNameThree),
+            _ => null,
+        };
+
+        if (attribute is null)
+        {
+            return null;
+        }
+
+        ApplyInvokeMethodNamedArguments(attribute, attributeData.NamedArguments);
+        return attribute;
+    }
+
+    private static MappaInvokeMethodAttribute? CreateInvokeMethodAttributeWithMiddleArgument(
+        string targetParameterName,
+        TypedConstant middleArgument,
+        string methodName)
+    {
+        return middleArgument.Value switch
+        {
+            string fieldName => new MappaInvokeMethodAttribute(targetParameterName, fieldName, methodName),
+            INamedTypeSymbol classType => new MappaInvokeMethodAttribute(
+                targetParameterName,
+                new FakeType(classType.ToDisplayString()),
+                methodName),
+            _ => null,
+        };
+    }
+
+    private static void ApplyInvokeMethodNamedArguments(
+        MappaInvokeMethodAttribute attribute,
+        ImmutableArray<KeyValuePair<string, TypedConstant>> namedArguments)
+    {
+        foreach (var namedArgument in namedArguments)
+        {
+            if (namedArgument.Key == nameof(MappaInvokeMethodAttribute.SourcePropertyName)
+                && namedArgument.Value.Value is string sourcePropertyName)
+            {
+                attribute.SourcePropertyName = sourcePropertyName;
+            }
+        }
+    }
+
+    private static MappaObjectFactoryAttributeData? TryCreateMappaObjectFactoryAttributeData(AttributeData attributeData)
+    {
+        var constructorArguments = attributeData.ConstructorArguments;
+        var location = attributeData.ApplicationSyntaxReference?.GetSyntax().GetLocation();
+        if (constructorArguments.Length == 2
+            && constructorArguments[0].Value is INamedTypeSymbol targetType
+            && constructorArguments[1].Value is string methodName)
+        {
+            return new MappaObjectFactoryAttributeData(targetType, methodName, null, null, location);
+        }
+
+        if (constructorArguments.Length != 3
+            || constructorArguments[0].Value is not INamedTypeSymbol factoryTargetType
+            || constructorArguments[2].Value is not string factoryMethodName)
+        {
+            return null;
+        }
+
+        return CreateMappaObjectFactoryWithMiddleArgument(
+            factoryTargetType,
+            factoryMethodName,
+            constructorArguments[1],
+            location);
+    }
+
+    private static MappaObjectFactoryAttributeData? CreateMappaObjectFactoryWithMiddleArgument(
+        INamedTypeSymbol factoryTargetType,
+        string factoryMethodName,
+        TypedConstant middleArgument,
+        Location? location)
+    {
+        return middleArgument.Value switch
+        {
+            string fieldName => new MappaObjectFactoryAttributeData(
+                factoryTargetType,
+                factoryMethodName,
+                null,
+                fieldName,
+                location),
+            INamedTypeSymbol classType => new MappaObjectFactoryAttributeData(
+                factoryTargetType,
+                factoryMethodName,
+                new FakeType(classType.ToDisplayString()),
+                null,
+                location),
+            _ => null,
+        };
+    }
+
+    private static MapHookAttributeData? TryCreateMapHookAttributeData(AttributeData attributeData)
+    {
+        var constructorArguments = attributeData.ConstructorArguments;
+        var location = attributeData.ApplicationSyntaxReference?.GetSyntax().GetLocation();
+        if (constructorArguments.Length == 1
+            && constructorArguments[0].Value is string mapperMethodName)
+        {
+            return new MapHookAttributeData(mapperMethodName, null, null, location);
+        }
+
+        if (constructorArguments.Length != 2
+            || constructorArguments[1].Value is not string locatedMethodName)
+        {
+            return null;
+        }
+
+        return CreateMapHookWithLocationArgument(locatedMethodName, constructorArguments[0], location);
+    }
+
+    private static MapHookAttributeData? CreateMapHookWithLocationArgument(
+        string locatedMethodName,
+        TypedConstant locationArgument,
+        Location? location)
+    {
+        return locationArgument.Value switch
+        {
+            string fieldName => new MapHookAttributeData(locatedMethodName, null, fieldName, location),
+            INamedTypeSymbol classType => new MapHookAttributeData(
+                locatedMethodName,
+                new FakeType(classType.ToDisplayString()),
+                null,
+                location),
+            _ => null,
+        };
+    }
+
+    private static DateTimeStyles ReadDateTimeStyles(TypedConstant typedConstant)
+    {
+        return typedConstant.Value switch
+        {
+            null => MappaSettingsAttribute.UndefinedDateTimeStyle,
+            int intValue => (DateTimeStyles)intValue,
+            DateTimeStyles dateTimeStyles => dateTimeStyles,
+            _ => MappaSettingsAttribute.UndefinedDateTimeStyle,
+        };
+    }
+
+    private static NumberStyles ReadNumberStyles(TypedConstant typedConstant)
+    {
+        return typedConstant.Value switch
+        {
+            null => MappaSettingsAttribute.UndefinedNumberStyle,
+            int intValue => (NumberStyles)intValue,
+            NumberStyles numberStyles => numberStyles,
+            _ => MappaSettingsAttribute.UndefinedNumberStyle,
+        };
+    }
+
+    private static short ReadDepth(TypedConstant typedConstant)
+    {
+        return typedConstant.Value switch
+        {
+            null => MappaSettingsAttribute.UndefinedDepth,
+            short shortValue => shortValue,
+            int intValue => (short)intValue,
+            long longValue => (short)longValue,
+            _ => MappaSettingsAttribute.UndefinedDepth,
+        };
     }
 
     private static MapHookAttributeData[] GetMapHookAttributes(
@@ -1106,37 +1385,9 @@ internal static class AttributeDataExtensions
         foreach (var attributeData in attributes
                      .Where(attribute => SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, attributeSymbol)))
         {
-            var constructorArguments = attributeData.ConstructorArguments;
-            var location = attributeData.ApplicationSyntaxReference?.GetSyntax().GetLocation();
-            if (constructorArguments.Length == 1 &&
-                constructorArguments[0].Value is string mapperMethodName)
+            if (TryCreateMapHookAttributeData(attributeData) is { } mapHook)
             {
-                results.Add(new MapHookAttributeData(
-                    mapperMethodName,
-                    null,
-                    null,
-                    location));
-            }
-            else if (constructorArguments.Length == 2 &&
-                     constructorArguments[1].Value is string locatedMethodName)
-            {
-                switch (constructorArguments[0].Value)
-                {
-                    case string fieldName:
-                        results.Add(new MapHookAttributeData(
-                            locatedMethodName,
-                            null,
-                            fieldName,
-                            location));
-                        break;
-                    case INamedTypeSymbol classType:
-                        results.Add(new MapHookAttributeData(
-                            locatedMethodName,
-                            new FakeType(classType.ToDisplayString()),
-                            null,
-                            location));
-                        break;
-                }
+                results.Add(mapHook);
             }
         }
 
@@ -1233,5 +1484,27 @@ internal static class AttributeDataExtensions
                 .Select(value => value.Value)
                 .OfType<INamedTypeSymbol>(),
         ];
+    }
+
+    private sealed class MappaDependencyInjectionNamedArgumentValues
+    {
+        internal bool ExtensionMethod { get; set; } = true;
+
+        internal string? MethodName { get; set; }
+
+        internal MappaDependencyInjectionMethodAccessibility Accessibility { get; set; } =
+            MappaDependencyInjectionMethodAccessibility.Public;
+
+        internal MappaDependencyInjectionServiceLifetime ServiceLifetime { get; set; } =
+            MappaDependencyInjectionServiceLifetime.Singleton;
+
+        internal MappaDependencyInjectionInjectInterfaces InjectInterfaces { get; set; } =
+            MappaDependencyInjectionInjectInterfaces.ClassOnly;
+
+        internal ImmutableArray<INamedTypeSymbol> IgnoreTypes { get; set; } =
+            ImmutableArray<INamedTypeSymbol>.Empty;
+
+        internal ImmutableArray<INamedTypeSymbol> InjectFromAssemblies { get; set; } =
+            ImmutableArray<INamedTypeSymbol>.Empty;
     }
 }

--- a/Mappa.Generator/Extensions/InvokeMethodSourcePropertyUsage.cs
+++ b/Mappa.Generator/Extensions/InvokeMethodSourcePropertyUsage.cs
@@ -27,49 +27,62 @@ internal static class InvokeMethodSourcePropertyUsage
         IPropertySymbol? sourceProperty,
         ITypeSymbol sourceClassType,
         bool nullableEnabled)
-    {
-        switch (method.Parameters.Length)
+        => method.Parameters.Length switch
         {
-            case 0:
-                return false;
+            0 => false,
+            1 => UsesSourcePropertyForSingleParameter(method, compilation, sourceProperty, sourceClassType, nullableEnabled),
+            2 => UsesSourcePropertyForTwoParameters(method, compilation, sourceProperty, sourceClassType, nullableEnabled),
+            3 => sourceProperty is not null,
+            _ => false,
+        };
 
-            case 1:
-                if (method.ParameterIsMappaContext(compilation, 0))
-                {
-                    return false;
-                }
-
-                if (method.Parameters[0].Type.IsEqualTo(sourceClassType, nullableEnabled) ||
-                    compilation.HasImplicitConversion(sourceClassType, method.Parameters[0].Type))
-                {
-                    return false;
-                }
-
-                return sourceProperty is not null &&
-                       (method.Parameters[0].Type.IsEqualTo(sourceProperty.Type, nullableEnabled) ||
-                        compilation.HasImplicitConversion(sourceProperty.Type, method.Parameters[0].Type));
-
-            case 2:
-                if (method.ParameterIsMappaContext(compilation, 1))
-                {
-                    if (method.Parameters[0].Type.IsEqualTo(sourceClassType, nullableEnabled) ||
-                        compilation.HasImplicitConversion(sourceClassType, method.Parameters[0].Type))
-                    {
-                        return false;
-                    }
-
-                    return sourceProperty is not null &&
-                           (method.Parameters[0].Type.IsEqualTo(sourceProperty.Type, nullableEnabled) ||
-                            compilation.HasImplicitConversion(sourceProperty.Type, method.Parameters[0].Type));
-                }
-
-                return sourceProperty is not null;
-
-            case 3:
-                return sourceProperty is not null;
-
-            default:
-                return false;
+    private static bool UsesSourcePropertyForSingleParameter(
+        IMethodSymbol method,
+        Compilation compilation,
+        IPropertySymbol? sourceProperty,
+        ITypeSymbol sourceClassType,
+        bool nullableEnabled)
+    {
+        if (method.ParameterIsMappaContext(compilation, 0))
+        {
+            return false;
         }
+
+        if (ParameterAcceptsSourceType(method.Parameters[0].Type, compilation, sourceClassType, nullableEnabled))
+        {
+            return false;
+        }
+
+        return sourceProperty is not null &&
+               ParameterAcceptsSourceType(method.Parameters[0].Type, compilation, sourceProperty.Type, nullableEnabled);
     }
+
+    private static bool UsesSourcePropertyForTwoParameters(
+        IMethodSymbol method,
+        Compilation compilation,
+        IPropertySymbol? sourceProperty,
+        ITypeSymbol sourceClassType,
+        bool nullableEnabled)
+    {
+        if (method.ParameterIsMappaContext(compilation, 1))
+        {
+            if (ParameterAcceptsSourceType(method.Parameters[0].Type, compilation, sourceClassType, nullableEnabled))
+            {
+                return false;
+            }
+
+            return sourceProperty is not null &&
+                   ParameterAcceptsSourceType(method.Parameters[0].Type, compilation, sourceProperty.Type, nullableEnabled);
+        }
+
+        return sourceProperty is not null;
+    }
+
+    private static bool ParameterAcceptsSourceType(
+        ITypeSymbol parameterType,
+        Compilation compilation,
+        ITypeSymbol sourceType,
+        bool nullableEnabled)
+        => parameterType.IsEqualTo(sourceType, nullableEnabled) ||
+           compilation.HasImplicitConversion(sourceType, parameterType);
 }

--- a/Mappa.Generator/Extensions/MapMethodMappingAttributesValidator.TargetNames.cs
+++ b/Mappa.Generator/Extensions/MapMethodMappingAttributesValidator.TargetNames.cs
@@ -1,0 +1,153 @@
+// <copyright file="MapMethodMappingAttributesValidator.TargetNames.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using Mappa.Attributes;
+using Mappa.Generator.Models;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Mappa.Generator.Extensions;
+
+/// <summary>
+/// Target-name validation for <see cref="MapMethodMappingAttributesValidator"/>.
+/// </summary>
+internal static partial class MapMethodMappingAttributesValidator
+{
+    private static void ValidateUsePropertyTargetNames(
+        MappaMapAlgorithmContext context,
+        TargetNamesValidationContext validationContext,
+        MappaUsePropertyAttribute[] attributes)
+    {
+        foreach (var attribute in attributes)
+        {
+            ValidateTargetPropertyPath(
+                context,
+                validationContext.MethodDeclarationSyntax,
+                validationContext.MethodName,
+                validationContext.TargetTypeName,
+                nameof(MappaUsePropertyAttribute),
+                attribute.TargetPropertyName,
+                validationContext.PropertyNames,
+                validationContext.ConstructorParameterNames,
+                validationContext.TargetType,
+                validationContext.PropertyPathContext);
+            ValidateSourcePropertyPath(
+                context,
+                validationContext.MethodDeclarationSyntax,
+                validationContext.MethodName,
+                validationContext.SourceTypeName,
+                nameof(MappaUsePropertyAttribute),
+                attribute.TargetPropertyName,
+                attribute.SourcePropertyName,
+                validationContext.SourceType,
+                validationContext.PropertyPathContext);
+        }
+    }
+
+    private static void ValidateInvokeMethodTargetNames(
+        MappaMapAlgorithmContext context,
+        TargetNamesValidationContext validationContext,
+        MappaInvokeMethodAttribute[] attributes)
+    {
+        foreach (var attribute in attributes)
+        {
+            ValidateTargetPropertyPath(
+                context,
+                validationContext.MethodDeclarationSyntax,
+                validationContext.MethodName,
+                validationContext.TargetTypeName,
+                nameof(MappaInvokeMethodAttribute),
+                attribute.TargetPropertyName,
+                validationContext.PropertyNames,
+                validationContext.ConstructorParameterNames,
+                validationContext.TargetType,
+                validationContext.PropertyPathContext);
+
+            if (attribute.SourcePropertyName is not string sourcePropertyName
+                || string.IsNullOrWhiteSpace(sourcePropertyName))
+            {
+                continue;
+            }
+
+            ValidateSourcePropertyPath(
+                context,
+                validationContext.MethodDeclarationSyntax,
+                validationContext.MethodName,
+                validationContext.SourceTypeName,
+                nameof(MappaInvokeMethodAttribute),
+                attribute.TargetPropertyName,
+                sourcePropertyName,
+                validationContext.SourceType,
+                validationContext.PropertyPathContext);
+        }
+    }
+
+    private static void ValidateTargetOnlyAttributeNames<TAttribute>(
+        MappaMapAlgorithmContext context,
+        TargetNamesValidationContext validationContext,
+        TAttribute[] attributes,
+        string attributeName,
+        Func<TAttribute, string> getTargetPropertyName)
+        where TAttribute : notnull
+    {
+        foreach (var attribute in attributes)
+        {
+            ValidateTargetPropertyPath(
+                context,
+                validationContext.MethodDeclarationSyntax,
+                validationContext.MethodName,
+                validationContext.TargetTypeName,
+                attributeName,
+                getTargetPropertyName(attribute),
+                validationContext.PropertyNames,
+                validationContext.ConstructorParameterNames,
+                validationContext.TargetType,
+                validationContext.PropertyPathContext);
+        }
+    }
+
+    private sealed class TargetNamesValidationContext
+    {
+        internal TargetNamesValidationContext(
+            MethodDeclarationSyntax methodDeclarationSyntax,
+            string methodName,
+            string targetTypeName,
+            string sourceTypeName,
+            HashSet<string> propertyNames,
+            string[] constructorParameterNames,
+            ITypeSymbol targetType,
+            ITypeSymbol sourceType,
+            PropertyPathContext? propertyPathContext)
+        {
+            this.MethodDeclarationSyntax = methodDeclarationSyntax;
+            this.MethodName = methodName;
+            this.TargetTypeName = targetTypeName;
+            this.SourceTypeName = sourceTypeName;
+            this.PropertyNames = propertyNames;
+            this.ConstructorParameterNames = constructorParameterNames;
+            this.TargetType = targetType;
+            this.SourceType = sourceType;
+            this.PropertyPathContext = propertyPathContext;
+        }
+
+        internal MethodDeclarationSyntax MethodDeclarationSyntax { get; }
+
+        internal string MethodName { get; }
+
+        internal string TargetTypeName { get; }
+
+        internal string SourceTypeName { get; }
+
+        internal HashSet<string> PropertyNames { get; }
+
+        internal string[] ConstructorParameterNames { get; }
+
+        internal ITypeSymbol TargetType { get; }
+
+        internal ITypeSymbol SourceType { get; }
+
+        internal PropertyPathContext? PropertyPathContext { get; }
+    }
+}

--- a/Mappa.Generator/Extensions/MapMethodMappingAttributesValidator.cs
+++ b/Mappa.Generator/Extensions/MapMethodMappingAttributesValidator.cs
@@ -15,7 +15,7 @@ namespace Mappa.Generator.Extensions;
 /// <summary>
 /// Extension methods that validate mapping attributes declared on a map method.
 /// </summary>
-internal static class MapMethodMappingAttributesValidator
+internal static partial class MapMethodMappingAttributesValidator
 {
     /// <summary>
     /// Reports a warning for each mapping attribute whose <c>TargetPropertyName</c>
@@ -66,104 +66,37 @@ internal static class MapMethodMappingAttributesValidator
         var targetTypeName = targetType.ToDisplayString();
         var sourceTypeName = sourceType.ToDisplayString();
 
-        foreach (var attribute in mapMethod.GetAttributes<MappaUsePropertyAttribute>())
-        {
-            ValidateTargetPropertyPath(
-                context,
-                methodDeclarationSyntax,
-                methodName,
-                targetTypeName,
-                nameof(MappaUsePropertyAttribute),
-                attribute.TargetPropertyName,
-                propertyNames,
-                constructorParameterNames,
-                targetType,
-                context.PropertyPathContext);
-            ValidateSourcePropertyPath(
-                context,
-                methodDeclarationSyntax,
-                methodName,
-                sourceTypeName,
-                nameof(MappaUsePropertyAttribute),
-                attribute.TargetPropertyName,
-                attribute.SourcePropertyName,
-                sourceType,
-                context.PropertyPathContext);
-        }
+        var validationContext = new TargetNamesValidationContext(
+            methodDeclarationSyntax,
+            methodName,
+            targetTypeName,
+            sourceTypeName,
+            propertyNames,
+            constructorParameterNames,
+            targetType,
+            sourceType,
+            context.PropertyPathContext);
 
-        foreach (var attribute in mapMethod.GetAttributes<MappaInvokeMethodAttribute>())
-        {
-            ValidateTargetPropertyPath(
-                context,
-                methodDeclarationSyntax,
-                methodName,
-                targetTypeName,
-                nameof(MappaInvokeMethodAttribute),
-                attribute.TargetPropertyName,
-                propertyNames,
-                constructorParameterNames,
-                targetType,
-                context.PropertyPathContext);
-
-            if (!string.IsNullOrWhiteSpace(attribute.SourcePropertyName))
-            {
-                ValidateSourcePropertyPath(
-                    context,
-                    methodDeclarationSyntax,
-                    methodName,
-                    sourceTypeName,
-                    nameof(MappaInvokeMethodAttribute),
-                    attribute.TargetPropertyName,
-                    attribute.SourcePropertyName!,
-                    sourceType,
-                    context.PropertyPathContext);
-            }
-        }
-
-        foreach (var attribute in mapMethod.GetAttributes<MappaAssignFromContextAttribute>())
-        {
-            ValidateTargetPropertyPath(
-                context,
-                methodDeclarationSyntax,
-                methodName,
-                targetTypeName,
-                nameof(MappaAssignFromContextAttribute),
-                attribute.TargetPropertyName,
-                propertyNames,
-                constructorParameterNames,
-                targetType,
-                context.PropertyPathContext);
-        }
-
-        foreach (var attribute in mapMethod.GetAttributes<MappaAssignFromConstantAttribute>())
-        {
-            ValidateTargetPropertyPath(
-                context,
-                methodDeclarationSyntax,
-                methodName,
-                targetTypeName,
-                nameof(MappaAssignFromConstantAttribute),
-                attribute.TargetPropertyName,
-                propertyNames,
-                constructorParameterNames,
-                targetType,
-                context.PropertyPathContext);
-        }
-
-        foreach (var ignoreAttribute in mapMethod.GetAttributes<MappaIgnoreTargetPropertyAttribute>())
-        {
-            ValidateTargetPropertyPath(
-                context,
-                methodDeclarationSyntax,
-                methodName,
-                targetTypeName,
-                nameof(MappaIgnoreTargetPropertyAttribute),
-                ignoreAttribute.TargetPropertyName,
-                propertyNames,
-                constructorParameterNames,
-                targetType,
-                context.PropertyPathContext);
-        }
+        ValidateUsePropertyTargetNames(context, validationContext, mapMethod.GetAttributes<MappaUsePropertyAttribute>());
+        ValidateInvokeMethodTargetNames(context, validationContext, mapMethod.GetAttributes<MappaInvokeMethodAttribute>());
+        ValidateTargetOnlyAttributeNames(
+            context,
+            validationContext,
+            mapMethod.GetAttributes<MappaAssignFromContextAttribute>(),
+            nameof(MappaAssignFromContextAttribute),
+            attribute => attribute.TargetPropertyName);
+        ValidateTargetOnlyAttributeNames(
+            context,
+            validationContext,
+            mapMethod.GetAttributes<MappaAssignFromConstantAttribute>(),
+            nameof(MappaAssignFromConstantAttribute),
+            attribute => attribute.TargetPropertyName);
+        ValidateTargetOnlyAttributeNames(
+            context,
+            validationContext,
+            mapMethod.GetAttributes<MappaIgnoreTargetPropertyAttribute>(),
+            nameof(MappaIgnoreTargetPropertyAttribute),
+            attribute => attribute.TargetPropertyName);
     }
 
     /// <summary>
@@ -275,35 +208,14 @@ internal static class MapMethodMappingAttributesValidator
 
         foreach (var propertyName in mustMapAttribute.TargetPropertyNames.Distinct(StringComparer.Ordinal))
         {
-            if (ignoredPropertyNames.Contains(propertyName))
-            {
-                context.ReportDiagnostic(MappaDiagnostics.MultipleAttributesTargetTheSamePropertyOrParameter(
-                    methodDeclarationSyntax,
-                    propertyName));
-            }
-
-            var targetProperty = Array.Find(
+            ValidateSingleMustMapTargetPropertyName(
+                context,
+                methodDeclarationSyntax,
+                methodName,
+                targetTypeName,
                 targetProperties,
-                property => property.Name.Equals(propertyName, StringComparison.Ordinal));
-            if (targetProperty is null)
-            {
-                context.ReportDiagnostic(MappaDiagnostics.MappingAttributeTargetPropertyOrParameterDoesNotExist(
-                    methodDeclarationSyntax,
-                    methodName,
-                    nameof(MappaMustMapTargetPropertyAttribute),
-                    propertyName,
-                    targetTypeName));
-                continue;
-            }
-
-            if (targetProperty.IsRequired)
-            {
-                context.ReportDiagnostic(MappaDiagnostics.MappaMustMapTargetPropertyListsRequiredProperty(
-                    methodDeclarationSyntax,
-                    methodName,
-                    propertyName,
-                    targetTypeName));
-            }
+                ignoredPropertyNames,
+                propertyName);
         }
     }
 
@@ -336,43 +248,15 @@ internal static class MapMethodMappingAttributesValidator
             return;
         }
 
-        var methodName = context.GetRootMapMethod().MethodName;
-
-        if (!compilation.IsUnsafeAccessorSupported())
-        {
-            context.ReportDiagnostic(MappaDiagnostics.UnsafeAccessorNotSupported(
-                methodDeclarationSyntax,
-                methodName));
-        }
-
-        if (targetAttribute is { AllowProperties: false, AllowConstructors: false })
-        {
-            context.ReportDiagnostic(MappaDiagnostics.AllowInaccessibleTargetMembersDisabledAll(
-                methodDeclarationSyntax,
-                methodName));
-        }
-
-        if (sourceAttribute is not null)
-        {
-            ValidateMemberNamesExist(
-                context,
-                methodDeclarationSyntax,
-                methodName,
-                nameof(MappaAllowInaccessibleSourceMembersAttribute),
-                sourceAttribute.MemberNames,
-                context.SourceType);
-        }
-
-        if (targetAttribute is not null)
-        {
-            ValidateMemberNamesExist(
-                context,
-                methodDeclarationSyntax,
-                methodName,
-                nameof(MappaAllowInaccessibleTargetMembersAttribute),
-                targetAttribute.MemberNames,
-                context.TargetType);
-        }
+        ReportAllowInaccessibleMembersAttributeDiagnostics(
+            context,
+            compilation,
+            methodDeclarationSyntax,
+            targetAttribute,
+            sourceAttribute,
+            context.GetRootMapMethod().MethodName,
+            context.SourceType,
+            context.TargetType);
     }
 
     /// <summary>
@@ -450,6 +334,46 @@ internal static class MapMethodMappingAttributesValidator
         }
 
         return attributeTargetPath.EndsWith(propertyPathContext.RemainingTargetSegments);
+    }
+
+    private static void ValidateSingleMustMapTargetPropertyName(
+        MappaMapAlgorithmContext context,
+        MethodDeclarationSyntax methodDeclarationSyntax,
+        string methodName,
+        string targetTypeName,
+        IPropertySymbol[] targetProperties,
+        HashSet<string> ignoredPropertyNames,
+        string propertyName)
+    {
+        if (ignoredPropertyNames.Contains(propertyName))
+        {
+            context.ReportDiagnostic(MappaDiagnostics.MultipleAttributesTargetTheSamePropertyOrParameter(
+                methodDeclarationSyntax,
+                propertyName));
+        }
+
+        var targetProperty = Array.Find(
+            targetProperties,
+            property => property.Name.Equals(propertyName, StringComparison.Ordinal));
+        if (targetProperty is null)
+        {
+            context.ReportDiagnostic(MappaDiagnostics.MappingAttributeTargetPropertyOrParameterDoesNotExist(
+                methodDeclarationSyntax,
+                methodName,
+                nameof(MappaMustMapTargetPropertyAttribute),
+                propertyName,
+                targetTypeName));
+            return;
+        }
+
+        if (targetProperty.IsRequired)
+        {
+            context.ReportDiagnostic(MappaDiagnostics.MappaMustMapTargetPropertyListsRequiredProperty(
+                methodDeclarationSyntax,
+                methodName,
+                propertyName,
+                targetTypeName));
+        }
     }
 
     private static void ValidateTargetPropertyPath(
@@ -584,6 +508,53 @@ internal static class MapMethodMappingAttributesValidator
 
         return constructorParameterNames.Any(
             parameterName => parameterName.Equals(targetName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static void ReportAllowInaccessibleMembersAttributeDiagnostics(
+        MappaMapAlgorithmContext context,
+        Compilation compilation,
+        MethodDeclarationSyntax methodDeclarationSyntax,
+        MappaAllowInaccessibleTargetMembersAttribute? targetAttribute,
+        MappaAllowInaccessibleSourceMembersAttribute? sourceAttribute,
+        string methodName,
+        ITypeSymbol sourceType,
+        ITypeSymbol targetType)
+    {
+        if (!compilation.IsUnsafeAccessorSupported())
+        {
+            context.ReportDiagnostic(MappaDiagnostics.UnsafeAccessorNotSupported(
+                methodDeclarationSyntax,
+                methodName));
+        }
+
+        if (targetAttribute is { AllowProperties: false, AllowConstructors: false })
+        {
+            context.ReportDiagnostic(MappaDiagnostics.AllowInaccessibleTargetMembersDisabledAll(
+                methodDeclarationSyntax,
+                methodName));
+        }
+
+        if (sourceAttribute is not null)
+        {
+            ValidateMemberNamesExist(
+                context,
+                methodDeclarationSyntax,
+                methodName,
+                nameof(MappaAllowInaccessibleSourceMembersAttribute),
+                sourceAttribute.MemberNames,
+                sourceType);
+        }
+
+        if (targetAttribute is not null)
+        {
+            ValidateMemberNamesExist(
+                context,
+                methodDeclarationSyntax,
+                methodName,
+                nameof(MappaAllowInaccessibleTargetMembersAttribute),
+                targetAttribute.MemberNames,
+                targetType);
+        }
     }
 
     private static void ValidateMemberNamesExist(

--- a/Mappa.Generator/Extensions/MappaTypeMappingDefaultAttributeExtensions.cs
+++ b/Mappa.Generator/Extensions/MappaTypeMappingDefaultAttributeExtensions.cs
@@ -51,126 +51,177 @@ internal static class MappaTypeMappingDefaultAttributeExtensions
                 return false;
 
             case MappaTypeMappingDefaultBehavior.Throw:
-                // Check the type is an exception and there is a constructor that can be used.
-                if (attribute.Type is { } attributeType && !string.IsNullOrWhiteSpace(attributeType.FullName))
-                {
-                    var typeSymbol = compilation.GetTypeByMetadataName(attributeType.FullName.NormalizeType());
-                    if (typeSymbol is null)
-                    {
-                        throw new MappaGeneratorException($"Type '{attributeType.FullName}' cannot be loaded at compile time.");
-                    }
-
-                    if (!typeSymbol.CanBeThrown(compilation))
-                    {
-                        diagnostics.Add(MappaDiagnostics.TypeMustBeAnException(attributeType.FullName, location));
-                        return false;
-                    }
-
-                    if (typeSymbol.IsAbstract)
-                    {
-                        diagnostics.Add(MappaDiagnostics.TypeMustBeConcrete(attributeType.FullName, location));
-                        return false;
-                    }
-
-                    if (!typeSymbol.HasNamedTypeSymbolAccessibleZeroParametersConstructor(compilation)
-                        && !typeSymbol.HasNamedTypeSymbolAccessibleSingleStringParametersConstructor(compilation))
-                    {
-                        diagnostics.Add(MappaDiagnostics.TypeMustHaveAConstructorWithNoParametersOrAConstructorWithOneStringParameter(attributeType.FullName, location));
-                        return false;
-                    }
-                }
-
-                break;
+                return ValidateThrowBehavior(attribute, compilation, location, diagnostics);
 
             case MappaTypeMappingDefaultBehavior.Default:
             case MappaTypeMappingDefaultBehavior.Null:
-                // Check the type is not set.
-                if (attribute.Type is not null)
-                {
-                    diagnostics.Add(MappaDiagnostics.MappaTypeMappingDefaultAttributeUnusedType(location));
-                }
-
-                break;
+                ValidateDefaultOrNullBehavior(attribute, location, diagnostics);
+                return true;
 
             case MappaTypeMappingDefaultBehavior.MapSourceType:
-                if (attribute.Type is { } attributeTargetType && !string.IsNullOrWhiteSpace(attributeTargetType.FullName))
-                {
-                    var typeSymbol = compilation.GetTypeByMetadataName(attributeTargetType.FullName.NormalizeType());
-                    if (typeSymbol is null)
-                    {
-                        throw new MappaGeneratorException($"Type '{attributeTargetType.FullName}' cannot be loaded at compile time.");
-                    }
+                return ValidateMapSourceTypeBehavior(attribute, targetType, sourceType, compilation, location, diagnostics);
 
-                    if (!typeSymbol.IsImplementingOrIsDerivedFromClass(targetType))
-                    {
-                        diagnostics.Add(MappaDiagnostics.ExplicitTargetTypeDoesNotDeriveMapMethodTargetType(typeSymbol, targetType, location));
-                        return false;
-                    }
-
-                    if (typeSymbol.TypeKind == TypeKind.Interface)
-                    {
-                        diagnostics.Add(MappaDiagnostics.CannotIdentifyStrategy(typeSymbol, sourceType, location));
-                        return false;
-                    }
-
-                    if (typeSymbol.IsAbstract)
-                    {
-                        diagnostics.Add(MappaDiagnostics.CannotIdentifyStrategy(typeSymbol, sourceType, location));
-                        return false;
-                    }
-                }
-
-                break;
             case MappaTypeMappingDefaultBehavior.InvokeMethod:
-                // Check the method name is not defined.
-                if (string.IsNullOrWhiteSpace(attribute.MethodName))
-                {
-                    diagnostics.Add(MappaDiagnostics.MethodToInvokeUndefined(location));
-                    return false;
-                }
-
-                var invokeMethodTypeSymbol =
-                    (attribute.Type is { } invokingType && !string.IsNullOrWhiteSpace(invokingType.FullName))
-                        ? compilation.GetTypeByMetadataName(invokingType.FullName)
-                        : mapMethodParentClassSymbol;
-
-                if (invokeMethodTypeSymbol is null)
-                {
-                    throw new MappaGeneratorException("Type that can be used to identify the method to invoke cannot be loaded.");
-                }
-
-                var resolutionResult = InvokeMethodResolution.TryResolvePolymorphismInvokeMethod(
-                    invokeMethodTypeSymbol,
-                    attribute.MethodName!,
+                return ValidateInvokeMethodBehavior(
+                    attribute,
                     sourceType,
-                    compilation,
-                    attribute.Type is not null,
+                    mapMethodParentClassSymbol,
                     nullableEnabled,
                     mapMethodHasTwoParameters,
-                    out var method,
-                    out var ambiguityDetails);
-                switch (resolutionResult)
-                {
-                    case InvokeMethodResolutionResult.NotFound:
-                        diagnostics.Add(MappaDiagnostics.CannotIdentifySuitableMethodToInvoke(
-                            invokeMethodTypeSymbol.ToDisplayString(),
-                            attribute.MethodName!,
-                            location));
-                        return false;
-
-                    case InvokeMethodResolutionResult.Ambiguous:
-                        diagnostics.Add(MappaDiagnostics.AmbiguousInvokeMethodResolution(location, ambiguityDetails));
-                        return false;
-
-                    case InvokeMethodResolutionResult.Success:
-                        resolvedInvokeMethod = method;
-                        break;
-                }
-
-                break;
+                    compilation,
+                    location,
+                    diagnostics,
+                    out resolvedInvokeMethod);
 
             default:
                 throw new ArgumentOutOfRangeException(nameof(attribute));
+        }
+    }
+
+    private static bool ValidateThrowBehavior(
+        MappaTypeMappingDefaultAttribute attribute,
+        Compilation compilation,
+        Location? location,
+        ICollection<Diagnostic> diagnostics)
+    {
+        if (attribute.Type is not { } attributeType || string.IsNullOrWhiteSpace(attributeType.FullName))
+        {
+            return true;
+        }
+
+        var typeSymbol = compilation.GetTypeByMetadataName(attributeType.FullName.NormalizeType());
+        if (typeSymbol is null)
+        {
+            throw new MappaGeneratorException($"Type '{attributeType.FullName}' cannot be loaded at compile time.");
+        }
+
+        if (!typeSymbol.CanBeThrown(compilation))
+        {
+            diagnostics.Add(MappaDiagnostics.TypeMustBeAnException(attributeType.FullName, location));
+            return false;
+        }
+
+        if (typeSymbol.IsAbstract)
+        {
+            diagnostics.Add(MappaDiagnostics.TypeMustBeConcrete(attributeType.FullName, location));
+            return false;
+        }
+
+        if (!typeSymbol.HasNamedTypeSymbolAccessibleZeroParametersConstructor(compilation)
+            && !typeSymbol.HasNamedTypeSymbolAccessibleSingleStringParametersConstructor(compilation))
+        {
+            diagnostics.Add(MappaDiagnostics.TypeMustHaveAConstructorWithNoParametersOrAConstructorWithOneStringParameter(attributeType.FullName, location));
+            return false;
+        }
+
+        return true;
+    }
+
+    private static void ValidateDefaultOrNullBehavior(
+        MappaTypeMappingDefaultAttribute attribute,
+        Location? location,
+        ICollection<Diagnostic> diagnostics)
+    {
+        if (attribute.Type is not null)
+        {
+            diagnostics.Add(MappaDiagnostics.MappaTypeMappingDefaultAttributeUnusedType(location));
+        }
+    }
+
+    private static bool ValidateMapSourceTypeBehavior(
+        MappaTypeMappingDefaultAttribute attribute,
+        ITypeSymbol targetType,
+        ITypeSymbol sourceType,
+        Compilation compilation,
+        Location? location,
+        ICollection<Diagnostic> diagnostics)
+    {
+        if (attribute.Type is not { } attributeTargetType || string.IsNullOrWhiteSpace(attributeTargetType.FullName))
+        {
+            return true;
+        }
+
+        var typeSymbol = compilation.GetTypeByMetadataName(attributeTargetType.FullName.NormalizeType());
+        if (typeSymbol is null)
+        {
+            throw new MappaGeneratorException($"Type '{attributeTargetType.FullName}' cannot be loaded at compile time.");
+        }
+
+        if (!typeSymbol.IsImplementingOrIsDerivedFromClass(targetType))
+        {
+            diagnostics.Add(MappaDiagnostics.ExplicitTargetTypeDoesNotDeriveMapMethodTargetType(typeSymbol, targetType, location));
+            return false;
+        }
+
+        if (typeSymbol.TypeKind == TypeKind.Interface)
+        {
+            diagnostics.Add(MappaDiagnostics.CannotIdentifyStrategy(typeSymbol, sourceType, location));
+            return false;
+        }
+
+        if (typeSymbol.IsAbstract)
+        {
+            diagnostics.Add(MappaDiagnostics.CannotIdentifyStrategy(typeSymbol, sourceType, location));
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool ValidateInvokeMethodBehavior(
+        MappaTypeMappingDefaultAttribute attribute,
+        ITypeSymbol sourceType,
+        ITypeSymbol mapMethodParentClassSymbol,
+        bool nullableEnabled,
+        bool mapMethodHasTwoParameters,
+        Compilation compilation,
+        Location? location,
+        ICollection<Diagnostic> diagnostics,
+        out IMethodSymbol? resolvedInvokeMethod)
+    {
+        resolvedInvokeMethod = null;
+        if (attribute.MethodName is not { } methodName || string.IsNullOrWhiteSpace(methodName))
+        {
+            diagnostics.Add(MappaDiagnostics.MethodToInvokeUndefined(location));
+            return false;
+        }
+
+        var invokeMethodTypeSymbol =
+            (attribute.Type is { } invokingType && !string.IsNullOrWhiteSpace(invokingType.FullName))
+                ? compilation.GetTypeByMetadataName(invokingType.FullName)
+                : mapMethodParentClassSymbol;
+
+        if (invokeMethodTypeSymbol is null)
+        {
+            throw new MappaGeneratorException("Type that can be used to identify the method to invoke cannot be loaded.");
+        }
+
+        var resolutionResult = InvokeMethodResolution.TryResolvePolymorphismInvokeMethod(
+            invokeMethodTypeSymbol,
+            methodName,
+            sourceType,
+            compilation,
+            attribute.Type is not null,
+            nullableEnabled,
+            mapMethodHasTwoParameters,
+            out var method,
+            out var ambiguityDetails);
+        switch (resolutionResult)
+        {
+            case InvokeMethodResolutionResult.NotFound:
+                diagnostics.Add(MappaDiagnostics.CannotIdentifySuitableMethodToInvoke(
+                    invokeMethodTypeSymbol.ToDisplayString(),
+                    methodName,
+                    location));
+                return false;
+
+            case InvokeMethodResolutionResult.Ambiguous:
+                diagnostics.Add(MappaDiagnostics.AmbiguousInvokeMethodResolution(location, ambiguityDetails));
+                return false;
+
+            case InvokeMethodResolutionResult.Success:
+                resolvedInvokeMethod = method;
+                break;
         }
 
         return true;

--- a/Mappa.Generator/Extensions/MethodSymbolExtensions.cs
+++ b/Mappa.Generator/Extensions/MethodSymbolExtensions.cs
@@ -219,50 +219,14 @@ internal static class MethodSymbolExtensions
         Predicate<ITypeSymbol> returnTypeCheck,
         ITypeSymbol[] parameterTypes)
     {
-        // Look up for accessible method in the type and its hierarchy.
-        var currentSymbol = targetTypeSymbol;
-        while (currentSymbol is not null)
-        {
-            if (HasExpectedMethod(currentSymbol, methodName))
-            {
-                return InterfaceMethodAccessMode.Direct;
-            }
-
-            currentSymbol = currentSymbol.BaseType;
-        }
-
-        string explicitName = $"{fullInterfaceName}<{elementTypeName}>.{methodName}";
-        currentSymbol = targetTypeSymbol;
-        while (currentSymbol is not null)
-        {
-            if (HasExpectedMethod(currentSymbol, explicitName))
-            {
-                return InterfaceMethodAccessMode.InterfaceExplicit;
-            }
-
-            currentSymbol = currentSymbol.BaseType;
-        }
-
-        // Look up for the generic variant of the method name.
-        if (targetTypeSymbol is INamedTypeSymbol
-            { OriginalDefinition.TypeArguments.Length: > 0 } namedTypeSymbol)
-        {
-            var typeArgumentName = namedTypeSymbol.OriginalDefinition.TypeArguments[0].Name;
-            string genericName = $"{fullInterfaceName}<{typeArgumentName}>.{methodName}";
-            currentSymbol = targetTypeSymbol;
-            while (currentSymbol is not null)
-            {
-                if (HasExpectedMethod(currentSymbol, genericName))
-                {
-                    return InterfaceMethodAccessMode.InterfaceExplicit;
-                }
-
-                currentSymbol = currentSymbol.BaseType;
-            }
-        }
-
-        // The method cannot be found.
-        return InterfaceMethodAccessMode.None;
+        bool HasExpectedMethod(ITypeSymbol typeSymbol, string name)
+            => typeSymbol
+                .GetMembers()
+                .OfType<IMethodSymbol>()
+                .Any(method => method.Name.Equals(name, StringComparison.Ordinal)
+                     && returnTypeCheck(method.ReturnType)
+                     && method.Parameters.Length == parameterTypes.Length
+                     && EqualParameters(method));
 
         bool EqualParameters(IMethodSymbol methodSymbol)
         {
@@ -277,14 +241,29 @@ internal static class MethodSymbolExtensions
             return true;
         }
 
-        bool HasExpectedMethod(ITypeSymbol typeSymbol, string name)
-            => typeSymbol
-                .GetMembers()
-                .OfType<IMethodSymbol>()
-                .Any(method => method.Name.Equals(name, StringComparison.Ordinal)
-                     && returnTypeCheck(method.ReturnType)
-                     && method.Parameters.Length == parameterTypes.Length
-                     && EqualParameters(method));
+        if (ExistsInTypeHierarchy(targetTypeSymbol, type => HasExpectedMethod(type, methodName)))
+        {
+            return InterfaceMethodAccessMode.Direct;
+        }
+
+        string explicitName = $"{fullInterfaceName}<{elementTypeName}>.{methodName}";
+        if (ExistsInTypeHierarchy(targetTypeSymbol, type => HasExpectedMethod(type, explicitName)))
+        {
+            return InterfaceMethodAccessMode.InterfaceExplicit;
+        }
+
+        if (targetTypeSymbol is INamedTypeSymbol
+            { OriginalDefinition.TypeArguments.Length: > 0 } namedTypeSymbol)
+        {
+            var typeArgumentName = namedTypeSymbol.OriginalDefinition.TypeArguments[0].Name;
+            string genericName = $"{fullInterfaceName}<{typeArgumentName}>.{methodName}";
+            if (ExistsInTypeHierarchy(targetTypeSymbol, type => HasExpectedMethod(type, genericName)))
+            {
+                return InterfaceMethodAccessMode.InterfaceExplicit;
+            }
+        }
+
+        return InterfaceMethodAccessMode.None;
     }
 
     /// <summary>
@@ -298,71 +277,40 @@ internal static class MethodSymbolExtensions
         this ITypeSymbol targetTypeSymbol,
         Compilation compilation)
     {
-        // Get and value type
         var (keyType, valueType) = targetTypeSymbol.GetKeyAndValueTypes(compilation);
 
-        // Look up for an indexer implementation in the hierarchy.
-        var currentType = targetTypeSymbol;
-        while (currentType is not null)
-        {
-            var hasIndexer = HasIndexer("this[]");
-            if (hasIndexer)
-            {
-                return InterfaceMethodAccessMode.Direct;
-            }
-
-            currentType = currentType.BaseType;
-        }
-
-        // Look for non-generic explicit implementation of IDictionary
-        var nonGenericName = $"System.Collections.Generic.IDictionary<{TypeSymbolExtensions.NormalizeType(keyType.ToDisplayString())},{TypeSymbolExtensions.NormalizeType(valueType.ToDisplayString())}>.this[]";
-        currentType = targetTypeSymbol;
-        while (currentType is not null)
-        {
-            var hasIndexer = HasIndexer(nonGenericName);
-            if (hasIndexer)
-            {
-                return InterfaceMethodAccessMode.InterfaceExplicit;
-            }
-
-            currentType = currentType.BaseType;
-        }
-
-        // Look for generic explicit implementation of IDictionary
-        if (targetTypeSymbol is INamedTypeSymbol { OriginalDefinition.TypeArguments.Length: 2 } namedTypeSymbol)
-        {
-            var keyTypeArgument = namedTypeSymbol.OriginalDefinition.TypeArguments[0].Name;
-            var valueTypeArgument = namedTypeSymbol.OriginalDefinition.TypeArguments[1].Name;
-
-            var genericName = $"System.Collections.Generic.IDictionary<{keyTypeArgument},{valueTypeArgument}>.this[]";
-
-            currentType = targetTypeSymbol;
-            while (currentType is not null)
-            {
-                var hasIndexer = HasIndexer(genericName);
-                if (hasIndexer)
-                {
-                    return InterfaceMethodAccessMode.InterfaceExplicit;
-                }
-
-                currentType = currentType.BaseType;
-            }
-        }
-
-        // Not found
-        return InterfaceMethodAccessMode.None;
-
         bool HasIndexer(string name)
-        {
-            var hasIndexer = targetTypeSymbol.GetMembers()
+            => targetTypeSymbol.GetMembers()
                 .OfType<IPropertySymbol>()
                 .Any(propertySymbol => propertySymbol.IsIndexer
                                          && propertySymbol.Parameters.Length == 1
                                          && propertySymbol.Name.Equals(name, StringComparison.OrdinalIgnoreCase)
                                          && SymbolEqualityComparer.Default.Equals(propertySymbol.Type, valueType)
                                          && SymbolEqualityComparer.Default.Equals(propertySymbol.Parameters[0].Type, keyType));
-            return hasIndexer;
+
+        if (HasIndexer("this[]"))
+        {
+            return InterfaceMethodAccessMode.Direct;
         }
+
+        var nonGenericName = $"System.Collections.Generic.IDictionary<{TypeSymbolExtensions.NormalizeType(keyType.ToDisplayString())},{TypeSymbolExtensions.NormalizeType(valueType.ToDisplayString())}>.this[]";
+        if (HasIndexer(nonGenericName))
+        {
+            return InterfaceMethodAccessMode.InterfaceExplicit;
+        }
+
+        if (targetTypeSymbol is INamedTypeSymbol { OriginalDefinition.TypeArguments.Length: 2 } namedTypeSymbol)
+        {
+            var keyTypeArgument = namedTypeSymbol.OriginalDefinition.TypeArguments[0].Name;
+            var valueTypeArgument = namedTypeSymbol.OriginalDefinition.TypeArguments[1].Name;
+            var genericName = $"System.Collections.Generic.IDictionary<{keyTypeArgument},{valueTypeArgument}>.this[]";
+            if (HasIndexer(genericName))
+            {
+                return InterfaceMethodAccessMode.InterfaceExplicit;
+            }
+        }
+
+        return InterfaceMethodAccessMode.None;
     }
 
     /// <summary>
@@ -378,60 +326,38 @@ internal static class MethodSymbolExtensions
     {
         var (keyType, valueType) = targetTypeSymbol.GetKeyAndValueTypes(compilation);
 
-        var currentType = targetTypeSymbol;
-        while (currentType is not null)
-        {
-            if (HasAdd("Add"))
-            {
-                return InterfaceMethodAccessMode.Direct;
-            }
-
-            currentType = currentType.BaseType;
-        }
-
-        var nonGenericName = $"System.Collections.Generic.IDictionary<{TypeSymbolExtensions.NormalizeType(keyType.ToDisplayString())},{TypeSymbolExtensions.NormalizeType(valueType.ToDisplayString())}>.Add";
-        currentType = targetTypeSymbol;
-        while (currentType is not null)
-        {
-            if (HasAdd(nonGenericName))
-            {
-                return InterfaceMethodAccessMode.InterfaceExplicit;
-            }
-
-            currentType = currentType.BaseType;
-        }
-
-        if (targetTypeSymbol is INamedTypeSymbol { OriginalDefinition.TypeArguments.Length: 2 } namedTypeSymbol)
-        {
-            var keyTypeArgument = namedTypeSymbol.OriginalDefinition.TypeArguments[0].Name;
-            var valueTypeArgument = namedTypeSymbol.OriginalDefinition.TypeArguments[1].Name;
-
-            var genericName = $"System.Collections.Generic.IDictionary<{keyTypeArgument},{valueTypeArgument}>.Add";
-
-            currentType = targetTypeSymbol;
-            while (currentType is not null)
-            {
-                if (HasAdd(genericName))
-                {
-                    return InterfaceMethodAccessMode.InterfaceExplicit;
-                }
-
-                currentType = currentType.BaseType;
-            }
-        }
-
-        return InterfaceMethodAccessMode.None;
-
         bool HasAdd(string name)
-        {
-            return targetTypeSymbol.GetMembers()
+            => targetTypeSymbol.GetMembers()
                 .OfType<IMethodSymbol>()
                 .Any(methodSymbol => methodSymbol.Name.Equals(name, StringComparison.OrdinalIgnoreCase)
                                      && methodSymbol.ReturnType.IsVoid()
                                      && methodSymbol.Parameters.Length == 2
                                      && SymbolEqualityComparer.Default.Equals(methodSymbol.Parameters[0].Type, keyType)
                                      && SymbolEqualityComparer.Default.Equals(methodSymbol.Parameters[1].Type, valueType));
+
+        if (HasAdd("Add"))
+        {
+            return InterfaceMethodAccessMode.Direct;
         }
+
+        var nonGenericName = $"System.Collections.Generic.IDictionary<{TypeSymbolExtensions.NormalizeType(keyType.ToDisplayString())},{TypeSymbolExtensions.NormalizeType(valueType.ToDisplayString())}>.Add";
+        if (HasAdd(nonGenericName))
+        {
+            return InterfaceMethodAccessMode.InterfaceExplicit;
+        }
+
+        if (targetTypeSymbol is INamedTypeSymbol { OriginalDefinition.TypeArguments.Length: 2 } namedTypeSymbol)
+        {
+            var keyTypeArgument = namedTypeSymbol.OriginalDefinition.TypeArguments[0].Name;
+            var valueTypeArgument = namedTypeSymbol.OriginalDefinition.TypeArguments[1].Name;
+            var genericName = $"System.Collections.Generic.IDictionary<{keyTypeArgument},{valueTypeArgument}>.Add";
+            if (HasAdd(genericName))
+            {
+                return InterfaceMethodAccessMode.InterfaceExplicit;
+            }
+        }
+
+        return InterfaceMethodAccessMode.None;
     }
 
     /// <summary>
@@ -456,5 +382,21 @@ internal static class MethodSymbolExtensions
         }
 
         return true;
+    }
+
+    private static bool ExistsInTypeHierarchy(ITypeSymbol typeSymbol, Func<ITypeSymbol, bool> predicate)
+    {
+        var currentSymbol = typeSymbol;
+        while (currentSymbol is not null)
+        {
+            if (predicate(currentSymbol))
+            {
+                return true;
+            }
+
+            currentSymbol = currentSymbol.BaseType;
+        }
+
+        return false;
     }
 }

--- a/Mappa.Generator/Extensions/PropertyPathAttributeMatching.cs
+++ b/Mappa.Generator/Extensions/PropertyPathAttributeMatching.cs
@@ -34,21 +34,15 @@ internal static class PropertyPathAttributeMatching
 
         if (propertyPathContext is null)
         {
-            return targetPath.GetFirstSegment() is string firstSegment
-                   && firstSegment.Equals(memberName, stringComparison);
+            return MatchesTargetMemberAtRoot(targetPath, memberName, stringComparison);
         }
 
         if (propertyPathContext.IsNestedAttributeScope)
         {
-            return propertyPathContext.OuterTargetSegment is string outerTargetSegment
-                   && targetPath.Segments.Length >= 2
-                   && targetPath.Segments[0].Equals(outerTargetSegment, stringComparison)
-                   && targetPath.Segments[targetPath.Segments.Length - 1].Equals(memberName, stringComparison);
+            return MatchesTargetMemberInNestedAttributeScope(targetPath, memberName, propertyPathContext, stringComparison);
         }
 
-        return propertyPathContext.RemainingTargetSegments.Length > 0
-               && propertyPathContext.RemainingTargetSegments[0].Equals(memberName, stringComparison)
-               && targetPath.EndsWith(propertyPathContext.RemainingTargetSegments);
+        return MatchesTargetMemberForRemainingSegments(targetPath, memberName, propertyPathContext, stringComparison);
     }
 
     /// <summary>
@@ -60,9 +54,15 @@ internal static class PropertyPathAttributeMatching
     internal static PropertyPathContext CreatePropertyPathContext(string targetPath, string? sourcePath)
     {
         var parsedTargetPath = PropertyPath.Parse(targetPath);
-        var parsedSourcePath = string.IsNullOrWhiteSpace(sourcePath)
-            ? PropertyPath.Parse(string.Empty)
-            : PropertyPath.Parse(sourcePath!);
+        PropertyPath parsedSourcePath;
+        if (string.IsNullOrWhiteSpace(sourcePath))
+        {
+            parsedSourcePath = PropertyPath.Parse(string.Empty);
+        }
+        else
+        {
+            parsedSourcePath = PropertyPath.Parse(sourcePath);
+        }
 
         return new PropertyPathContext(
             targetPath,
@@ -123,4 +123,30 @@ internal static class PropertyPathAttributeMatching
 
         return parsedSourcePath.GetFirstSegment();
     }
+
+    private static bool MatchesTargetMemberAtRoot(
+        PropertyPath targetPath,
+        string memberName,
+        StringComparison stringComparison)
+        => targetPath.GetFirstSegment() is string firstSegment
+           && firstSegment.Equals(memberName, stringComparison);
+
+    private static bool MatchesTargetMemberInNestedAttributeScope(
+        PropertyPath targetPath,
+        string memberName,
+        PropertyPathContext propertyPathContext,
+        StringComparison stringComparison)
+        => propertyPathContext.OuterTargetSegment is string outerTargetSegment
+           && targetPath.Segments.Length >= 2
+           && targetPath.Segments[0].Equals(outerTargetSegment, stringComparison)
+           && targetPath.Segments[targetPath.Segments.Length - 1].Equals(memberName, stringComparison);
+
+    private static bool MatchesTargetMemberForRemainingSegments(
+        PropertyPath targetPath,
+        string memberName,
+        PropertyPathContext propertyPathContext,
+        StringComparison stringComparison)
+        => propertyPathContext.RemainingTargetSegments.Length > 0
+           && propertyPathContext.RemainingTargetSegments[0].Equals(memberName, stringComparison)
+           && targetPath.EndsWith(propertyPathContext.RemainingTargetSegments);
 }

--- a/Mappa.Generator/Extensions/TypeSymbolExtensions.cs
+++ b/Mappa.Generator/Extensions/TypeSymbolExtensions.cs
@@ -70,6 +70,39 @@ internal static class TypeSymbolExtensions
     private const string ExceptionFullName = "System.Exception";
     private const string IQueryableFullName = "System.Linq.IQueryable`1";
 
+    private static readonly string[] SystemTupleMetadataNames =
+    [
+        Tuple1Fullname,
+        Tuple2Fullname,
+        Tuple3Fullname,
+        Tuple4Fullname,
+        Tuple5Fullname,
+        Tuple6Fullname,
+        Tuple7Fullname,
+        Tuple8Fullname,
+    ];
+
+    private static readonly Dictionary<string, string> NormalizedTypeAliases = new(StringComparer.Ordinal)
+    {
+        ["sbyte"] = typeof(sbyte).ToString(),
+        ["short"] = typeof(short).ToString(),
+        ["int"] = typeof(int).ToString(),
+        ["long"] = typeof(long).ToString(),
+        ["byte"] = typeof(byte).ToString(),
+        ["ushort"] = typeof(ushort).ToString(),
+        ["uint"] = typeof(uint).ToString(),
+        ["ulong"] = typeof(ulong).ToString(),
+        ["float"] = typeof(float).ToString(),
+        ["double"] = typeof(double).ToString(),
+        ["string"] = typeof(string).ToString(),
+        ["char"] = typeof(char).ToString(),
+        ["decimal"] = typeof(decimal).ToString(),
+        ["nint"] = typeof(nint).ToString(),
+        ["nuint"] = typeof(nuint).ToString(),
+        ["void"] = typeof(void).ToString(),
+        ["bool"] = typeof(bool).ToString(),
+    };
+
     /// <summary>
     /// Check if the type is <see cref="Void"/>.
     /// </summary>
@@ -614,15 +647,15 @@ internal static class TypeSymbolExtensions
     /// <param name="compilation">The compilation.</param>
     /// <returns><c>true</c> if the type symbol is <see cref="IDictionary{K,V}"/>.</returns>
     internal static bool IsTuple(this ITypeSymbol typeSymbol, Compilation compilation)
-        => typeSymbol.IsTupleType
-           || SymbolEqualityComparer.Default.Equals(compilation.GetTypeByMetadataName(Tuple1Fullname), typeSymbol.OriginalDefinition)
-           || SymbolEqualityComparer.Default.Equals(compilation.GetTypeByMetadataName(Tuple2Fullname), typeSymbol.OriginalDefinition)
-           || SymbolEqualityComparer.Default.Equals(compilation.GetTypeByMetadataName(Tuple3Fullname), typeSymbol.OriginalDefinition)
-           || SymbolEqualityComparer.Default.Equals(compilation.GetTypeByMetadataName(Tuple4Fullname), typeSymbol.OriginalDefinition)
-           || SymbolEqualityComparer.Default.Equals(compilation.GetTypeByMetadataName(Tuple5Fullname), typeSymbol.OriginalDefinition)
-           || SymbolEqualityComparer.Default.Equals(compilation.GetTypeByMetadataName(Tuple6Fullname), typeSymbol.OriginalDefinition)
-           || SymbolEqualityComparer.Default.Equals(compilation.GetTypeByMetadataName(Tuple7Fullname), typeSymbol.OriginalDefinition)
-           || SymbolEqualityComparer.Default.Equals(compilation.GetTypeByMetadataName(Tuple8Fullname), typeSymbol.OriginalDefinition);
+    {
+        if (typeSymbol.IsTupleType)
+        {
+            return true;
+        }
+
+        return SystemTupleMetadataNames.Any(metadataName =>
+            SymbolEqualityComparer.Default.Equals(compilation.GetTypeByMetadataName(metadataName), typeSymbol.OriginalDefinition));
+    }
 
     /// <summary>
     /// Gets the element type of the container.
@@ -642,15 +675,10 @@ internal static class TypeSymbolExtensions
             return namedTypeSymbol.TypeArguments.First();
         }
 
-        if (typeSymbol is INamedTypeSymbol nonGenericNamedTypeSymbol)
+        if (TryGetElementTypeFromEnumerableInterface(typeSymbol, out var elementTypeFromInterface)
+            && elementTypeFromInterface is not null)
         {
-            foreach (var @interface in nonGenericNamedTypeSymbol.AllInterfaces)
-            {
-                if (@interface is not null && @interface.IsGenericType && @interface.IsIEnumerable())
-                {
-                    return @interface.TypeArguments.First();
-                }
-            }
+            return elementTypeFromInterface;
         }
 
         throw new MappaGeneratorException($"Cannot obtain element type of \"{typeSymbol.ToDisplayString()}\"");
@@ -665,37 +693,19 @@ internal static class TypeSymbolExtensions
     /// <exception cref="MappaGeneratorException">If <paramref name="typeSymbol"/> is not an array or a generic type.</exception>
     internal static (ITypeSymbol KeyType, ITypeSymbol ValueType) GetKeyAndValueTypes(this ITypeSymbol typeSymbol, Compilation compilation)
     {
-        if (typeSymbol is INamedTypeSymbol { TypeArguments.Length: 2 } namedTypeSymbol)
+        if (TryGetKeyAndValueFromTypeArguments(typeSymbol, out var fromTypeArguments))
         {
-            return (namedTypeSymbol.TypeArguments.First(), namedTypeSymbol.TypeArguments.Last());
+            return fromTypeArguments;
         }
 
-        if (typeSymbol is INamedTypeSymbol { TypeArguments.Length: 1 } mightBeEnumerable)
+        if (TryGetKeyAndValueFromEnumerableElement(typeSymbol, compilation, out var fromEnumerable))
         {
-            var enumerableElementType = mightBeEnumerable.GetElementType();
-            if (enumerableElementType.IsKeyValuePair(compilation))
-            {
-                return enumerableElementType.GetKeyAndValueTypes(compilation);
-            }
+            return fromEnumerable;
         }
 
-        // The type might be non-generic but still implement an IDictionary
-        // so we need to check all the interfaces to get the type argument of
-        // the first IDictionary{TKey, TValue}.
-        if (typeSymbol is INamedTypeSymbol symbol)
+        if (TryGetKeyAndValueFromInterfaces(typeSymbol, compilation, out var fromInterfaces))
         {
-            foreach (var @interface in symbol.AllInterfaces)
-            {
-                if (@interface is not null && @interface.IsGenericType && @interface.IsIDictionary(compilation))
-                {
-                    return (@interface.TypeArguments.First(), @interface.TypeArguments.Last());
-                }
-
-                if (@interface is not null && @interface.IsGenericType && @interface.IsIEnumerableOfKeyValuePairs(compilation))
-                {
-                    return @interface.GetKeyAndValueTypes(compilation);
-                }
-            }
+            return fromInterfaces;
         }
 
         throw new MappaGeneratorException($"Cannot obtain key and value types of \"{typeSymbol.ToDisplayString()}\"");
@@ -966,35 +976,12 @@ internal static class TypeSymbolExtensions
         ITypeSymbol methodType,
         bool isNullableEnabled)
     {
-        if (!isNullableEnabled)
+        if (!AreEligibleForRelaxedNullabilityMatch(requiredType, methodType, isNullableEnabled))
         {
             return false;
         }
 
-        if (!SymbolEqualityComparer.Default.Equals(requiredType, methodType))
-        {
-            return false;
-        }
-
-        if (requiredType.NullableAnnotation == NullableAnnotation.None
-            || methodType.NullableAnnotation == NullableAnnotation.None)
-        {
-            return false;
-        }
-
-        if (requiredType.NullableAnnotation == NullableAnnotation.Annotated
-            && methodType.NullableAnnotation == NullableAnnotation.NotAnnotated)
-        {
-            return true;
-        }
-
-        if (requiredType.NullableAnnotation == NullableAnnotation.NotAnnotated
-            && methodType.NullableAnnotation == NullableAnnotation.Annotated)
-        {
-            return true;
-        }
-
-        return false;
+        return HasOppositeNullableAnnotations(requiredType.NullableAnnotation, methodType.NullableAnnotation);
     }
 
     /// <summary>
@@ -1137,24 +1124,7 @@ internal static class TypeSymbolExtensions
 
         foreach (var attribute in fieldSymbol.GetAttributes())
         {
-            var attributeClass = attribute.AttributeClass;
-            if (attributeClass is null)
-            {
-                continue;
-            }
-
-            var isDescriptionAttribute = descriptionAttributeSymbol is not null
-                && SymbolEqualityComparer.Default.Equals(attributeClass, descriptionAttributeSymbol);
-            isDescriptionAttribute |= attributeClass.Name == "DescriptionAttribute"
-                && attributeClass.ContainingNamespace.ToDisplayString() == "System.ComponentModel";
-            if (!isDescriptionAttribute)
-            {
-                continue;
-            }
-
-            if (attribute.ConstructorArguments.Length > 0
-                && attribute.ConstructorArguments[0].Value is string description
-                && !string.IsNullOrWhiteSpace(description))
+            if (TryReadDescriptionFromAttribute(attribute, descriptionAttributeSymbol, out var description))
             {
                 return description;
             }
@@ -2004,27 +1974,7 @@ internal static class TypeSymbolExtensions
     /// <param name="type">The type name to be normalised.</param>
     /// <returns>The normalised name of the type.</returns>
     internal static string NormalizeType(this string type)
-        => type switch
-        {
-            "sbyte" => typeof(sbyte).ToString(),
-            "short" => typeof(short).ToString(),
-            "int" => typeof(int).ToString(),
-            "long" => typeof(long).ToString(),
-            "byte" => typeof(byte).ToString(),
-            "ushort" => typeof(ushort).ToString(),
-            "uint" => typeof(uint).ToString(),
-            "ulong" => typeof(ulong).ToString(),
-            "float" => typeof(float).ToString(),
-            "double" => typeof(double).ToString(),
-            "string" => typeof(string).ToString(),
-            "char" => typeof(char).ToString(),
-            "decimal" => typeof(decimal).ToString(),
-            "nint" => typeof(nint).ToString(),
-            "nuint" => typeof(nuint).ToString(),
-            "void" => typeof(void).ToString(),
-            "bool" => typeof(bool).ToString(),
-            _ => type,
-        };
+        => NormalizedTypeAliases.TryGetValue(type, out var normalized) ? normalized : type;
 
     /// <summary>
     /// Check if <paramref name="typeSymbol"/> is either <see cref="IsValueTypeNullable"/>
@@ -2248,18 +2198,183 @@ internal static class TypeSymbolExtensions
         bool nullableEnabled,
         bool acceptTwoParameters)
     {
-        return (!mustBeStatic || methodSymbol.IsStatic) && methodSymbol.Parameters.Length switch
+        if (mustBeStatic && !methodSymbol.IsStatic)
+        {
+            return false;
+        }
+
+        return methodSymbol.Parameters.Length switch
         {
             0 => true,
-            1 => methodSymbol.AreParametersRefModifiersValid()
-                 && methodSymbol.Parameters[0].Type.IsEqualTo(expectedSourceType, nullableEnabled),
-            2 when acceptTwoParameters => methodSymbol.AreParametersRefModifiersValid()
-                                          && IsFirstParameterOk()
-                                          && IsSecondParameterOk(),
+            1 => ValidatePolymorphismSingleParameterMethod(methodSymbol, expectedSourceType, nullableEnabled),
+            2 when acceptTwoParameters => ValidatePolymorphismTwoParameterMethod(methodSymbol, expectedSourceType, compilation, nullableEnabled),
             _ => false,
         };
+    }
 
-        bool IsFirstParameterOk() => methodSymbol.Parameters[0].Type.IsEqualTo(expectedSourceType, nullableEnabled);
-        bool IsSecondParameterOk() => methodSymbol.SecondParameterIsMappaContext(compilation);
+    private static bool ValidatePolymorphismSingleParameterMethod(
+        IMethodSymbol methodSymbol,
+        ITypeSymbol expectedSourceType,
+        bool nullableEnabled)
+    {
+        return methodSymbol.AreParametersRefModifiersValid()
+               && methodSymbol.Parameters[0].Type.IsEqualTo(expectedSourceType, nullableEnabled);
+    }
+
+    private static bool ValidatePolymorphismTwoParameterMethod(
+        IMethodSymbol methodSymbol,
+        ITypeSymbol expectedSourceType,
+        Compilation compilation,
+        bool nullableEnabled)
+    {
+        return methodSymbol.AreParametersRefModifiersValid()
+               && methodSymbol.Parameters[0].Type.IsEqualTo(expectedSourceType, nullableEnabled)
+               && methodSymbol.SecondParameterIsMappaContext(compilation);
+    }
+
+    private static bool AreEligibleForRelaxedNullabilityMatch(
+        ITypeSymbol requiredType,
+        ITypeSymbol methodType,
+        bool isNullableEnabled)
+    {
+        return isNullableEnabled
+               && SymbolEqualityComparer.Default.Equals(requiredType, methodType)
+               && requiredType.NullableAnnotation is not NullableAnnotation.None
+               && methodType.NullableAnnotation is not NullableAnnotation.None;
+    }
+
+    private static bool HasOppositeNullableAnnotations(
+        NullableAnnotation requiredAnnotation,
+        NullableAnnotation methodAnnotation)
+    {
+        return (requiredAnnotation, methodAnnotation) switch
+        {
+            (NullableAnnotation.Annotated, NullableAnnotation.NotAnnotated) => true,
+            (NullableAnnotation.NotAnnotated, NullableAnnotation.Annotated) => true,
+            _ => false,
+        };
+    }
+
+    private static bool TryGetElementTypeFromEnumerableInterface(ITypeSymbol typeSymbol, out ITypeSymbol? elementType)
+    {
+        elementType = null;
+        if (typeSymbol is not INamedTypeSymbol nonGenericNamedTypeSymbol)
+        {
+            return false;
+        }
+
+        foreach (var @interface in nonGenericNamedTypeSymbol.AllInterfaces)
+        {
+            if (@interface is not null && @interface.IsGenericType && @interface.IsIEnumerable())
+            {
+                elementType = @interface.TypeArguments.First();
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryReadDescriptionFromAttribute(
+        AttributeData attribute,
+        INamedTypeSymbol? descriptionAttributeSymbol,
+        out string? description)
+    {
+        description = null;
+        var attributeClass = attribute.AttributeClass;
+        if (attributeClass is null || !IsDescriptionAttributeClass(attributeClass, descriptionAttributeSymbol))
+        {
+            return false;
+        }
+
+        if (attribute.ConstructorArguments.Length > 0
+            && attribute.ConstructorArguments[0].Value is string descriptionValue
+            && !string.IsNullOrWhiteSpace(descriptionValue))
+        {
+            description = descriptionValue;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsDescriptionAttributeClass(INamedTypeSymbol attributeClass, INamedTypeSymbol? descriptionAttributeSymbol)
+    {
+        if (descriptionAttributeSymbol is not null
+            && SymbolEqualityComparer.Default.Equals(attributeClass, descriptionAttributeSymbol))
+        {
+            return true;
+        }
+
+        return attributeClass.Name == "DescriptionAttribute"
+               && attributeClass.ContainingNamespace.ToDisplayString() == "System.ComponentModel";
+    }
+
+    private static bool TryGetKeyAndValueFromTypeArguments(
+        ITypeSymbol typeSymbol,
+        out (ITypeSymbol KeyType, ITypeSymbol ValueType) keyAndValueTypes)
+    {
+        if (typeSymbol is INamedTypeSymbol { TypeArguments.Length: 2 } namedTypeSymbol)
+        {
+            keyAndValueTypes = (namedTypeSymbol.TypeArguments.First(), namedTypeSymbol.TypeArguments.Last());
+            return true;
+        }
+
+        keyAndValueTypes = default;
+        return false;
+    }
+
+    private static bool TryGetKeyAndValueFromEnumerableElement(
+        ITypeSymbol typeSymbol,
+        Compilation compilation,
+        out (ITypeSymbol KeyType, ITypeSymbol ValueType) keyAndValueTypes)
+    {
+        if (typeSymbol is INamedTypeSymbol { TypeArguments.Length: 1 } mightBeEnumerable)
+        {
+            var enumerableElementType = mightBeEnumerable.GetElementType();
+            if (enumerableElementType.IsKeyValuePair(compilation))
+            {
+                keyAndValueTypes = enumerableElementType.GetKeyAndValueTypes(compilation);
+                return true;
+            }
+        }
+
+        keyAndValueTypes = default;
+        return false;
+    }
+
+    private static bool TryGetKeyAndValueFromInterfaces(
+        ITypeSymbol typeSymbol,
+        Compilation compilation,
+        out (ITypeSymbol KeyType, ITypeSymbol ValueType) keyAndValueTypes)
+    {
+        if (typeSymbol is not INamedTypeSymbol symbol)
+        {
+            keyAndValueTypes = default;
+            return false;
+        }
+
+        foreach (var @interface in symbol.AllInterfaces)
+        {
+            if (@interface is null || !@interface.IsGenericType)
+            {
+                continue;
+            }
+
+            if (@interface.IsIDictionary(compilation))
+            {
+                keyAndValueTypes = (@interface.TypeArguments.First(), @interface.TypeArguments.Last());
+                return true;
+            }
+
+            if (@interface.IsIEnumerableOfKeyValuePairs(compilation))
+            {
+                keyAndValueTypes = @interface.GetKeyAndValueTypes(compilation);
+                return true;
+            }
+        }
+
+        keyAndValueTypes = default;
+        return false;
     }
 }

--- a/Mappa.Generator/Helpers/InvokeMethodResolution.cs
+++ b/Mappa.Generator/Helpers/InvokeMethodResolution.cs
@@ -240,19 +240,14 @@ internal static class InvokeMethodResolution
         method = null;
         ambiguityDetails = string.Empty;
 
-        var methodsWithTheRightNameAndReturnType = methods
-            .Where(candidate =>
-                candidate.Name.Equals(methodName, StringComparison.Ordinal) &&
-                compilation.IsSymbolAccessibleWithin(candidate, mapClass) &&
-                (candidate.ReturnType.IsEqualTo(targetType, nullableEnabled) ||
-                 compilation.HasImplicitConversion(candidate.ReturnType, targetType)) &&
-                staticRequirement switch
-                {
-                    InvokeMethodStaticRequirement.StaticOrNotStatic => true,
-                    InvokeMethodStaticRequirement.Static => candidate.IsStatic,
-                    InvokeMethodStaticRequirement.NotStatic => !candidate.IsStatic,
-                    _ => false,
-                })
+        var methodsWithTheRightNameAndReturnType = FilterCandidatesByNameReturnTypeAndStatic(
+                methods,
+                compilation,
+                mapClass,
+                methodName,
+                targetType,
+                nullableEnabled,
+                staticRequirement)
             .ToArray();
 
         if (methodsWithTheRightNameAndReturnType.Length == 0)
@@ -262,6 +257,78 @@ internal static class InvokeMethodResolution
 
         var rootProvidesMappaContext = rootMapMethod.ProvideMappaContextWhenInvoked();
         var typeDisplayName = mapClass.ToDisplayString();
+        var sourcePropertyType = sourceProperty?.Type;
+
+        foreach (var tierPredicate in BuildMappaInvokeMethodResolutionTiers(
+                     compilation,
+                     sourceClassType,
+                     sourcePropertyType,
+                     nullableEnabled,
+                     rootProvidesMappaContext))
+        {
+            var tierResult = PickFromTier(
+                methodsWithTheRightNameAndReturnType,
+                methodName,
+                typeDisplayName,
+                tierPredicate);
+            if (tierResult.Status is not InvokeMethodResolutionResult.NotFound)
+            {
+                method = tierResult.Method;
+                ambiguityDetails = tierResult.AmbiguityDetails;
+                return tierResult.Status;
+            }
+        }
+
+        return InvokeMethodResolutionResult.NotFound;
+    }
+
+    private static IEnumerable<Func<IMethodSymbol, bool>> BuildMappaInvokeMethodResolutionTiers(
+        Compilation compilation,
+        ITypeSymbol sourceClassType,
+        ITypeSymbol? sourcePropertyType,
+        bool nullableEnabled,
+        bool rootProvidesMappaContext)
+    {
+        foreach (var tier in BuildExactAndImplicitSourcePropertyTiers(
+                     compilation,
+                     sourceClassType,
+                     sourcePropertyType,
+                     nullableEnabled,
+                     rootProvidesMappaContext))
+        {
+            yield return tier;
+        }
+
+        foreach (var tier in BuildSourceOnlyResolutionTiers(
+                     compilation,
+                     sourceClassType,
+                     nullableEnabled,
+                     rootProvidesMappaContext))
+        {
+            yield return tier;
+        }
+
+        foreach (var tier in BuildPropertyOnlyAndEmptyResolutionTiers(
+                     compilation,
+                     sourcePropertyType,
+                     nullableEnabled,
+                     rootProvidesMappaContext))
+        {
+            yield return tier;
+        }
+    }
+
+    private static IEnumerable<Func<IMethodSymbol, bool>> BuildExactAndImplicitSourcePropertyTiers(
+        Compilation compilation,
+        ITypeSymbol sourceClassType,
+        ITypeSymbol? sourcePropertyType,
+        bool nullableEnabled,
+        bool rootProvidesMappaContext)
+    {
+        if (sourcePropertyType is null)
+        {
+            yield break;
+        }
 
         bool IsExactSourceType(ITypeSymbol parameterType)
             => parameterType.IsEqualTo(sourceClassType, nullableEnabled);
@@ -271,240 +338,148 @@ internal static class InvokeMethodResolution
                compilation.HasImplicitConversion(sourceClassType, parameterType);
 
         bool IsExactSourcePropertyType(ITypeSymbol parameterType)
-            => sourceProperty is not null &&
-               parameterType.IsEqualTo(sourceProperty.Type, nullableEnabled);
+            => parameterType.IsEqualTo(sourcePropertyType, nullableEnabled);
 
         bool IsImplicitSourcePropertyType(ITypeSymbol parameterType)
-            => sourceProperty is not null &&
-               (IsExactSourcePropertyType(parameterType) ||
-                compilation.HasImplicitConversion(sourceProperty.Type, parameterType));
-
-        if (rootProvidesMappaContext && sourceProperty is not null)
-        {
-            var tier1Result = PickFromTier(
-                methodsWithTheRightNameAndReturnType,
-                methodName,
-                typeDisplayName,
-                candidate => candidate.Parameters.Length == 3 &&
-                             IsExactSourceType(candidate.Parameters[0].Type) &&
-                             IsExactSourcePropertyType(candidate.Parameters[1].Type) &&
-                             candidate.ParameterIsMappaContext(compilation, 2));
-            if (tier1Result.Status is not InvokeMethodResolutionResult.NotFound)
-            {
-                method = tier1Result.Method;
-                ambiguityDetails = tier1Result.AmbiguityDetails;
-                return tier1Result.Status;
-            }
-        }
-
-        if (sourceProperty is not null)
-        {
-            var tier2Result = PickFromTier(
-                methodsWithTheRightNameAndReturnType,
-                methodName,
-                typeDisplayName,
-                candidate => candidate.Parameters.Length == 2 &&
-                             IsExactSourceType(candidate.Parameters[0].Type) &&
-                             IsExactSourcePropertyType(candidate.Parameters[1].Type));
-            if (tier2Result.Status is not InvokeMethodResolutionResult.NotFound)
-            {
-                method = tier2Result.Method;
-                ambiguityDetails = tier2Result.AmbiguityDetails;
-                return tier2Result.Status;
-            }
-        }
-
-        if (rootProvidesMappaContext && sourceProperty is not null)
-        {
-            var tier3Result = PickFromTier(
-                methodsWithTheRightNameAndReturnType,
-                methodName,
-                typeDisplayName,
-                candidate => candidate.Parameters.Length == 3 &&
-                             IsImplicitSourceType(candidate.Parameters[0].Type) &&
-                             IsImplicitSourcePropertyType(candidate.Parameters[1].Type) &&
-                             candidate.ParameterIsMappaContext(compilation, 2));
-            if (tier3Result.Status is not InvokeMethodResolutionResult.NotFound)
-            {
-                method = tier3Result.Method;
-                ambiguityDetails = tier3Result.AmbiguityDetails;
-                return tier3Result.Status;
-            }
-        }
-
-        if (sourceProperty is not null)
-        {
-            var tier4Result = PickFromTier(
-                methodsWithTheRightNameAndReturnType,
-                methodName,
-                typeDisplayName,
-                candidate => candidate.Parameters.Length == 2 &&
-                             IsImplicitSourceType(candidate.Parameters[0].Type) &&
-                             IsImplicitSourcePropertyType(candidate.Parameters[1].Type));
-            if (tier4Result.Status is not InvokeMethodResolutionResult.NotFound)
-            {
-                method = tier4Result.Method;
-                ambiguityDetails = tier4Result.AmbiguityDetails;
-                return tier4Result.Status;
-            }
-        }
+            => IsExactSourcePropertyType(parameterType) ||
+               compilation.HasImplicitConversion(sourcePropertyType, parameterType);
 
         if (rootProvidesMappaContext)
         {
-            var tier5Result = PickFromTier(
-                methodsWithTheRightNameAndReturnType,
-                methodName,
-                typeDisplayName,
-                candidate => candidate.Parameters.Length == 2 &&
-                             IsExactSourceType(candidate.Parameters[0].Type) &&
-                             candidate.ParameterIsMappaContext(compilation, 1));
-            if (tier5Result.Status is not InvokeMethodResolutionResult.NotFound)
-            {
-                method = tier5Result.Method;
-                ambiguityDetails = tier5Result.AmbiguityDetails;
-                return tier5Result.Status;
-            }
+            yield return candidate => candidate.Parameters.Length == 3 &&
+                                      IsExactSourceType(candidate.Parameters[0].Type) &&
+                                      IsExactSourcePropertyType(candidate.Parameters[1].Type) &&
+                                      candidate.ParameterIsMappaContext(compilation, 2);
         }
 
-        var tier6Result = PickFromTier(
-            methodsWithTheRightNameAndReturnType,
-            methodName,
-            typeDisplayName,
-            candidate => candidate.Parameters.Length == 1 &&
-                         IsExactSourceType(candidate.Parameters[0].Type));
-        if (tier6Result.Status is not InvokeMethodResolutionResult.NotFound)
-        {
-            method = tier6Result.Method;
-            ambiguityDetails = tier6Result.AmbiguityDetails;
-            return tier6Result.Status;
-        }
+        yield return candidate => candidate.Parameters.Length == 2 &&
+                                  IsExactSourceType(candidate.Parameters[0].Type) &&
+                                  IsExactSourcePropertyType(candidate.Parameters[1].Type);
 
         if (rootProvidesMappaContext)
         {
-            var tier7Result = PickFromTier(
-                methodsWithTheRightNameAndReturnType,
-                methodName,
-                typeDisplayName,
-                candidate => candidate.Parameters.Length == 2 &&
-                             IsImplicitSourceType(candidate.Parameters[0].Type) &&
-                             candidate.ParameterIsMappaContext(compilation, 1));
-            if (tier7Result.Status is not InvokeMethodResolutionResult.NotFound)
-            {
-                method = tier7Result.Method;
-                ambiguityDetails = tier7Result.AmbiguityDetails;
-                return tier7Result.Status;
-            }
+            yield return candidate => candidate.Parameters.Length == 3 &&
+                                      IsImplicitSourceType(candidate.Parameters[0].Type) &&
+                                      IsImplicitSourcePropertyType(candidate.Parameters[1].Type) &&
+                                      candidate.ParameterIsMappaContext(compilation, 2);
         }
 
-        var tier8Result = PickFromTier(
-            methodsWithTheRightNameAndReturnType,
-            methodName,
-            typeDisplayName,
-            candidate => candidate.Parameters.Length == 1 &&
-                         compilation.HasImplicitConversion(sourceClassType, candidate.Parameters[0].Type));
-        if (tier8Result.Status is not InvokeMethodResolutionResult.NotFound)
-        {
-            method = tier8Result.Method;
-            ambiguityDetails = tier8Result.AmbiguityDetails;
-            return tier8Result.Status;
-        }
-
-        if (rootProvidesMappaContext && sourceProperty is not null)
-        {
-            var tier9Result = PickFromTier(
-                methodsWithTheRightNameAndReturnType,
-                methodName,
-                typeDisplayName,
-                candidate => candidate.Parameters.Length == 2 &&
-                             IsExactSourcePropertyType(candidate.Parameters[0].Type) &&
-                             candidate.ParameterIsMappaContext(compilation, 1));
-            if (tier9Result.Status is not InvokeMethodResolutionResult.NotFound)
-            {
-                method = tier9Result.Method;
-                ambiguityDetails = tier9Result.AmbiguityDetails;
-                return tier9Result.Status;
-            }
-        }
-
-        if (sourceProperty is not null)
-        {
-            var tier10Result = PickFromTier(
-                methodsWithTheRightNameAndReturnType,
-                methodName,
-                typeDisplayName,
-                candidate => candidate.Parameters.Length == 1 &&
-                             IsExactSourcePropertyType(candidate.Parameters[0].Type));
-            if (tier10Result.Status is not InvokeMethodResolutionResult.NotFound)
-            {
-                method = tier10Result.Method;
-                ambiguityDetails = tier10Result.AmbiguityDetails;
-                return tier10Result.Status;
-            }
-        }
-
-        if (rootProvidesMappaContext && sourceProperty is not null)
-        {
-            var tier11Result = PickFromTier(
-                methodsWithTheRightNameAndReturnType,
-                methodName,
-                typeDisplayName,
-                candidate => candidate.Parameters.Length == 2 &&
-                             IsImplicitSourcePropertyType(candidate.Parameters[0].Type) &&
-                             candidate.ParameterIsMappaContext(compilation, 1));
-            if (tier11Result.Status is not InvokeMethodResolutionResult.NotFound)
-            {
-                method = tier11Result.Method;
-                ambiguityDetails = tier11Result.AmbiguityDetails;
-                return tier11Result.Status;
-            }
-        }
-
-        if (sourceProperty is not null)
-        {
-            var tier12Result = PickFromTier(
-                methodsWithTheRightNameAndReturnType,
-                methodName,
-                typeDisplayName,
-                candidate => candidate.Parameters.Length == 1 &&
-                             compilation.HasImplicitConversion(sourceProperty.Type, candidate.Parameters[0].Type));
-            if (tier12Result.Status is not InvokeMethodResolutionResult.NotFound)
-            {
-                method = tier12Result.Method;
-                ambiguityDetails = tier12Result.AmbiguityDetails;
-                return tier12Result.Status;
-            }
-        }
-
-        if (rootProvidesMappaContext)
-        {
-            var tier13Result = PickFromTier(
-                methodsWithTheRightNameAndReturnType,
-                methodName,
-                typeDisplayName,
-                candidate => candidate.Parameters.Length == 1 &&
-                             candidate.ParameterIsMappaContext(compilation, 0));
-            if (tier13Result.Status is not InvokeMethodResolutionResult.NotFound)
-            {
-                method = tier13Result.Method;
-                ambiguityDetails = tier13Result.AmbiguityDetails;
-                return tier13Result.Status;
-            }
-        }
-
-        var tier14Result = PickFromTier(
-            methodsWithTheRightNameAndReturnType,
-            methodName,
-            typeDisplayName,
-            candidate => candidate.Parameters.Length == 0);
-        if (tier14Result.Status is not InvokeMethodResolutionResult.NotFound)
-        {
-            method = tier14Result.Method;
-            ambiguityDetails = tier14Result.AmbiguityDetails;
-            return tier14Result.Status;
-        }
-
-        return InvokeMethodResolutionResult.NotFound;
+        yield return candidate => candidate.Parameters.Length == 2 &&
+                                  IsImplicitSourceType(candidate.Parameters[0].Type) &&
+                                  IsImplicitSourcePropertyType(candidate.Parameters[1].Type);
     }
+
+    private static IEnumerable<Func<IMethodSymbol, bool>> BuildSourceOnlyResolutionTiers(
+        Compilation compilation,
+        ITypeSymbol sourceClassType,
+        bool nullableEnabled,
+        bool rootProvidesMappaContext)
+    {
+        bool IsExactSourceType(ITypeSymbol parameterType)
+            => parameterType.IsEqualTo(sourceClassType, nullableEnabled);
+
+        bool IsImplicitSourceType(ITypeSymbol parameterType)
+            => IsExactSourceType(parameterType) ||
+               compilation.HasImplicitConversion(sourceClassType, parameterType);
+
+        if (rootProvidesMappaContext)
+        {
+            yield return candidate => candidate.Parameters.Length == 2 &&
+                                      IsExactSourceType(candidate.Parameters[0].Type) &&
+                                      candidate.ParameterIsMappaContext(compilation, 1);
+        }
+
+        yield return candidate => candidate.Parameters.Length == 1 &&
+                                  IsExactSourceType(candidate.Parameters[0].Type);
+
+        if (rootProvidesMappaContext)
+        {
+            yield return candidate => candidate.Parameters.Length == 2 &&
+                                      IsImplicitSourceType(candidate.Parameters[0].Type) &&
+                                      candidate.ParameterIsMappaContext(compilation, 1);
+        }
+
+        yield return candidate => candidate.Parameters.Length == 1 &&
+                                  compilation.HasImplicitConversion(sourceClassType, candidate.Parameters[0].Type);
+    }
+
+    private static IEnumerable<Func<IMethodSymbol, bool>> BuildPropertyOnlyAndEmptyResolutionTiers(
+        Compilation compilation,
+        ITypeSymbol? sourcePropertyType,
+        bool nullableEnabled,
+        bool rootProvidesMappaContext)
+    {
+        if (sourcePropertyType is not null)
+        {
+            bool IsExactSourcePropertyType(ITypeSymbol parameterType)
+                => parameterType.IsEqualTo(sourcePropertyType, nullableEnabled);
+
+            bool IsImplicitSourcePropertyType(ITypeSymbol parameterType)
+                => IsExactSourcePropertyType(parameterType) ||
+                   compilation.HasImplicitConversion(sourcePropertyType, parameterType);
+
+            if (rootProvidesMappaContext)
+            {
+                yield return candidate => candidate.Parameters.Length == 2 &&
+                                          IsExactSourcePropertyType(candidate.Parameters[0].Type) &&
+                                          candidate.ParameterIsMappaContext(compilation, 1);
+            }
+
+            yield return candidate => candidate.Parameters.Length == 1 &&
+                                      IsExactSourcePropertyType(candidate.Parameters[0].Type);
+
+            if (rootProvidesMappaContext)
+            {
+                yield return candidate => candidate.Parameters.Length == 2 &&
+                                          IsImplicitSourcePropertyType(candidate.Parameters[0].Type) &&
+                                          candidate.ParameterIsMappaContext(compilation, 1);
+            }
+
+            yield return candidate => candidate.Parameters.Length == 1 &&
+                                      compilation.HasImplicitConversion(sourcePropertyType, candidate.Parameters[0].Type);
+        }
+
+        if (rootProvidesMappaContext)
+        {
+            yield return candidate => candidate.Parameters.Length == 1 &&
+                                      candidate.ParameterIsMappaContext(compilation, 0);
+        }
+
+        yield return candidate => candidate.Parameters.Length == 0;
+    }
+
+    private static IEnumerable<IMethodSymbol> FilterCandidatesByNameReturnTypeAndStatic(
+        IMethodSymbol[] methods,
+        Compilation compilation,
+        ITypeSymbol mapClass,
+        string methodName,
+        ITypeSymbol targetType,
+        bool nullableEnabled,
+        InvokeMethodStaticRequirement staticRequirement)
+    {
+        return methods.Where(candidate =>
+            candidate.Name.Equals(methodName, StringComparison.Ordinal) &&
+            compilation.IsSymbolAccessibleWithin(candidate, mapClass) &&
+            MatchesReturnType(compilation, candidate.ReturnType, targetType, nullableEnabled) &&
+            MatchesStaticRequirement(candidate, staticRequirement));
+    }
+
+    private static bool MatchesReturnType(
+        Compilation compilation,
+        ITypeSymbol returnType,
+        ITypeSymbol targetType,
+        bool nullableEnabled)
+        => returnType.IsEqualTo(targetType, nullableEnabled) ||
+           compilation.HasImplicitConversion(returnType, targetType);
+
+    private static bool MatchesStaticRequirement(IMethodSymbol candidate, InvokeMethodStaticRequirement staticRequirement)
+        => staticRequirement switch
+        {
+            InvokeMethodStaticRequirement.StaticOrNotStatic => true,
+            InvokeMethodStaticRequirement.Static => candidate.IsStatic,
+            InvokeMethodStaticRequirement.NotStatic => !candidate.IsStatic,
+            _ => false,
+        };
 
     private static TierPickResult PickFromTier(
         IMethodSymbol[] pool,

--- a/Mappa.Generator/Helpers/MapHookResolver.cs
+++ b/Mappa.Generator/Helpers/MapHookResolver.cs
@@ -119,90 +119,31 @@ internal sealed class MapHookResolver
         ITypeSymbol mappedValueType,
         string hookKind)
     {
-        ISymbol? fieldOrProperty = null;
-        ITypeSymbol? explicitType = null;
-        ITypeSymbol lookupType;
-        InvokeMethodStaticRequirement staticRequirement;
-
-        if (attribute.FieldName is not null)
+        if (!this.TryBuildHookLookup(attribute, out var lookup))
         {
-            fieldOrProperty = this.compilation.LocateAccessibleFieldOrPropertyInTypeHierarchy(
-                this.mapClass,
-                attribute.FieldName,
-                this.mapClass);
-            if (fieldOrProperty is null)
-            {
-                this.context.ReportDiagnostic(MappaDiagnostics.CannotFindFieldOrProperty(
-                    attribute.Location,
-                    attribute.FieldName));
-                return null;
-            }
-
-            lookupType = GetFieldOrPropertyType(fieldOrProperty);
-            staticRequirement = this.mapMethod.CanBeUsedByStaticMethod && !fieldOrProperty.IsStatic
-                ? InvokeMethodStaticRequirement.Static
-                : InvokeMethodStaticRequirement.StaticOrNotStatic;
-        }
-        else if (attribute.ClassType is not null)
-        {
-            var classTypeFullName = attribute.ClassType.FullName;
-            if (string.IsNullOrWhiteSpace(classTypeFullName))
-            {
-                throw new MappaGeneratorException($"Cannot detect the full name for hook type '{attribute.ClassType}'.");
-            }
-
-            explicitType = this.compilation.GetTypeByMetadataName(classTypeFullName);
-            if (explicitType is null)
-            {
-                this.context.ReportDiagnostic(MappaDiagnostics.CannotDetectType(
-                    attribute.Location,
-                    classTypeFullName));
-                return null;
-            }
-
-            lookupType = explicitType;
-            staticRequirement = InvokeMethodStaticRequirement.Static;
-        }
-        else
-        {
-            lookupType = this.mapClass;
-            staticRequirement = this.mapMethod.CanBeUsedByStaticMethod
-                ? InvokeMethodStaticRequirement.Static
-                : InvokeMethodStaticRequirement.StaticOrNotStatic;
+            return null;
         }
 
-        var methods = lookupType.LocateMethodsIncludingInheritedInterfaces(attribute.MethodName);
+        var methods = lookup.LookupType.LocateMethodsIncludingInheritedInterfaces(attribute.MethodName);
         var resolutionResult = this.TryResolveHook(
-            lookupType,
+            lookup.LookupType,
             methods,
             attribute.MethodName,
             mappedValueType,
-            staticRequirement,
+            lookup.StaticRequirement,
             attribute.Location,
             reportAmbiguity: true,
             out var method);
 
-        if (resolutionResult is InvokeMethodResolutionResult.NotFound &&
-            fieldOrProperty is not null &&
-            this.mapMethod.CanBeUsedByStaticMethod &&
-            !fieldOrProperty.IsStatic)
-        {
-            var instanceResolutionResult = this.TryResolveHook(
-                lookupType,
+        if (this.ShouldReportFieldMustBeStatic(
+                resolutionResult,
+                lookup.FieldOrProperty,
+                lookup.LookupType,
                 methods,
-                attribute.MethodName,
-                mappedValueType,
-                InvokeMethodStaticRequirement.NotStatic,
-                attribute.Location,
-                reportAmbiguity: false,
-                out _);
-            if (instanceResolutionResult is not InvokeMethodResolutionResult.NotFound)
-            {
-                this.context.ReportDiagnostic(MappaDiagnostics.FieldOrPropertyMustBeStatic(
-                    fieldOrProperty.Name,
-                    attribute.Location));
-                return null;
-            }
+                attribute,
+                mappedValueType))
+        {
+            return null;
         }
 
         if (resolutionResult is InvokeMethodResolutionResult.NotFound)
@@ -216,8 +157,114 @@ internal sealed class MapHookResolver
         }
 
         return resolutionResult is InvokeMethodResolutionResult.Success && method is not null
-            ? new MapHook(method, fieldOrProperty, explicitType, attribute.Location)
+            ? new MapHook(method, lookup.FieldOrProperty, lookup.ExplicitType, attribute.Location)
             : null;
+    }
+
+    private bool TryBuildHookLookup(MapHookAttributeData attribute, out HookLookup lookup)
+    {
+        if (attribute.FieldName is not null)
+        {
+            return this.TryBuildFieldHookLookup(attribute, out lookup);
+        }
+
+        if (attribute.ClassType is not null)
+        {
+            return this.TryBuildClassTypeHookLookup(attribute, out lookup);
+        }
+
+        lookup = new HookLookup(
+            this.mapClass,
+            this.mapMethod.CanBeUsedByStaticMethod ? InvokeMethodStaticRequirement.Static : InvokeMethodStaticRequirement.StaticOrNotStatic,
+            null,
+            null);
+        return true;
+    }
+
+    private bool TryBuildFieldHookLookup(MapHookAttributeData attribute, out HookLookup lookup)
+    {
+        if (attribute.FieldName is not { Length: > 0 } fieldName || string.IsNullOrWhiteSpace(fieldName))
+        {
+            lookup = default;
+            return false;
+        }
+
+        var fieldOrProperty = this.compilation.LocateAccessibleFieldOrPropertyInTypeHierarchy(
+            this.mapClass,
+            fieldName,
+            this.mapClass);
+        if (fieldOrProperty is null)
+        {
+            this.context.ReportDiagnostic(MappaDiagnostics.CannotFindFieldOrProperty(
+                attribute.Location,
+                fieldName));
+            lookup = default;
+            return false;
+        }
+
+        var staticRequirement = this.mapMethod.CanBeUsedByStaticMethod && !fieldOrProperty.IsStatic
+            ? InvokeMethodStaticRequirement.Static
+            : InvokeMethodStaticRequirement.StaticOrNotStatic;
+        lookup = new HookLookup(GetFieldOrPropertyType(fieldOrProperty), staticRequirement, fieldOrProperty, null);
+        return true;
+    }
+
+    private bool TryBuildClassTypeHookLookup(MapHookAttributeData attribute, out HookLookup lookup)
+    {
+        var classTypeFullName = attribute.ClassType?.FullName;
+        if (classTypeFullName is not { Length: > 0 } metadataName || string.IsNullOrWhiteSpace(metadataName))
+        {
+            throw new MappaGeneratorException($"Cannot detect the full name for hook type '{attribute.ClassType}'.");
+        }
+
+        var explicitType = this.compilation.GetTypeByMetadataName(metadataName);
+        if (explicitType is null)
+        {
+            this.context.ReportDiagnostic(MappaDiagnostics.CannotDetectType(
+                attribute.Location,
+                classTypeFullName));
+            lookup = default;
+            return false;
+        }
+
+        lookup = new HookLookup(explicitType, InvokeMethodStaticRequirement.Static, null, explicitType);
+        return true;
+    }
+
+    private bool ShouldReportFieldMustBeStatic(
+        InvokeMethodResolutionResult resolutionResult,
+        ISymbol? fieldOrProperty,
+        ITypeSymbol lookupType,
+        IMethodSymbol[] methods,
+        MapHookAttributeData attribute,
+        ITypeSymbol mappedValueType)
+    {
+        if (resolutionResult is not InvokeMethodResolutionResult.NotFound
+            || fieldOrProperty is null
+            || !this.mapMethod.CanBeUsedByStaticMethod
+            || fieldOrProperty.IsStatic)
+        {
+            return false;
+        }
+
+        var instanceResolutionResult = this.TryResolveHook(
+            lookupType,
+            methods,
+            attribute.MethodName,
+            mappedValueType,
+            InvokeMethodStaticRequirement.NotStatic,
+            attribute.Location,
+            reportAmbiguity: false,
+            out _);
+        if (instanceResolutionResult is InvokeMethodResolutionResult.NotFound)
+        {
+            return false;
+        }
+
+        this.context.ReportDiagnostic(MappaDiagnostics.FieldOrPropertyMustBeStatic(
+            fieldOrProperty.Name,
+            attribute.Location));
+        return true;
     }
 
     private InvokeMethodResolutionResult TryResolveHook(
@@ -278,5 +325,28 @@ internal sealed class MapHookResolver
         }
 
         return [.. hooks];
+    }
+
+    private readonly struct HookLookup
+    {
+        internal HookLookup(
+            ITypeSymbol lookupType,
+            InvokeMethodStaticRequirement staticRequirement,
+            ISymbol? fieldOrProperty,
+            ITypeSymbol? explicitType)
+        {
+            this.LookupType = lookupType;
+            this.StaticRequirement = staticRequirement;
+            this.FieldOrProperty = fieldOrProperty;
+            this.ExplicitType = explicitType;
+        }
+
+        internal ITypeSymbol LookupType { get; }
+
+        internal InvokeMethodStaticRequirement StaticRequirement { get; }
+
+        internal ISymbol? FieldOrProperty { get; }
+
+        internal ITypeSymbol? ExplicitType { get; }
     }
 }

--- a/Mappa.Generator/Helpers/ObjectFactoryResolver.cs
+++ b/Mappa.Generator/Helpers/ObjectFactoryResolver.cs
@@ -113,80 +113,44 @@ internal sealed class ObjectFactoryResolver
         return new TierPickResult(InvokeMethodResolutionResult.Ambiguous, null);
     }
 
+    private static bool ApplyTierPick(
+        TierPickResult tierPick,
+        ObjectFactoryInvocationKind kind,
+        ref IMethodSymbol? method,
+        ref ObjectFactoryInvocationKind invocationKind)
+    {
+        if (tierPick.Status is InvokeMethodResolutionResult.NotFound)
+        {
+            return false;
+        }
+
+        method = tierPick.Method;
+        invocationKind = kind;
+        return true;
+    }
+
     private ObjectFactory? ResolveFactory(MappaObjectFactoryAttributeData attribute)
     {
-        ISymbol? fieldOrProperty = null;
-        ITypeSymbol? explicitType = null;
-        ITypeSymbol lookupType;
-        InvokeMethodStaticRequirement staticRequirement;
-
-        if (attribute.FieldName is not null)
+        if (!this.TryBuildFactoryLookup(attribute, out var lookup))
         {
-            fieldOrProperty = this.compilation.LocateAccessibleFieldOrPropertyInTypeHierarchy(
-                this.mapClass,
-                attribute.FieldName,
-                this.mapClass);
-            if (fieldOrProperty is null)
-            {
-                this.ReportFactoryNotFound(attribute);
-                return null;
-            }
-
-            lookupType = GetFieldOrPropertyType(fieldOrProperty);
-            staticRequirement = this.mapMethod.CanBeUsedByStaticMethod && !fieldOrProperty.IsStatic
-                ? InvokeMethodStaticRequirement.Static
-                : InvokeMethodStaticRequirement.StaticOrNotStatic;
-        }
-        else if (attribute.ClassType is not null)
-        {
-            var classTypeFullName = attribute.ClassType.FullName;
-            if (string.IsNullOrWhiteSpace(classTypeFullName))
-            {
-                throw new MappaGeneratorException($"Cannot detect the full name for factory type '{attribute.ClassType}'.");
-            }
-
-            explicitType = this.compilation.GetTypeByMetadataName(classTypeFullName);
-            if (explicitType is null)
-            {
-                this.ReportFactoryNotFound(attribute);
-                return null;
-            }
-
-            lookupType = explicitType;
-            staticRequirement = InvokeMethodStaticRequirement.Static;
-        }
-        else
-        {
-            lookupType = this.mapClass;
-            staticRequirement = this.mapMethod.CanBeUsedByStaticMethod
-                ? InvokeMethodStaticRequirement.Static
-                : InvokeMethodStaticRequirement.StaticOrNotStatic;
+            return null;
         }
 
-        var methods = lookupType.LocateMethodsIncludingInheritedInterfaces(attribute.MethodName);
+        var methods = lookup.LookupType.LocateMethodsIncludingInheritedInterfaces(attribute.MethodName);
         var resolution = this.TryResolveFactoryMethod(
             methods,
             attribute.MethodName,
-            staticRequirement,
+            lookup.StaticRequirement,
             out var method,
             out var invocationKind);
 
-        if (resolution is InvokeMethodResolutionResult.NotFound &&
-            fieldOrProperty is not null &&
-            this.mapMethod.CanBeUsedByStaticMethod &&
-            !fieldOrProperty.IsStatic)
-        {
-            var instanceResolution = this.TryResolveFactoryMethod(
+        if (this.ShouldRejectNonStaticFactoryField(
+                resolution,
+                lookup.FieldOrProperty,
                 methods,
-                attribute.MethodName,
-                InvokeMethodStaticRequirement.NotStatic,
-                out _,
-                out _);
-            if (instanceResolution is not InvokeMethodResolutionResult.NotFound)
-            {
-                this.ReportFactoryNotFound(attribute);
-                return null;
-            }
+                attribute))
+        {
+            return null;
         }
 
         if (resolution is not InvokeMethodResolutionResult.Success || method is null)
@@ -195,7 +159,102 @@ internal sealed class ObjectFactoryResolver
             return null;
         }
 
-        return new ObjectFactory(method, fieldOrProperty, explicitType, invocationKind, attribute.Location);
+        return new ObjectFactory(method, lookup.FieldOrProperty, lookup.ExplicitType, invocationKind, attribute.Location);
+    }
+
+    private bool TryBuildFactoryLookup(MappaObjectFactoryAttributeData attribute, out FactoryLookup lookup)
+    {
+        if (attribute.FieldName is not null)
+        {
+            return this.TryBuildFieldFactoryLookup(attribute, out lookup);
+        }
+
+        if (attribute.ClassType is not null)
+        {
+            return this.TryBuildClassTypeFactoryLookup(attribute, out lookup);
+        }
+
+        lookup = new FactoryLookup(
+            this.mapClass,
+            this.mapMethod.CanBeUsedByStaticMethod ? InvokeMethodStaticRequirement.Static : InvokeMethodStaticRequirement.StaticOrNotStatic,
+            null,
+            null);
+        return true;
+    }
+
+    private bool TryBuildFieldFactoryLookup(MappaObjectFactoryAttributeData attribute, out FactoryLookup lookup)
+    {
+        if (attribute.FieldName is not { Length: > 0 } fieldName || string.IsNullOrWhiteSpace(fieldName))
+        {
+            lookup = default;
+            return false;
+        }
+
+        var fieldOrProperty = this.compilation.LocateAccessibleFieldOrPropertyInTypeHierarchy(
+            this.mapClass,
+            fieldName,
+            this.mapClass);
+        if (fieldOrProperty is null)
+        {
+            this.ReportFactoryNotFound(attribute);
+            lookup = default;
+            return false;
+        }
+
+        var staticRequirement = this.mapMethod.CanBeUsedByStaticMethod && !fieldOrProperty.IsStatic
+            ? InvokeMethodStaticRequirement.Static
+            : InvokeMethodStaticRequirement.StaticOrNotStatic;
+        lookup = new FactoryLookup(GetFieldOrPropertyType(fieldOrProperty), staticRequirement, fieldOrProperty, null);
+        return true;
+    }
+
+    private bool TryBuildClassTypeFactoryLookup(MappaObjectFactoryAttributeData attribute, out FactoryLookup lookup)
+    {
+        var classTypeFullName = attribute.ClassType?.FullName;
+        if (classTypeFullName is not { Length: > 0 } metadataName || string.IsNullOrWhiteSpace(metadataName))
+        {
+            throw new MappaGeneratorException($"Cannot detect the full name for factory type '{attribute.ClassType}'.");
+        }
+
+        var explicitType = this.compilation.GetTypeByMetadataName(metadataName);
+        if (explicitType is null)
+        {
+            this.ReportFactoryNotFound(attribute);
+            lookup = default;
+            return false;
+        }
+
+        lookup = new FactoryLookup(explicitType, InvokeMethodStaticRequirement.Static, null, explicitType);
+        return true;
+    }
+
+    private bool ShouldRejectNonStaticFactoryField(
+        InvokeMethodResolutionResult resolution,
+        ISymbol? fieldOrProperty,
+        IMethodSymbol[] methods,
+        MappaObjectFactoryAttributeData attribute)
+    {
+        if (resolution is not InvokeMethodResolutionResult.NotFound
+            || fieldOrProperty is null
+            || !this.mapMethod.CanBeUsedByStaticMethod
+            || fieldOrProperty.IsStatic)
+        {
+            return false;
+        }
+
+        var instanceResolution = this.TryResolveFactoryMethod(
+            methods,
+            attribute.MethodName,
+            InvokeMethodStaticRequirement.NotStatic,
+            out _,
+            out _);
+        if (instanceResolution is InvokeMethodResolutionResult.NotFound)
+        {
+            return false;
+        }
+
+        this.ReportFactoryNotFound(attribute);
+        return true;
     }
 
     private InvokeMethodResolutionResult TryResolveFactoryMethod(
@@ -208,12 +267,30 @@ internal sealed class ObjectFactoryResolver
         method = null;
         invocationKind = ObjectFactoryInvocationKind.FullyProduced;
 
-        var nullableEnabled = this.mapMethod.NullableEnabled;
-        var sourceType = this.context.SourceType;
-        var targetType = this.context.TargetType;
-        var mapMethodProvidesContext = this.mapMethod.ProvideMappaContextWhenInvoked();
+        var candidates = this.FilterFactoryMethodCandidates(methods, methodName, staticRequirement);
+        if (candidates.Length == 0)
+        {
+            return InvokeMethodResolutionResult.NotFound;
+        }
 
-        var candidates = methods
+        var standardTierResult = this.TryResolveStandardFactoryTiers(candidates, out method, out invocationKind);
+        if (standardTierResult is not InvokeMethodResolutionResult.NotFound)
+        {
+            return standardTierResult;
+        }
+
+        return this.TryResolveParameterizedFactoryTier(candidates, out method, out invocationKind);
+    }
+
+    private IMethodSymbol[] FilterFactoryMethodCandidates(
+        IMethodSymbol[] methods,
+        string methodName,
+        InvokeMethodStaticRequirement staticRequirement)
+    {
+        var nullableEnabled = this.mapMethod.NullableEnabled;
+        var targetType = this.context.TargetType;
+
+        return methods
             .Where(candidate =>
                 candidate.Name.Equals(methodName, StringComparison.Ordinal) &&
                 this.compilation.IsSymbolAccessibleWithin(candidate, this.mapClass) &&
@@ -226,11 +303,19 @@ internal sealed class ObjectFactoryResolver
                     _ => false,
                 })
             .ToArray();
+    }
 
-        if (candidates.Length == 0)
-        {
-            return InvokeMethodResolutionResult.NotFound;
-        }
+    private InvokeMethodResolutionResult TryResolveStandardFactoryTiers(
+        IMethodSymbol[] candidates,
+        out IMethodSymbol? method,
+        out ObjectFactoryInvocationKind invocationKind)
+    {
+        method = null;
+        invocationKind = ObjectFactoryInvocationKind.FullyProduced;
+
+        var nullableEnabled = this.mapMethod.NullableEnabled;
+        var sourceType = this.context.SourceType;
+        var mapMethodProvidesContext = this.mapMethod.ProvideMappaContextWhenInvoked();
 
         bool IsSourceParameter(IParameterSymbol parameter)
             => parameter.RefKind is RefKind.None &&
@@ -247,10 +332,8 @@ internal sealed class ObjectFactoryResolver
                 candidate => candidate.Parameters.Length == 2 &&
                              IsSourceParameter(candidate.Parameters[0]) &&
                              IsContextParameter(candidate, 1));
-            if (sourceAndContextResult.Status is not InvokeMethodResolutionResult.NotFound)
+            if (ApplyTierPick(sourceAndContextResult, ObjectFactoryInvocationKind.FullyProduced, ref method, ref invocationKind))
             {
-                method = sourceAndContextResult.Method;
-                invocationKind = ObjectFactoryInvocationKind.FullyProduced;
                 return sourceAndContextResult.Status;
             }
         }
@@ -259,10 +342,8 @@ internal sealed class ObjectFactoryResolver
             candidates,
             candidate => candidate.Parameters.Length == 1 &&
                          IsSourceParameter(candidate.Parameters[0]));
-        if (sourceOnlyResult.Status is not InvokeMethodResolutionResult.NotFound)
+        if (ApplyTierPick(sourceOnlyResult, ObjectFactoryInvocationKind.FullyProduced, ref method, ref invocationKind))
         {
-            method = sourceOnlyResult.Method;
-            invocationKind = ObjectFactoryInvocationKind.FullyProduced;
             return sourceOnlyResult.Status;
         }
 
@@ -272,10 +353,8 @@ internal sealed class ObjectFactoryResolver
                 candidates,
                 candidate => candidate.Parameters.Length == 1 &&
                              IsContextParameter(candidate, 0));
-            if (contextOnlyResult.Status is not InvokeMethodResolutionResult.NotFound)
+            if (ApplyTierPick(contextOnlyResult, ObjectFactoryInvocationKind.EmptyCtorLike, ref method, ref invocationKind))
             {
-                method = contextOnlyResult.Method;
-                invocationKind = ObjectFactoryInvocationKind.EmptyCtorLike;
                 return contextOnlyResult.Status;
             }
         }
@@ -283,15 +362,33 @@ internal sealed class ObjectFactoryResolver
         var parameterlessResult = PickFromTier(
             candidates,
             candidate => candidate.Parameters.Length == 0);
-        if (parameterlessResult.Status is not InvokeMethodResolutionResult.NotFound)
+        if (ApplyTierPick(parameterlessResult, ObjectFactoryInvocationKind.EmptyCtorLike, ref method, ref invocationKind))
         {
-            method = parameterlessResult.Method;
-            invocationKind = ObjectFactoryInvocationKind.EmptyCtorLike;
             return parameterlessResult.Status;
         }
 
-        // Tier 5: any remaining signature is parameterized-like.
-        // Prefer the candidate with the highest parameter count when unique at that count.
+        return InvokeMethodResolutionResult.NotFound;
+    }
+
+    private InvokeMethodResolutionResult TryResolveParameterizedFactoryTier(
+        IMethodSymbol[] candidates,
+        out IMethodSymbol? method,
+        out ObjectFactoryInvocationKind invocationKind)
+    {
+        method = null;
+        invocationKind = ObjectFactoryInvocationKind.ParameterizedLike;
+
+        var nullableEnabled = this.mapMethod.NullableEnabled;
+        var sourceType = this.context.SourceType;
+
+        bool IsSourceParameter(IParameterSymbol parameter)
+            => parameter.RefKind is RefKind.None &&
+               parameter.Type.IsEqualTo(sourceType, nullableEnabled);
+
+        bool IsContextParameter(IMethodSymbol candidate, int index)
+            => candidate.Parameters[index].RefKind is RefKind.None &&
+               candidate.ParameterIsMappaContext(this.compilation, index);
+
         var parameterizedCandidates = candidates
             .Where(candidate =>
                 !(candidate.Parameters.Length == 2 &&
@@ -315,7 +412,6 @@ internal sealed class ObjectFactoryResolver
 
         var parameterizedResult = ResolveUniqueCandidate(preferredCandidates);
         method = parameterizedResult.Method;
-        invocationKind = ObjectFactoryInvocationKind.ParameterizedLike;
         return parameterizedResult.Status;
     }
 
@@ -330,6 +426,29 @@ internal sealed class ObjectFactoryResolver
             this.mapMethod.MethodName,
             attribute.TargetType.ToDisplayString(),
             attribute.MethodName));
+    }
+
+    private readonly struct FactoryLookup
+    {
+        internal FactoryLookup(
+            ITypeSymbol lookupType,
+            InvokeMethodStaticRequirement staticRequirement,
+            ISymbol? fieldOrProperty,
+            ITypeSymbol? explicitType)
+        {
+            this.LookupType = lookupType;
+            this.StaticRequirement = staticRequirement;
+            this.FieldOrProperty = fieldOrProperty;
+            this.ExplicitType = explicitType;
+        }
+
+        internal ITypeSymbol LookupType { get; }
+
+        internal InvokeMethodStaticRequirement StaticRequirement { get; }
+
+        internal ISymbol? FieldOrProperty { get; }
+
+        internal ITypeSymbol? ExplicitType { get; }
     }
 
     private sealed class TierPickResult

--- a/Mappa.Generator/Helpers/ProjectionMapMethodEligibilityValidator.cs
+++ b/Mappa.Generator/Helpers/ProjectionMapMethodEligibilityValidator.cs
@@ -8,6 +8,7 @@ using Mappa.Generator.Extensions;
 using Mappa.Generator.Models;
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Mappa.Generator.Helpers;
 
@@ -48,56 +49,192 @@ internal static class ProjectionMapMethodEligibilityValidator
             return true;
         }
 
+        return ValidateProjectionQueryableMethod(
+            mapMethod,
+            compilation,
+            classContext,
+            classBeforeMapAttributes,
+            classAfterMapAttributes,
+            classObjectFactoryAttributes,
+            methodObjectFactoryAttributes,
+            mappaUserSettings);
+    }
+
+    private static bool ValidateProjectionQueryableMethod(
+        MapMethod mapMethod,
+        Compilation compilation,
+        MappaClassGeneratorContext classContext,
+        MapHookAttributeData[] classBeforeMapAttributes,
+        MapHookAttributeData[] classAfterMapAttributes,
+        MappaObjectFactoryAttributeData[] classObjectFactoryAttributes,
+        MappaObjectFactoryAttributeData[] methodObjectFactoryAttributes,
+        IMappaUserSettings mappaUserSettings)
+    {
         var methodDeclarationSyntax = mapMethod.MethodDeclarationSyntax;
         var methodName = mapMethod.MethodName;
 
-        if (mapMethod.MethodSymbol.Parameters.Length > 1
-            && mapMethod.MethodSymbol.SecondParameterIsMappaContext(compilation))
+        if (mapMethod.MethodSymbol is not IMethodSymbol methodSymbol)
         {
-            classContext.ReportDiagnostic(
-                MappaDiagnostics.ProjectionMethodHasMappaContextParameter(methodDeclarationSyntax, methodName));
+            return true;
+        }
+
+        if (!ValidateProjectionQueryableHasNoMappaContextParameter(
+                methodSymbol,
+                compilation,
+                classContext,
+                methodDeclarationSyntax,
+                methodName))
+        {
             return false;
         }
 
-        if (ReferenceHandlingCodeGenerator.IsReferenceHandlingRequested(mappaUserSettings))
+        if (!ValidateProjectionQueryableHasNoReferenceHandling(
+                mappaUserSettings,
+                classContext,
+                methodDeclarationSyntax,
+                methodName))
         {
-            classContext.ReportDiagnostic(
-                MappaDiagnostics.ProjectionMappingNotSupported(
-                    methodDeclarationSyntax?.GetLocation(),
-                    methodName,
-                    "reference handling"));
             return false;
         }
 
-        var methodAttributes = mapMethod.MethodSymbol.GetAttributes();
-        var hasMethodBeforeMapHooks = methodAttributes.GetMappaBeforeMapAttributes(compilation).Length > 0;
-        var hasMethodAfterMapHooks = methodAttributes.GetMappaAfterMapAttributes(compilation).Length > 0;
-        if (classBeforeMapAttributes.Length > 0
-            || classAfterMapAttributes.Length > 0
-            || hasMethodBeforeMapHooks
-            || hasMethodAfterMapHooks)
+        if (!ValidateProjectionQueryableHasNoBeforeOrAfterMapHooks(
+                mapMethod,
+                compilation,
+                classContext,
+                classBeforeMapAttributes,
+                classAfterMapAttributes,
+                methodDeclarationSyntax,
+                methodName))
         {
-            classContext.ReportDiagnostic(
-                MappaDiagnostics.ProjectionMethodHasBeforeOrAfterMapHooks(methodDeclarationSyntax, methodName));
             return false;
         }
 
-        if (classObjectFactoryAttributes.Length > 0
-            || methodObjectFactoryAttributes.Length > 0)
+        if (!ValidateProjectionQueryableHasNoObjectFactory(
+                classObjectFactoryAttributes,
+                methodObjectFactoryAttributes,
+                classContext,
+                methodDeclarationSyntax,
+                methodName))
         {
-            classContext.ReportDiagnostic(
-                MappaDiagnostics.ProjectionMethodHasObjectFactory(methodDeclarationSyntax, methodName));
             return false;
         }
 
-        if (mapMethod.GetAttribute<MappaAllowInaccessibleSourceMembersAttribute>() is not null
-            || mapMethod.GetAttribute<MappaAllowInaccessibleTargetMembersAttribute>() is not null)
+        return ValidateProjectionQueryableHasNoAllowInaccessibleMembers(mapMethod, classContext, methodDeclarationSyntax, methodName);
+    }
+
+    private static bool ValidateProjectionQueryableHasNoMappaContextParameter(
+        IMethodSymbol methodSymbol,
+        Compilation compilation,
+        MappaClassGeneratorContext classContext,
+        MethodDeclarationSyntax? methodDeclarationSyntax,
+        string methodName)
+    {
+        if (methodSymbol.Parameters.Length <= 1
+            || !methodSymbol.SecondParameterIsMappaContext(compilation))
         {
-            classContext.ReportDiagnostic(
-                MappaDiagnostics.ProjectionMethodHasAllowInaccessibleMembers(methodDeclarationSyntax, methodName));
+            return true;
+        }
+
+        classContext.ReportDiagnostic(
+            MappaDiagnostics.ProjectionMethodHasMappaContextParameter(methodDeclarationSyntax, methodName));
+        return false;
+    }
+
+    private static bool ValidateProjectionQueryableHasNoReferenceHandling(
+        IMappaUserSettings mappaUserSettings,
+        MappaClassGeneratorContext classContext,
+        MethodDeclarationSyntax? methodDeclarationSyntax,
+        string methodName)
+    {
+        if (!ReferenceHandlingCodeGenerator.IsReferenceHandlingRequested(mappaUserSettings))
+        {
+            return true;
+        }
+
+        classContext.ReportDiagnostic(
+            MappaDiagnostics.ProjectionMappingNotSupported(
+                methodDeclarationSyntax?.GetLocation(),
+                methodName,
+                "reference handling"));
+        return false;
+    }
+
+    private static bool ValidateProjectionQueryableHasNoBeforeOrAfterMapHooks(
+        MapMethod mapMethod,
+        Compilation compilation,
+        MappaClassGeneratorContext classContext,
+        MapHookAttributeData[] classBeforeMapAttributes,
+        MapHookAttributeData[] classAfterMapAttributes,
+        MethodDeclarationSyntax? methodDeclarationSyntax,
+        string methodName)
+    {
+        if (!HasBeforeOrAfterMapHooks(
+                mapMethod,
+                compilation,
+                classBeforeMapAttributes,
+                classAfterMapAttributes))
+        {
+            return true;
+        }
+
+        classContext.ReportDiagnostic(
+            MappaDiagnostics.ProjectionMethodHasBeforeOrAfterMapHooks(methodDeclarationSyntax, methodName));
+        return false;
+    }
+
+    private static bool ValidateProjectionQueryableHasNoObjectFactory(
+        MappaObjectFactoryAttributeData[] classObjectFactoryAttributes,
+        MappaObjectFactoryAttributeData[] methodObjectFactoryAttributes,
+        MappaClassGeneratorContext classContext,
+        MethodDeclarationSyntax? methodDeclarationSyntax,
+        string methodName)
+    {
+        if (classObjectFactoryAttributes.Length == 0 && methodObjectFactoryAttributes.Length == 0)
+        {
+            return true;
+        }
+
+        classContext.ReportDiagnostic(
+            MappaDiagnostics.ProjectionMethodHasObjectFactory(methodDeclarationSyntax, methodName));
+        return false;
+    }
+
+    private static bool ValidateProjectionQueryableHasNoAllowInaccessibleMembers(
+        MapMethod mapMethod,
+        MappaClassGeneratorContext classContext,
+        MethodDeclarationSyntax? methodDeclarationSyntax,
+        string methodName)
+    {
+        if (mapMethod.GetAttribute<MappaAllowInaccessibleSourceMembersAttribute>() is null
+            && mapMethod.GetAttribute<MappaAllowInaccessibleTargetMembersAttribute>() is null)
+        {
+            return true;
+        }
+
+        classContext.ReportDiagnostic(
+            MappaDiagnostics.ProjectionMethodHasAllowInaccessibleMembers(methodDeclarationSyntax, methodName));
+        return false;
+    }
+
+    private static bool HasBeforeOrAfterMapHooks(
+        MapMethod mapMethod,
+        Compilation compilation,
+        MapHookAttributeData[] classBeforeMapAttributes,
+        MapHookAttributeData[] classAfterMapAttributes)
+    {
+        if (classBeforeMapAttributes.Length > 0 || classAfterMapAttributes.Length > 0)
+        {
+            return true;
+        }
+
+        var methodAttributes = mapMethod.MethodSymbol?.GetAttributes();
+        if (methodAttributes is null)
+        {
             return false;
         }
 
-        return true;
+        var attributes = methodAttributes.GetValueOrDefault();
+        return attributes.GetMappaBeforeMapAttributes(compilation).Length > 0
+               || attributes.GetMappaAfterMapAttributes(compilation).Length > 0;
     }
 }

--- a/Mappa.Generator/Helpers/PropertyPathExpressionBuilder.cs
+++ b/Mappa.Generator/Helpers/PropertyPathExpressionBuilder.cs
@@ -57,36 +57,24 @@ internal static class PropertyPathExpressionBuilder
             return chainExpression;
         }
 
-        var expression = chainExpression;
-        var diagnosticPath = string.Empty;
-        var usedConditionalAccess = false;
-        var receiverTypeForAccess = pathStartingType;
+        var segmentChain = BuildSegmentAccessChain(
+            chainExpression,
+            pathSegments,
+            pathStartingType,
+            nullableEnabled,
+            resolvedProperties,
+            out var diagnosticPath,
+            out var receiverTypeForAccess,
+            out var usedConditionalAccess);
 
-        for (var index = 0; index < pathSegments.Length; index++)
-        {
-            var segment = pathSegments[index];
-            var useConditionalAccess = ShouldUseConditionalAccess(receiverTypeForAccess, nullableEnabled);
-            usedConditionalAccess = usedConditionalAccess || useConditionalAccess;
-            var accessOperator = useConditionalAccess ? "?." : ".";
-            expression = $"{expression}{accessOperator}{segment}";
-            diagnosticPath = string.IsNullOrWhiteSpace(diagnosticPath)
-                ? segment
-                : $"{diagnosticPath}.{segment}";
-            receiverTypeForAccess = resolvedProperties[index].Type;
-        }
-
-        // Append ?? throw only when the access expression can be null and the target cannot.
-        var expressionCanBeNull = usedConditionalAccess
-            || IsNullableCapableType(receiverTypeForAccess, nullableEnabled);
-        if (expressionCanBeNull && !targetType.IsNullable())
-        {
-            var pathForDiagnostic = string.IsNullOrWhiteSpace(diagnosticPathOverride)
-                ? diagnosticPath
-                : diagnosticPathOverride;
-            expression = $"{expression} ?? throw new System.NullReferenceException({CSharpLiteralHelper.ToStringLiteral($"\"{pathForDiagnostic}\" is null.")})";
-        }
-
-        return expression;
+        return MaybeAppendNullCoalescingThrow(
+            segmentChain,
+            usedConditionalAccess,
+            receiverTypeForAccess,
+            nullableEnabled,
+            targetType,
+            diagnosticPath,
+            diagnosticPathOverride);
     }
 
     /// <summary>
@@ -104,6 +92,60 @@ internal static class PropertyPathExpressionBuilder
         }
 
         return $"{receiverExpression}.{path.ToDotSeparatedString()}";
+    }
+
+    private static string BuildSegmentAccessChain(
+        string chainExpression,
+        string[] pathSegments,
+        ITypeSymbol pathStartingType,
+        bool nullableEnabled,
+        IPropertySymbol[] resolvedProperties,
+        out string diagnosticPath,
+        out ITypeSymbol receiverTypeForAccess,
+        out bool usedConditionalAccess)
+    {
+        var expression = chainExpression;
+        diagnosticPath = string.Empty;
+        usedConditionalAccess = false;
+        var receiverTypeForAccessLocal = pathStartingType;
+
+        for (var index = 0; index < pathSegments.Length; index++)
+        {
+            var segment = pathSegments[index];
+            var useConditionalAccess = ShouldUseConditionalAccess(receiverTypeForAccessLocal, nullableEnabled);
+            usedConditionalAccess = usedConditionalAccess || useConditionalAccess;
+            var accessOperator = useConditionalAccess ? "?." : ".";
+            expression = $"{expression}{accessOperator}{segment}";
+            diagnosticPath = string.IsNullOrWhiteSpace(diagnosticPath)
+                ? segment
+                : $"{diagnosticPath}.{segment}";
+            receiverTypeForAccessLocal = resolvedProperties[index].Type;
+        }
+
+        receiverTypeForAccess = receiverTypeForAccessLocal;
+        return expression;
+    }
+
+    private static string MaybeAppendNullCoalescingThrow(
+        string expression,
+        bool usedConditionalAccess,
+        ITypeSymbol receiverTypeForAccess,
+        bool nullableEnabled,
+        ITypeSymbol targetType,
+        string diagnosticPath,
+        string? diagnosticPathOverride)
+    {
+        var expressionCanBeNull = usedConditionalAccess
+            || IsNullableCapableType(receiverTypeForAccess, nullableEnabled);
+        if (!expressionCanBeNull || targetType.IsNullable())
+        {
+            return expression;
+        }
+
+        var pathForDiagnostic = string.IsNullOrWhiteSpace(diagnosticPathOverride)
+            ? diagnosticPath
+            : diagnosticPathOverride;
+        return $"{expression} ?? throw new System.NullReferenceException({CSharpLiteralHelper.ToStringLiteral($"\"{pathForDiagnostic}\" is null.")})";
     }
 
     private static bool ShouldUseConditionalAccess(ITypeSymbol segmentType, bool nullableEnabled)

--- a/Mappa.Generator/Helpers/ReferenceHandlingCodeGenerator.cs
+++ b/Mappa.Generator/Helpers/ReferenceHandlingCodeGenerator.cs
@@ -25,6 +25,23 @@ internal static class ReferenceHandlingCodeGenerator
     /// </summary>
     internal const string AccessorMethodName = "GetReferenceManager";
 
+    private static readonly Type[] ContainerOrWrapperStrategyTypes =
+    [
+        typeof(CollectionToCollectionMapStrategy),
+        typeof(DictionaryToDictionaryMapStrategy),
+        typeof(NullableStrategy),
+        typeof(TupleToTupleMapStrategy),
+        typeof(PolymorphismMapStrategy),
+        typeof(OptionalTargetPropertyMapStrategy),
+        typeof(OptionalSourcePropertyMapStrategy),
+        typeof(ReadonlyDictionaryPropertyMapStrategy),
+        typeof(ReadonlyCollectionPropertyMapStrategy),
+        typeof(ReadonlyAddCollectionPropertyMapStrategy),
+        typeof(ReadonlyQueuePropertyMapStrategy),
+        typeof(ReadonlyStackPropertyMapStrategy),
+        typeof(QueryableProjectionMapStrategy),
+    ];
+
     /// <summary>
     /// Returns <c>true</c> when ReferenceReusing or MaxRuntimeDepth is requested on <paramref name="settings"/>.
     /// </summary>
@@ -252,19 +269,16 @@ internal static class ReferenceHandlingCodeGenerator
             return false;
         }
 
-        if (IsContainerOrWrapperStrategy(strategy))
-        {
-            return false;
-        }
-
-        if (strategy is IdentityMapStrategy identity
-            && (identity.NestedFieldStrategies.Count > 0 || !identity.RequiresMemberwiseClone))
+        if (IsContainerOrWrapperStrategy(strategy) || IsIdentityStrategyIneligibleForReferenceHandling(strategy))
         {
             return false;
         }
 
         return AreReferenceTypesEligibleForReuse(strategy.TargetType, strategy.SourceType);
     }
+
+    private static bool IsContainerOrWrapperStrategy(MapStrategy strategy)
+        => ContainerOrWrapperStrategyTypes.Any(strategyType => strategyType.IsInstanceOfType(strategy));
 
     private static bool ShouldIncreaseDepth(MapStrategy strategy, MappaBuilderContext context)
     {
@@ -273,24 +287,21 @@ internal static class ReferenceHandlingCodeGenerator
             return false;
         }
 
-        if (IsContainerOrWrapperStrategy(strategy))
+        if (IsContainerOrWrapperStrategy(strategy) || IsIdentityStrategyIneligibleForReferenceHandling(strategy))
         {
             return false;
         }
 
-        if (strategy is IdentityMapStrategy identity
-            && (identity.NestedFieldStrategies.Count > 0 || !identity.RequiresMemberwiseClone))
-        {
-            return false;
-        }
+        return IsReferenceTypeEligibleForRuntimeDepth(strategy.TargetType);
+    }
 
-        var targetType = strategy.TargetType;
-        if (targetType.IsString() || targetType.IsEnum())
-        {
-            return false;
-        }
+    private static bool IsIdentityStrategyIneligibleForReferenceHandling(MapStrategy strategy)
+        => strategy is IdentityMapStrategy identity
+           && (identity.NestedFieldStrategies.Count > 0 || !identity.RequiresMemberwiseClone);
 
-        if (targetType.IsValueTypeNullable())
+    private static bool IsReferenceTypeEligibleForRuntimeDepth(ITypeSymbol targetType)
+    {
+        if (IsIneligiblePrimitiveOrNullableReferenceType(targetType))
         {
             return false;
         }
@@ -303,40 +314,25 @@ internal static class ReferenceHandlingCodeGenerator
         return true;
     }
 
-    private static bool IsContainerOrWrapperStrategy(MapStrategy strategy)
-        => strategy is CollectionToCollectionMapStrategy
-            or DictionaryToDictionaryMapStrategy
-            or NullableStrategy
-            or TupleToTupleMapStrategy
-            or PolymorphismMapStrategy
-            or OptionalTargetPropertyMapStrategy
-            or OptionalSourcePropertyMapStrategy
-            or ReadonlyDictionaryPropertyMapStrategy
-            or ReadonlyCollectionPropertyMapStrategy
-            or ReadonlyAddCollectionPropertyMapStrategy
-            or ReadonlyQueuePropertyMapStrategy
-            or ReadonlyStackPropertyMapStrategy
-            or QueryableProjectionMapStrategy;
+    private static bool IsIneligiblePrimitiveOrNullableReferenceType(ITypeSymbol type)
+        => type.IsString() || type.IsEnum() || type.IsValueTypeNullable();
 
     private static bool AreReferenceTypesEligibleForReuse(ITypeSymbol targetType, ITypeSymbol sourceType)
     {
-        if (targetType.IsString() || sourceType.IsString()
-            || targetType.IsEnum() || sourceType.IsEnum())
+        if (IsIneligiblePrimitiveOrNullableReferenceType(targetType)
+            || IsIneligiblePrimitiveOrNullableReferenceType(sourceType))
         {
             return false;
         }
 
-        if (targetType.IsValueTypeNullable() || sourceType.IsValueTypeNullable())
-        {
-            return false;
-        }
-
-        if ((targetType.IsValueType && !targetType.IsReferenceType)
-            || (sourceType.IsValueType && !sourceType.IsReferenceType))
+        if (IsNonReferenceValueType(targetType) || IsNonReferenceValueType(sourceType))
         {
             return false;
         }
 
         return targetType.IsReferenceType && sourceType.IsReferenceType;
     }
+
+    private static bool IsNonReferenceValueType(ITypeSymbol type)
+        => type.IsValueType && !type.IsReferenceType;
 }

--- a/Mappa.Generator/IsExternalInit.cs
+++ b/Mappa.Generator/IsExternalInit.cs
@@ -1,0 +1,16 @@
+// <copyright file="IsExternalInit.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+#if !NET5_0_OR_GREATER
+namespace System.Runtime.CompilerServices;
+
+/// <summary>
+/// Enables the <c>init</c> accessor and positional record structs on older TFMs.
+/// </summary>
+#pragma warning disable S2094 // Empty class required for init accessors on older TFMs
+internal static class IsExternalInit
+{
+}
+#pragma warning restore S2094
+#endif

--- a/Mappa.Generator/Models/MappaGlobalOptions.cs
+++ b/Mappa.Generator/Models/MappaGlobalOptions.cs
@@ -319,353 +319,64 @@ internal sealed class MappaGlobalOptions
     {
         var options = analyzerConfigOptionsProvider.GetOptions(syntaxTree);
 
-        this.MappaDebug = options.TryGetValue(GetOptionName(MappaDebugFlagName), out var mappaDebug)
-                          && !string.IsNullOrWhiteSpace(mappaDebug)
-                          && "true".Equals(mappaDebug, StringComparison.OrdinalIgnoreCase);
+        this.MappaDebug = ReadBooleanFlag(options, MappaDebugFlagName);
+        this.MappaDebugComments = ReadBooleanFlag(options, MappaDebugCommentsFlagName);
 
-        this.MappaDebugComments =
-            options.TryGetValue(GetOptionName(MappaDebugCommentsFlagName), out var mappaDebugComments)
-            && !string.IsNullOrWhiteSpace(mappaDebugComments)
-            && "true".Equals(mappaDebugComments, StringComparison.OrdinalIgnoreCase);
-
-        this.DateTimeFormat = options.TryGetValue(GetOptionName(MappaSettingsDateTimeFormat), out var dateTimeFormat)
-                              && !string.IsNullOrWhiteSpace(dateTimeFormat)
-            ? dateTimeFormat
-            : null;
-
-        this.DateTimeOffsetFormat = options.TryGetValue(GetOptionName(MappaSettingsDateTimeOffsetFormat), out var dateTimeOffsetFormat)
-                              && !string.IsNullOrWhiteSpace(dateTimeOffsetFormat)
-            ? dateTimeOffsetFormat
-            : null;
-
-        this.DateOnlyFormat = options.TryGetValue(GetOptionName(MappaSettingsDateOnlyFormat), out var dateOnlyFormat)
-                              && !string.IsNullOrWhiteSpace(dateOnlyFormat)
-            ? dateOnlyFormat
-            : null;
-
-        this.TimeOnlyFormat = options.TryGetValue(GetOptionName(MappaSettingsTimeOnlyFormat), out var timeOnlyFormat)
-                              && !string.IsNullOrWhiteSpace(timeOnlyFormat)
-            ? timeOnlyFormat
-            : null;
-
+        this.DateTimeFormat = ReadFormatOption(options, MappaSettingsDateTimeFormat);
+        this.DateTimeOffsetFormat = ReadFormatOption(options, MappaSettingsDateTimeOffsetFormat);
+        this.DateOnlyFormat = ReadFormatOption(options, MappaSettingsDateOnlyFormat);
+        this.TimeOnlyFormat = ReadFormatOption(options, MappaSettingsTimeOnlyFormat);
         this.DateTimeStyle = ReadDateTimeStylesOption(options, MappaSettingsDateTimeStyle);
-
         this.DateTimeOffsetStyle = ReadDateTimeStylesOption(options, MappaSettingsDateTimeOffsetStyle);
-
         this.DateOnlyStyle = ReadDateTimeStylesOption(options, MappaSettingsDateOnlyStyle);
-
         this.TimeOnlyStyle = ReadDateTimeStylesOption(options, MappaSettingsTimeOnlyStyle);
-
         this.GlobalDateTimeStyle = ReadDateTimeStylesOption(options, MappaSettingsGlobalDateTimeStyle);
-
-        this.TimeSpanFormat = options.TryGetValue(GetOptionName(MappaSettingsTimeSpanFormat), out var timeSpanFormat)
-                              && !string.IsNullOrWhiteSpace(timeSpanFormat)
-            ? timeSpanFormat
-            : null;
-
+        this.TimeSpanFormat = ReadFormatOption(options, MappaSettingsTimeSpanFormat);
         this.GuidFormat = ReadFormatOption(options, MappaSettingsGuidFormat);
-
         this.ByteFormat = ReadFormatOption(options, MappaSettingsByteFormat);
-
         this.SByteFormat = ReadFormatOption(options, MappaSettingsSByteFormat);
-
         this.ShortFormat = ReadFormatOption(options, MappaSettingsShortFormat);
-
         this.UShortFormat = ReadFormatOption(options, MappaSettingsUShortFormat);
-
         this.IntFormat = ReadFormatOption(options, MappaSettingsIntFormat);
-
         this.UIntFormat = ReadFormatOption(options, MappaSettingsUIntFormat);
-
         this.LongFormat = ReadFormatOption(options, MappaSettingsLongFormat);
-
         this.ULongFormat = ReadFormatOption(options, MappaSettingsULongFormat);
-
         this.DecimalFormat = ReadFormatOption(options, MappaSettingsDecimalFormat);
-
         this.FloatFormat = ReadFormatOption(options, MappaSettingsFloatFormat);
-
         this.DoubleFormat = ReadFormatOption(options, MappaSettingsDoubleFormat);
-
         this.ByteStyle = ReadNumberStylesOption(options, MappaSettingsByteStyle);
-
         this.SByteStyle = ReadNumberStylesOption(options, MappaSettingsSByteStyle);
-
         this.ShortStyle = ReadNumberStylesOption(options, MappaSettingsShortStyle);
-
         this.UShortStyle = ReadNumberStylesOption(options, MappaSettingsUShortStyle);
-
         this.IntStyle = ReadNumberStylesOption(options, MappaSettingsIntStyle);
-
         this.UIntStyle = ReadNumberStylesOption(options, MappaSettingsUIntStyle);
-
         this.LongStyle = ReadNumberStylesOption(options, MappaSettingsLongStyle);
-
         this.ULongStyle = ReadNumberStylesOption(options, MappaSettingsULongStyle);
-
         this.DecimalStyle = ReadNumberStylesOption(options, MappaSettingsDecimalStyle);
-
         this.FloatStyle = ReadNumberStylesOption(options, MappaSettingsFloatStyle);
-
         this.DoubleStyle = ReadNumberStylesOption(options, MappaSettingsDoubleStyle);
-
         this.GlobalNumberStyle = ReadNumberStylesOption(options, MappaSettingsGlobalNumberStyle);
-
-        this.CultureName = options.TryGetValue(GetOptionName(MappaSettingsCultureName), out var cultureName)
-                           && !string.IsNullOrWhiteSpace(cultureName)
-            ? cultureName
-            : null;
-
-        this.CultureInfoSetting = options.TryGetValue(GetOptionName(MappaSettingsCultureInfoSettings), out var cultureInfoSettings)
-                                  && !string.IsNullOrWhiteSpace(cultureInfoSettings)
-            ? GetCultureInfoSettingsFromString(cultureInfoSettings)
-            : CultureInfoSetting.None;
-
-        this.ProtobufOptional = options.TryGetValue(GetOptionName(MappaSettingsProtobufOptional), out var protobufOptional)
-            ? GetBooleanSettingFromString(protobufOptional)
-            : BooleanSetting.Undefined;
-
-        this.PragmaWarning = options.TryGetValue(GetOptionName(MappaSettingsPragmaWarning), out var pragmaWarning)
-            ? GetPragmaWarningSettingFromString(pragmaWarning)
-            : PragmaWarningSetting.NoBlock;
-
-        this.FastCollections = options.TryGetValue(GetOptionName(MappaSettingsFastCollections), out var fastCollections)
-            ? GetBooleanSettingFromString(fastCollections)
-            : BooleanSetting.Undefined;
-
-        this.ContainerCapacityConstructors = options.TryGetValue(GetOptionName(MappaSettingsContainerCapacityConstructors), out var containerCapacityConstructors)
-            ? GetBooleanSettingFromString(containerCapacityConstructors)
-            : BooleanSetting.Undefined;
-
-        this.PreventEnumerableCount = options.TryGetValue(GetOptionName(MappaSettingsPreventEnumerableCount), out var preventEnumerableCount)
-            ? GetBooleanSettingFromString(preventEnumerableCount)
-            : BooleanSetting.Undefined;
-
-        this.PolymorphicMapMethodWithMatchingDefaultAttribute = options.TryGetValue(GetOptionName(MappaSettingsPolymorphicMapMethodWithMatchingDefaultAttribute), out var polymorphicMapMethodWithMatchingDefaultAttribute)
-            ? GetBooleanSettingFromString(polymorphicMapMethodWithMatchingDefaultAttribute)
-            : BooleanSetting.Undefined;
-
-        this.CompatibleMapMethod = options.TryGetValue(GetOptionName(MappaSettingsCompatibleMapMethod), out var compatibleMapMethod)
-            ? GetBooleanSettingFromString(compatibleMapMethod)
-            : BooleanSetting.Undefined;
-
-        this.CaseInsensitivePropertyMap = options.TryGetValue(GetOptionName(MappaSettingsCaseInsensitivePropertyMap), out var caseInsensitivePropertyMap)
-            ? GetBooleanSettingFromString(caseInsensitivePropertyMap)
-            : BooleanSetting.Undefined;
-
-        this.IgnoreUnderscoreForPropertyMap = options.TryGetValue(GetOptionName(MappaSettingsIgnoreUnderscoreForPropertyMap), out var ignoreUnderscoreForPropertyMap)
-            ? GetBooleanSettingFromString(ignoreUnderscoreForPropertyMap)
-            : BooleanSetting.Undefined;
-
-        this.CaseInsensitiveEnumMap = options.TryGetValue(GetOptionName(MappaSettingsCaseInsensitiveEnumMap), out var caseInsensitiveEnumMap)
-            ? GetBooleanSettingFromString(caseInsensitiveEnumMap)
-            : BooleanSetting.Undefined;
-
-        this.EnumStringMapSetting = options.TryGetValue(GetOptionName(MappaSettingsEnumStringMapSetting), out var enumStringMapSetting)
-            ? GetEnumStringMapSettingFromString(enumStringMapSetting)
-            : EnumStringMapSetting.MemberName;
-
-        this.EnumToEnumMapSetting = options.TryGetValue(GetOptionName(MappaSettingsEnumToEnumMapSetting), out var enumToEnumMapSetting)
-            ? GetEnumToEnumMapSettingFromString(enumToEnumMapSetting)
-            : EnumToEnumMapSetting.MemberName;
-
-        this.IdentityMapDeepCopy = options.TryGetValue(GetOptionName(MappaSettingsIdentityMapDeepCopy), out var identityMapDeepCopy)
-            ? GetIdentityMapDeepCopySettingFromString(identityMapDeepCopy)
-            : IdentityMapDeepCopySetting.ShallowCopy;
-
-        this.ReferenceReusing = options.TryGetValue(GetOptionName(MappaSettingsReferenceReusing), out var referenceReusing)
-            ? GetBooleanSettingFromString(referenceReusing)
-            : BooleanSetting.Undefined;
-
+        this.CultureName = ReadFormatOption(options, MappaSettingsCultureName);
+        this.CultureInfoSetting = ReadCultureInfoSettingOption(options, MappaSettingsCultureInfoSettings);
+        this.ProtobufOptional = ReadBooleanSettingOption(options, MappaSettingsProtobufOptional, BooleanSetting.Undefined);
+        this.PragmaWarning = ReadPragmaWarningSettingOption(options, MappaSettingsPragmaWarning);
+        this.FastCollections = ReadBooleanSettingOption(options, MappaSettingsFastCollections, BooleanSetting.Undefined);
+        this.ContainerCapacityConstructors = ReadBooleanSettingOption(options, MappaSettingsContainerCapacityConstructors, BooleanSetting.Undefined);
+        this.PreventEnumerableCount = ReadBooleanSettingOption(options, MappaSettingsPreventEnumerableCount, BooleanSetting.Undefined);
+        this.PolymorphicMapMethodWithMatchingDefaultAttribute = ReadBooleanSettingOption(options, MappaSettingsPolymorphicMapMethodWithMatchingDefaultAttribute, BooleanSetting.Undefined);
+        this.CompatibleMapMethod = ReadBooleanSettingOption(options, MappaSettingsCompatibleMapMethod, BooleanSetting.Undefined);
+        this.CaseInsensitivePropertyMap = ReadBooleanSettingOption(options, MappaSettingsCaseInsensitivePropertyMap, BooleanSetting.Undefined);
+        this.IgnoreUnderscoreForPropertyMap = ReadBooleanSettingOption(options, MappaSettingsIgnoreUnderscoreForPropertyMap, BooleanSetting.Undefined);
+        this.CaseInsensitiveEnumMap = ReadBooleanSettingOption(options, MappaSettingsCaseInsensitiveEnumMap, BooleanSetting.Undefined);
+        this.EnumStringMapSetting = ReadEnumStringMapSettingOption(options, MappaSettingsEnumStringMapSetting);
+        this.EnumToEnumMapSetting = ReadEnumToEnumMapSettingOption(options, MappaSettingsEnumToEnumMapSetting);
+        this.IdentityMapDeepCopy = ReadIdentityMapDeepCopySettingOption(options, MappaSettingsIdentityMapDeepCopy);
+        this.ReferenceReusing = ReadBooleanSettingOption(options, MappaSettingsReferenceReusing, BooleanSetting.Undefined);
         this.MaxRuntimeDepth = ReadDepthOption(options, MappaSettingsMaxRuntimeDepth, DefaultMaxRuntimeDepth);
-
         this.MaxCompileTimeDepth = ReadDepthOption(options, MappaSettingsMaxCompileTimeDepth, DefaultMaxCompileTimeDepth);
-
-        this.BreakCompileTimeCycles = options.TryGetValue(GetOptionName(MappaSettingsBreakCompileTimeCycles), out var breakCompileTimeCycles)
-            ? GetBooleanSettingFromString(breakCompileTimeCycles)
-            : BooleanSetting.Undefined;
-
-        this.EnumerableConcreteType = options.TryGetValue(GetOptionName(MappaSettingsEnumerableConcreteType), out var enumerableConcreteType)
-            ? GetEnumerableConcreteTypeSettingFromString(enumerableConcreteType)
-            : EnumerableConcreteTypeSetting.List;
-
-        this.DictionaryAssignment = options.TryGetValue(GetOptionName(MappaSettingsDictionaryAssignment), out var dictionaryAssignment)
-            ? GetDictionaryAssignmentSettingFromString(dictionaryAssignment)
-            : DictionaryAssignmentSetting.Indexer;
-
-        static CultureInfoSetting GetCultureInfoSettingsFromString(string cultureInfoSettings)
-        {
-            if (cultureInfoSettings.Equals(nameof(CultureInfoSetting.CurrentCulture), StringComparison.OrdinalIgnoreCase))
-            {
-                return CultureInfoSetting.CurrentCulture;
-            }
-
-            if (cultureInfoSettings.Equals(nameof(CultureInfoSetting.InvariantCulture), StringComparison.OrdinalIgnoreCase))
-            {
-                return CultureInfoSetting.InvariantCulture;
-            }
-
-            if (cultureInfoSettings.Equals(nameof(CultureInfoSetting.UserDefined), StringComparison.OrdinalIgnoreCase))
-            {
-                return CultureInfoSetting.UserDefined;
-            }
-
-            return CultureInfoSetting.None;
-        }
-
-        static BooleanSetting GetBooleanSettingFromString(string enableSettings)
-        {
-            if (enableSettings.Equals(nameof(BooleanSetting.Undefined), StringComparison.OrdinalIgnoreCase))
-            {
-                return BooleanSetting.Undefined;
-            }
-
-            if (enableSettings.Equals(nameof(BooleanSetting.Enable), StringComparison.OrdinalIgnoreCase))
-            {
-                return BooleanSetting.Enable;
-            }
-
-            if (enableSettings.Equals(nameof(BooleanSetting.Disable), StringComparison.OrdinalIgnoreCase))
-            {
-                return BooleanSetting.Disable;
-            }
-
-            return BooleanSetting.Undefined;
-        }
-
-        static EnumToEnumMapSetting GetEnumToEnumMapSettingFromString(string enumToEnumMapSettingValue)
-        {
-            if (enumToEnumMapSettingValue.Equals(nameof(EnumToEnumMapSetting.NumericValue), StringComparison.OrdinalIgnoreCase))
-            {
-                return EnumToEnumMapSetting.NumericValue;
-            }
-
-            if (enumToEnumMapSettingValue.Equals(nameof(EnumToEnumMapSetting.Description), StringComparison.OrdinalIgnoreCase))
-            {
-                return EnumToEnumMapSetting.Description;
-            }
-
-            if (enumToEnumMapSettingValue.Equals(nameof(EnumToEnumMapSetting.Undefined), StringComparison.OrdinalIgnoreCase))
-            {
-                return EnumToEnumMapSetting.Undefined;
-            }
-
-            return EnumToEnumMapSetting.MemberName;
-        }
-
-        static EnumStringMapSetting GetEnumStringMapSettingFromString(string enumStringMapSettingValue)
-        {
-            if (enumStringMapSettingValue.Equals(nameof(EnumStringMapSetting.Description), StringComparison.OrdinalIgnoreCase))
-            {
-                return EnumStringMapSetting.Description;
-            }
-
-            if (enumStringMapSettingValue.Equals(nameof(EnumStringMapSetting.Undefined), StringComparison.OrdinalIgnoreCase))
-            {
-                return EnumStringMapSetting.Undefined;
-            }
-
-            return EnumStringMapSetting.MemberName;
-        }
-
-        static IdentityMapDeepCopySetting GetIdentityMapDeepCopySettingFromString(string identityMapDeepCopyValue)
-        {
-            if (identityMapDeepCopyValue.Equals(nameof(IdentityMapDeepCopySetting.DeepCopy), StringComparison.OrdinalIgnoreCase))
-            {
-                return IdentityMapDeepCopySetting.DeepCopy;
-            }
-
-            if (identityMapDeepCopyValue.Equals(nameof(IdentityMapDeepCopySetting.NestedDeepCopy), StringComparison.OrdinalIgnoreCase))
-            {
-                return IdentityMapDeepCopySetting.NestedDeepCopy;
-            }
-
-            if (identityMapDeepCopyValue.Equals(nameof(IdentityMapDeepCopySetting.Undefined), StringComparison.OrdinalIgnoreCase))
-            {
-                return IdentityMapDeepCopySetting.Undefined;
-            }
-
-            return IdentityMapDeepCopySetting.ShallowCopy;
-        }
-
-        static EnumerableConcreteTypeSetting GetEnumerableConcreteTypeSettingFromString(string enumerableConcreteTypeValue)
-        {
-            if (enumerableConcreteTypeValue.Equals(nameof(EnumerableConcreteTypeSetting.Array), StringComparison.OrdinalIgnoreCase))
-            {
-                return EnumerableConcreteTypeSetting.Array;
-            }
-
-            if (enumerableConcreteTypeValue.Equals(nameof(EnumerableConcreteTypeSetting.Undefined), StringComparison.OrdinalIgnoreCase))
-            {
-                return EnumerableConcreteTypeSetting.Undefined;
-            }
-
-            return EnumerableConcreteTypeSetting.List;
-        }
-
-        static DictionaryAssignmentSetting GetDictionaryAssignmentSettingFromString(string dictionaryAssignmentValue)
-        {
-            if (dictionaryAssignmentValue.Equals(nameof(DictionaryAssignmentSetting.Add), StringComparison.OrdinalIgnoreCase))
-            {
-                return DictionaryAssignmentSetting.Add;
-            }
-
-            if (dictionaryAssignmentValue.Equals(nameof(DictionaryAssignmentSetting.Undefined), StringComparison.OrdinalIgnoreCase))
-            {
-                return DictionaryAssignmentSetting.Undefined;
-            }
-
-            return DictionaryAssignmentSetting.Indexer;
-        }
-
-        static PragmaWarningSetting GetPragmaWarningSettingFromString(string enableSettings)
-        {
-            if (enableSettings.Equals(nameof(PragmaWarningSetting.Undefined), StringComparison.OrdinalIgnoreCase))
-            {
-                return PragmaWarningSetting.Undefined;
-            }
-
-            if (enableSettings.Equals(nameof(PragmaWarningSetting.NoBlock), StringComparison.OrdinalIgnoreCase))
-            {
-                return PragmaWarningSetting.NoBlock;
-            }
-
-            if (enableSettings.Equals(nameof(BooleanSetting.Disable), StringComparison.OrdinalIgnoreCase))
-            {
-                return PragmaWarningSetting.Disable;
-            }
-
-            return PragmaWarningSetting.Undefined;
-        }
-
-        static string? ReadFormatOption(AnalyzerConfigOptions options, string optionName)
-            => options.TryGetValue(GetOptionName(optionName), out var format)
-               && !string.IsNullOrWhiteSpace(format)
-                ? format
-                : null;
-
-        static DateTimeStyles? ReadDateTimeStylesOption(AnalyzerConfigOptions options, string optionName)
-            => options.TryGetValue(GetOptionName(optionName), out var dateTimeStyles)
-                ? ParseDateTimeStylesCodeHelper.TryParseFromString(dateTimeStyles)
-                : null;
-
-        static NumberStyles? ReadNumberStylesOption(AnalyzerConfigOptions options, string optionName)
-            => options.TryGetValue(GetOptionName(optionName), out var numberStyles)
-                ? ParseNumberStylesCodeHelper.TryParseFromString(numberStyles)
-                : null;
-
-        static short ReadDepthOption(AnalyzerConfigOptions options, string optionName, short defaultValue)
-        {
-            if (!options.TryGetValue(GetOptionName(optionName), out var depthValue)
-                || string.IsNullOrWhiteSpace(depthValue)
-                || !short.TryParse(depthValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
-                || parsed < 0)
-            {
-                return defaultValue;
-            }
-
-            return parsed;
-        }
+        this.BreakCompileTimeCycles = ReadBooleanSettingOption(options, MappaSettingsBreakCompileTimeCycles, BooleanSetting.Undefined);
+        this.EnumerableConcreteType = ReadEnumerableConcreteTypeSettingOption(options, MappaSettingsEnumerableConcreteType);
+        this.DictionaryAssignment = ReadDictionaryAssignmentSettingOption(options, MappaSettingsDictionaryAssignment);
     }
 
     /// <inheritdoc />
@@ -842,6 +553,226 @@ internal sealed class MappaGlobalOptions
     /// Gets a value indicating whether to report debug comments in the generated code.
     /// </summary>
     internal bool MappaDebugComments { get; }
+
+    private static bool ReadBooleanFlag(AnalyzerConfigOptions options, string optionName)
+        => options.TryGetValue(GetOptionName(optionName), out var value)
+           && !string.IsNullOrWhiteSpace(value)
+           && "true".Equals(value, StringComparison.OrdinalIgnoreCase);
+
+    private static string? ReadFormatOption(AnalyzerConfigOptions options, string optionName)
+        => options.TryGetValue(GetOptionName(optionName), out var format)
+           && !string.IsNullOrWhiteSpace(format)
+            ? format
+            : null;
+
+    private static DateTimeStyles? ReadDateTimeStylesOption(AnalyzerConfigOptions options, string optionName)
+        => options.TryGetValue(GetOptionName(optionName), out var dateTimeStyles)
+            ? ParseDateTimeStylesCodeHelper.TryParseFromString(dateTimeStyles)
+            : null;
+
+    private static NumberStyles? ReadNumberStylesOption(AnalyzerConfigOptions options, string optionName)
+        => options.TryGetValue(GetOptionName(optionName), out var numberStyles)
+            ? ParseNumberStylesCodeHelper.TryParseFromString(numberStyles)
+            : null;
+
+    private static short ReadDepthOption(AnalyzerConfigOptions options, string optionName, short defaultValue)
+    {
+        if (!options.TryGetValue(GetOptionName(optionName), out var depthValue)
+            || string.IsNullOrWhiteSpace(depthValue)
+            || !short.TryParse(depthValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+            || parsed < 0)
+        {
+            return defaultValue;
+        }
+
+        return parsed;
+    }
+
+    private static CultureInfoSetting ReadCultureInfoSettingOption(AnalyzerConfigOptions options, string optionName)
+        => options.TryGetValue(GetOptionName(optionName), out var cultureInfoSettings)
+           && !string.IsNullOrWhiteSpace(cultureInfoSettings)
+            ? GetCultureInfoSettingsFromString(cultureInfoSettings)
+            : CultureInfoSetting.None;
+
+    private static BooleanSetting ReadBooleanSettingOption(AnalyzerConfigOptions options, string optionName, BooleanSetting defaultValue)
+        => options.TryGetValue(GetOptionName(optionName), out var value)
+            ? GetBooleanSettingFromString(value)
+            : defaultValue;
+
+    private static PragmaWarningSetting ReadPragmaWarningSettingOption(AnalyzerConfigOptions options, string optionName)
+        => options.TryGetValue(GetOptionName(optionName), out var pragmaWarning)
+            ? GetPragmaWarningSettingFromString(pragmaWarning)
+            : PragmaWarningSetting.NoBlock;
+
+    private static EnumStringMapSetting ReadEnumStringMapSettingOption(AnalyzerConfigOptions options, string optionName)
+        => options.TryGetValue(GetOptionName(optionName), out var enumStringMapSetting)
+            ? GetEnumStringMapSettingFromString(enumStringMapSetting)
+            : EnumStringMapSetting.MemberName;
+
+    private static EnumToEnumMapSetting ReadEnumToEnumMapSettingOption(AnalyzerConfigOptions options, string optionName)
+        => options.TryGetValue(GetOptionName(optionName), out var enumToEnumMapSetting)
+            ? GetEnumToEnumMapSettingFromString(enumToEnumMapSetting)
+            : EnumToEnumMapSetting.MemberName;
+
+    private static IdentityMapDeepCopySetting ReadIdentityMapDeepCopySettingOption(AnalyzerConfigOptions options, string optionName)
+        => options.TryGetValue(GetOptionName(optionName), out var identityMapDeepCopy)
+            ? GetIdentityMapDeepCopySettingFromString(identityMapDeepCopy)
+            : IdentityMapDeepCopySetting.ShallowCopy;
+
+    private static EnumerableConcreteTypeSetting ReadEnumerableConcreteTypeSettingOption(AnalyzerConfigOptions options, string optionName)
+        => options.TryGetValue(GetOptionName(optionName), out var enumerableConcreteType)
+            ? GetEnumerableConcreteTypeSettingFromString(enumerableConcreteType)
+            : EnumerableConcreteTypeSetting.List;
+
+    private static DictionaryAssignmentSetting ReadDictionaryAssignmentSettingOption(AnalyzerConfigOptions options, string optionName)
+        => options.TryGetValue(GetOptionName(optionName), out var dictionaryAssignment)
+            ? GetDictionaryAssignmentSettingFromString(dictionaryAssignment)
+            : DictionaryAssignmentSetting.Indexer;
+
+    private static CultureInfoSetting GetCultureInfoSettingsFromString(string cultureInfoSettings)
+    {
+        if (cultureInfoSettings.Equals(nameof(CultureInfoSetting.CurrentCulture), StringComparison.OrdinalIgnoreCase))
+        {
+            return CultureInfoSetting.CurrentCulture;
+        }
+
+        if (cultureInfoSettings.Equals(nameof(CultureInfoSetting.InvariantCulture), StringComparison.OrdinalIgnoreCase))
+        {
+            return CultureInfoSetting.InvariantCulture;
+        }
+
+        if (cultureInfoSettings.Equals(nameof(CultureInfoSetting.UserDefined), StringComparison.OrdinalIgnoreCase))
+        {
+            return CultureInfoSetting.UserDefined;
+        }
+
+        return CultureInfoSetting.None;
+    }
+
+    private static BooleanSetting GetBooleanSettingFromString(string enableSettings)
+    {
+        if (enableSettings.Equals(nameof(BooleanSetting.Undefined), StringComparison.OrdinalIgnoreCase))
+        {
+            return BooleanSetting.Undefined;
+        }
+
+        if (enableSettings.Equals(nameof(BooleanSetting.Enable), StringComparison.OrdinalIgnoreCase))
+        {
+            return BooleanSetting.Enable;
+        }
+
+        if (enableSettings.Equals(nameof(BooleanSetting.Disable), StringComparison.OrdinalIgnoreCase))
+        {
+            return BooleanSetting.Disable;
+        }
+
+        return BooleanSetting.Undefined;
+    }
+
+    private static EnumToEnumMapSetting GetEnumToEnumMapSettingFromString(string enumToEnumMapSettingValue)
+    {
+        if (enumToEnumMapSettingValue.Equals(nameof(EnumToEnumMapSetting.NumericValue), StringComparison.OrdinalIgnoreCase))
+        {
+            return EnumToEnumMapSetting.NumericValue;
+        }
+
+        if (enumToEnumMapSettingValue.Equals(nameof(EnumToEnumMapSetting.Description), StringComparison.OrdinalIgnoreCase))
+        {
+            return EnumToEnumMapSetting.Description;
+        }
+
+        if (enumToEnumMapSettingValue.Equals(nameof(EnumToEnumMapSetting.Undefined), StringComparison.OrdinalIgnoreCase))
+        {
+            return EnumToEnumMapSetting.Undefined;
+        }
+
+        return EnumToEnumMapSetting.MemberName;
+    }
+
+    private static EnumStringMapSetting GetEnumStringMapSettingFromString(string enumStringMapSettingValue)
+    {
+        if (enumStringMapSettingValue.Equals(nameof(EnumStringMapSetting.Description), StringComparison.OrdinalIgnoreCase))
+        {
+            return EnumStringMapSetting.Description;
+        }
+
+        if (enumStringMapSettingValue.Equals(nameof(EnumStringMapSetting.Undefined), StringComparison.OrdinalIgnoreCase))
+        {
+            return EnumStringMapSetting.Undefined;
+        }
+
+        return EnumStringMapSetting.MemberName;
+    }
+
+    private static IdentityMapDeepCopySetting GetIdentityMapDeepCopySettingFromString(string identityMapDeepCopyValue)
+    {
+        if (identityMapDeepCopyValue.Equals(nameof(IdentityMapDeepCopySetting.DeepCopy), StringComparison.OrdinalIgnoreCase))
+        {
+            return IdentityMapDeepCopySetting.DeepCopy;
+        }
+
+        if (identityMapDeepCopyValue.Equals(nameof(IdentityMapDeepCopySetting.NestedDeepCopy), StringComparison.OrdinalIgnoreCase))
+        {
+            return IdentityMapDeepCopySetting.NestedDeepCopy;
+        }
+
+        if (identityMapDeepCopyValue.Equals(nameof(IdentityMapDeepCopySetting.Undefined), StringComparison.OrdinalIgnoreCase))
+        {
+            return IdentityMapDeepCopySetting.Undefined;
+        }
+
+        return IdentityMapDeepCopySetting.ShallowCopy;
+    }
+
+    private static EnumerableConcreteTypeSetting GetEnumerableConcreteTypeSettingFromString(string enumerableConcreteTypeValue)
+    {
+        if (enumerableConcreteTypeValue.Equals(nameof(EnumerableConcreteTypeSetting.Array), StringComparison.OrdinalIgnoreCase))
+        {
+            return EnumerableConcreteTypeSetting.Array;
+        }
+
+        if (enumerableConcreteTypeValue.Equals(nameof(EnumerableConcreteTypeSetting.Undefined), StringComparison.OrdinalIgnoreCase))
+        {
+            return EnumerableConcreteTypeSetting.Undefined;
+        }
+
+        return EnumerableConcreteTypeSetting.List;
+    }
+
+    private static DictionaryAssignmentSetting GetDictionaryAssignmentSettingFromString(string dictionaryAssignmentValue)
+    {
+        if (dictionaryAssignmentValue.Equals(nameof(DictionaryAssignmentSetting.Add), StringComparison.OrdinalIgnoreCase))
+        {
+            return DictionaryAssignmentSetting.Add;
+        }
+
+        if (dictionaryAssignmentValue.Equals(nameof(DictionaryAssignmentSetting.Undefined), StringComparison.OrdinalIgnoreCase))
+        {
+            return DictionaryAssignmentSetting.Undefined;
+        }
+
+        return DictionaryAssignmentSetting.Indexer;
+    }
+
+    private static PragmaWarningSetting GetPragmaWarningSettingFromString(string enableSettings)
+    {
+        if (enableSettings.Equals(nameof(PragmaWarningSetting.Undefined), StringComparison.OrdinalIgnoreCase))
+        {
+            return PragmaWarningSetting.Undefined;
+        }
+
+        if (enableSettings.Equals(nameof(PragmaWarningSetting.NoBlock), StringComparison.OrdinalIgnoreCase))
+        {
+            return PragmaWarningSetting.NoBlock;
+        }
+
+        if (enableSettings.Equals(nameof(BooleanSetting.Disable), StringComparison.OrdinalIgnoreCase))
+        {
+            return PragmaWarningSetting.Disable;
+        }
+
+        return PragmaWarningSetting.Undefined;
+    }
 
     private static string GetOptionName(string name)
 #pragma warning disable CA1308 // Normalize strings to uppercase

--- a/Mappa.Generator/Models/MappaUserSettings.cs
+++ b/Mappa.Generator/Models/MappaUserSettings.cs
@@ -486,24 +486,85 @@ internal sealed class MappaUserSettings
             return new NoActionDisposable();
         }
 
-        return new PopActionDisposable(
+        return new PopActionDisposable(this.CollectApplyDisposables(mappaSettingsAttribute));
+    }
+
+    private static T ApplyDefinedOrKeep<T>(T candidate, T undefinedSentinel, StackSetting<T> current)
+        where T : struct
+        => !EqualityComparer<T>.Default.Equals(candidate, undefinedSentinel) ? candidate : current;
+
+    private static DateTimeStyles? GetDateTimeStyle(DateTimeStyles style, StackSetting<DateTimeStyles?> currentStyle)
+        => style != MappaSettingsAttribute.UndefinedDateTimeStyle ? style : currentStyle;
+
+    private static NumberStyles? GetNumberStyle(NumberStyles style, StackSetting<NumberStyles?> currentStyle)
+        => style != MappaSettingsAttribute.UndefinedNumberStyle ? style : currentStyle;
+
+    private static short GetDepth(short depth, StackSetting<short> currentDepth)
+        => depth >= 0 ? depth : currentDepth;
+
+    private IDisposable[] CollectApplyDisposables(MappaSettingsAttribute mappaSettingsAttribute)
+    {
+#pragma warning disable CA2000 // Disposables are owned by PopActionDisposable.
+        return
         [
-#pragma warning disable CA2000 // Call System. IDisposable. Dispose on object created by '...' before all references to it are out of scope
+            .. this.CollectDateTimeFormatApplyDisposables(mappaSettingsAttribute),
+            .. this.CollectDateTimeStyleApplyDisposables(mappaSettingsAttribute),
+            .. this.CollectRemainingFormatApplyDisposables(mappaSettingsAttribute),
+            .. this.CollectNumericFormatApplyDisposables(mappaSettingsAttribute),
+            .. this.CollectNumberStyleApplyDisposables(mappaSettingsAttribute),
+            .. this.CollectFeatureToggleApplyDisposables(mappaSettingsAttribute),
+            .. this.CollectDepthApplyDisposables(mappaSettingsAttribute),
+        ];
+#pragma warning restore CA2000
+    }
+
+    private IDisposable[] CollectDateTimeFormatApplyDisposables(MappaSettingsAttribute mappaSettingsAttribute)
+    {
+#pragma warning disable CA2000
+        return
+        [
             this.dateTimeFormat.Apply(mappaSettingsAttribute.DateTimeFormat ?? this.dateTimeFormat),
             this.dateTimeOffsetFormat.Apply(mappaSettingsAttribute.DateTimeOffsetFormat ?? this.dateTimeOffsetFormat),
             this.dateOnlyFormat.Apply(mappaSettingsAttribute.DateOnlyFormat ?? this.dateOnlyFormat),
             this.timeOnlyFormat.Apply(mappaSettingsAttribute.TimeOnlyFormat ?? this.timeOnlyFormat),
+        ];
+#pragma warning restore CA2000
+    }
+
+    private IDisposable[] CollectDateTimeStyleApplyDisposables(MappaSettingsAttribute mappaSettingsAttribute)
+    {
+#pragma warning disable CA2000
+        return
+        [
             this.dateTimeStyle.Apply(GetDateTimeStyle(mappaSettingsAttribute.DateTimeStyle, this.dateTimeStyle)),
             this.dateTimeOffsetStyle.Apply(GetDateTimeStyle(mappaSettingsAttribute.DateTimeOffsetStyle, this.dateTimeOffsetStyle)),
             this.dateOnlyStyle.Apply(GetDateTimeStyle(mappaSettingsAttribute.DateOnlyStyle, this.dateOnlyStyle)),
             this.timeOnlyStyle.Apply(GetDateTimeStyle(mappaSettingsAttribute.TimeOnlyStyle, this.timeOnlyStyle)),
             this.globalDateTimeStyle.Apply(GetDateTimeStyle(mappaSettingsAttribute.GlobalDateTimeStyle, this.globalDateTimeStyle)),
+        ];
+#pragma warning restore CA2000
+    }
+
+    private IDisposable[] CollectRemainingFormatApplyDisposables(MappaSettingsAttribute mappaSettingsAttribute)
+    {
+#pragma warning disable CA2000
+        return
+        [
             this.timeSpanFormat.Apply(mappaSettingsAttribute.TimeSpanFormat ?? this.timeSpanFormat),
             this.guidFormat.Apply(mappaSettingsAttribute.GuidFormat ?? this.guidFormat),
             this.byteFormat.Apply(mappaSettingsAttribute.ByteFormat ?? this.byteFormat),
             this.sByteFormat.Apply(mappaSettingsAttribute.SByteFormat ?? this.sByteFormat),
             this.shortFormat.Apply(mappaSettingsAttribute.ShortFormat ?? this.shortFormat),
             this.uShortFormat.Apply(mappaSettingsAttribute.UShortFormat ?? this.uShortFormat),
+        ];
+#pragma warning restore CA2000
+    }
+
+    private IDisposable[] CollectNumericFormatApplyDisposables(MappaSettingsAttribute mappaSettingsAttribute)
+    {
+#pragma warning disable CA2000
+        return
+        [
             this.intFormat.Apply(mappaSettingsAttribute.IntFormat ?? this.intFormat),
             this.uIntFormat.Apply(mappaSettingsAttribute.UIntFormat ?? this.uIntFormat),
             this.longFormat.Apply(mappaSettingsAttribute.LongFormat ?? this.longFormat),
@@ -511,6 +572,15 @@ internal sealed class MappaUserSettings
             this.decimalFormat.Apply(mappaSettingsAttribute.DecimalFormat ?? this.decimalFormat),
             this.floatFormat.Apply(mappaSettingsAttribute.FloatFormat ?? this.floatFormat),
             this.doubleFormat.Apply(mappaSettingsAttribute.DoubleFormat ?? this.doubleFormat),
+        ];
+#pragma warning restore CA2000
+    }
+
+    private IDisposable[] CollectNumberStyleApplyDisposables(MappaSettingsAttribute mappaSettingsAttribute)
+    {
+#pragma warning disable CA2000
+        return
+        [
             this.byteStyle.Apply(GetNumberStyle(mappaSettingsAttribute.ByteStyle, this.byteStyle)),
             this.sByteStyle.Apply(GetNumberStyle(mappaSettingsAttribute.SByteStyle, this.sByteStyle)),
             this.shortStyle.Apply(GetNumberStyle(mappaSettingsAttribute.ShortStyle, this.shortStyle)),
@@ -523,39 +593,48 @@ internal sealed class MappaUserSettings
             this.floatStyle.Apply(GetNumberStyle(mappaSettingsAttribute.FloatStyle, this.floatStyle)),
             this.doubleStyle.Apply(GetNumberStyle(mappaSettingsAttribute.DoubleStyle, this.doubleStyle)),
             this.globalNumberStyle.Apply(GetNumberStyle(mappaSettingsAttribute.GlobalNumberStyle, this.globalNumberStyle)),
-            this.cultureInfoSetting.Apply(mappaSettingsAttribute.CultureInfoSetting is not CultureInfoSetting.Undefined ? mappaSettingsAttribute.CultureInfoSetting : this.cultureInfoSetting),
-            this.cultureName.Apply(mappaSettingsAttribute.CultureName ?? this.cultureName),
-            this.protobufOptional.Apply(mappaSettingsAttribute.ProtobufOptional is not BooleanSetting.Undefined ? mappaSettingsAttribute.ProtobufOptional : this.protobufOptional),
-            this.pragmaWarning.Apply(mappaSettingsAttribute.PragmaWarning is not PragmaWarningSetting.Undefined ? mappaSettingsAttribute.PragmaWarning : this.pragmaWarning),
-            this.fastCollections.Apply(mappaSettingsAttribute.FastCollections is not BooleanSetting.Undefined ? mappaSettingsAttribute.FastCollections : this.fastCollections),
-            this.containerCapacityConstructors.Apply(mappaSettingsAttribute.ContainerCapacityConstructors is not BooleanSetting.Undefined ? mappaSettingsAttribute.ContainerCapacityConstructors : this.containerCapacityConstructors),
-            this.preventEnumerableCount.Apply(mappaSettingsAttribute.PreventEnumerableCount is not BooleanSetting.Undefined ? mappaSettingsAttribute.PreventEnumerableCount : this.preventEnumerableCount),
-            this.enumerableConcreteType.Apply(mappaSettingsAttribute.EnumerableConcreteType is not EnumerableConcreteTypeSetting.Undefined ? mappaSettingsAttribute.EnumerableConcreteType : this.enumerableConcreteType),
-            this.dictionaryAssignment.Apply(mappaSettingsAttribute.DictionaryAssignment is not DictionaryAssignmentSetting.Undefined ? mappaSettingsAttribute.DictionaryAssignment : this.dictionaryAssignment),
-            this.polymorphicMapMethodWithMatchingDefaultAttribute.Apply(mappaSettingsAttribute.PolymorphicMapMethodWithMatchingDefaultAttribute is not BooleanSetting.Undefined ? mappaSettingsAttribute.PolymorphicMapMethodWithMatchingDefaultAttribute : this.polymorphicMapMethodWithMatchingDefaultAttribute),
-            this.compatibleMapMethod.Apply(mappaSettingsAttribute.CompatibleMapMethod is not BooleanSetting.Undefined ? mappaSettingsAttribute.CompatibleMapMethod : this.compatibleMapMethod),
-            this.caseInsensitivePropertyMap.Apply(mappaSettingsAttribute.CaseInsensitivePropertyMap is not BooleanSetting.Undefined ? mappaSettingsAttribute.CaseInsensitivePropertyMap : this.caseInsensitivePropertyMap),
-            this.ignoreUnderscoreForPropertyMap.Apply(mappaSettingsAttribute.IgnoreUnderscoreForPropertyMap is not BooleanSetting.Undefined ? mappaSettingsAttribute.IgnoreUnderscoreForPropertyMap : this.ignoreUnderscoreForPropertyMap),
-            this.caseInsensitiveEnumMap.Apply(mappaSettingsAttribute.CaseInsensitiveEnumMap is not BooleanSetting.Undefined ? mappaSettingsAttribute.CaseInsensitiveEnumMap : this.caseInsensitiveEnumMap),
-            this.enumStringMapSetting.Apply(mappaSettingsAttribute.EnumStringMapSetting is not EnumStringMapSetting.Undefined ? mappaSettingsAttribute.EnumStringMapSetting : this.enumStringMapSetting),
-            this.enumToEnumMapSetting.Apply(mappaSettingsAttribute.EnumToEnumMapSetting is not EnumToEnumMapSetting.Undefined ? mappaSettingsAttribute.EnumToEnumMapSetting : this.enumToEnumMapSetting),
-            this.identityMapDeepCopy.Apply(mappaSettingsAttribute.IdentityMapDeepCopy is not IdentityMapDeepCopySetting.Undefined ? mappaSettingsAttribute.IdentityMapDeepCopy : this.identityMapDeepCopy),
-            this.referenceReusing.Apply(mappaSettingsAttribute.ReferenceReusing is not BooleanSetting.Undefined ? mappaSettingsAttribute.ReferenceReusing : this.referenceReusing),
-            this.maxRuntimeDepth.Apply(GetDepth(mappaSettingsAttribute.MaxRuntimeDepth, this.maxRuntimeDepth)),
-            this.maxCompileTimeDepth.Apply(GetDepth(mappaSettingsAttribute.MaxCompileTimeDepth, this.maxCompileTimeDepth)),
-            this.breakCompileTimeCycles.Apply(mappaSettingsAttribute.BreakCompileTimeCycles is not BooleanSetting.Undefined ? mappaSettingsAttribute.BreakCompileTimeCycles : this.breakCompileTimeCycles),
- #pragma warning restore CA2000
-        ]);
+        ];
+#pragma warning restore CA2000
     }
 
-    private static DateTimeStyles? GetDateTimeStyle(DateTimeStyles style, StackSetting<DateTimeStyles?> currentStyle)
-        => style != MappaSettingsAttribute.UndefinedDateTimeStyle ? style : currentStyle;
+    private IDisposable[] CollectFeatureToggleApplyDisposables(MappaSettingsAttribute mappaSettingsAttribute)
+    {
+#pragma warning disable CA2000
+        return
+        [
+            this.cultureInfoSetting.Apply(ApplyDefinedOrKeep(mappaSettingsAttribute.CultureInfoSetting, CultureInfoSetting.Undefined, this.cultureInfoSetting)),
+            this.cultureName.Apply(mappaSettingsAttribute.CultureName ?? this.cultureName),
+            this.protobufOptional.Apply(ApplyDefinedOrKeep(mappaSettingsAttribute.ProtobufOptional, BooleanSetting.Undefined, this.protobufOptional)),
+            this.pragmaWarning.Apply(ApplyDefinedOrKeep(mappaSettingsAttribute.PragmaWarning, PragmaWarningSetting.Undefined, this.pragmaWarning)),
+            this.fastCollections.Apply(ApplyDefinedOrKeep(mappaSettingsAttribute.FastCollections, BooleanSetting.Undefined, this.fastCollections)),
+            this.containerCapacityConstructors.Apply(ApplyDefinedOrKeep(mappaSettingsAttribute.ContainerCapacityConstructors, BooleanSetting.Undefined, this.containerCapacityConstructors)),
+            this.preventEnumerableCount.Apply(ApplyDefinedOrKeep(mappaSettingsAttribute.PreventEnumerableCount, BooleanSetting.Undefined, this.preventEnumerableCount)),
+            this.enumerableConcreteType.Apply(ApplyDefinedOrKeep(mappaSettingsAttribute.EnumerableConcreteType, EnumerableConcreteTypeSetting.Undefined, this.enumerableConcreteType)),
+            this.dictionaryAssignment.Apply(ApplyDefinedOrKeep(mappaSettingsAttribute.DictionaryAssignment, DictionaryAssignmentSetting.Undefined, this.dictionaryAssignment)),
+            this.polymorphicMapMethodWithMatchingDefaultAttribute.Apply(ApplyDefinedOrKeep(mappaSettingsAttribute.PolymorphicMapMethodWithMatchingDefaultAttribute, BooleanSetting.Undefined, this.polymorphicMapMethodWithMatchingDefaultAttribute)),
+            this.compatibleMapMethod.Apply(ApplyDefinedOrKeep(mappaSettingsAttribute.CompatibleMapMethod, BooleanSetting.Undefined, this.compatibleMapMethod)),
+            this.caseInsensitivePropertyMap.Apply(ApplyDefinedOrKeep(mappaSettingsAttribute.CaseInsensitivePropertyMap, BooleanSetting.Undefined, this.caseInsensitivePropertyMap)),
+            this.ignoreUnderscoreForPropertyMap.Apply(ApplyDefinedOrKeep(mappaSettingsAttribute.IgnoreUnderscoreForPropertyMap, BooleanSetting.Undefined, this.ignoreUnderscoreForPropertyMap)),
+            this.caseInsensitiveEnumMap.Apply(ApplyDefinedOrKeep(mappaSettingsAttribute.CaseInsensitiveEnumMap, BooleanSetting.Undefined, this.caseInsensitiveEnumMap)),
+            this.enumStringMapSetting.Apply(ApplyDefinedOrKeep(mappaSettingsAttribute.EnumStringMapSetting, EnumStringMapSetting.Undefined, this.enumStringMapSetting)),
+            this.enumToEnumMapSetting.Apply(ApplyDefinedOrKeep(mappaSettingsAttribute.EnumToEnumMapSetting, EnumToEnumMapSetting.Undefined, this.enumToEnumMapSetting)),
+            this.identityMapDeepCopy.Apply(ApplyDefinedOrKeep(mappaSettingsAttribute.IdentityMapDeepCopy, IdentityMapDeepCopySetting.Undefined, this.identityMapDeepCopy)),
+            this.referenceReusing.Apply(ApplyDefinedOrKeep(mappaSettingsAttribute.ReferenceReusing, BooleanSetting.Undefined, this.referenceReusing)),
+        ];
+#pragma warning restore CA2000
+    }
 
-    private static NumberStyles? GetNumberStyle(NumberStyles style, StackSetting<NumberStyles?> currentStyle)
-        => style != MappaSettingsAttribute.UndefinedNumberStyle ? style : currentStyle;
-
-    private static short GetDepth(short depth, StackSetting<short> currentDepth)
-        => depth >= 0 ? depth : currentDepth;
+    private IDisposable[] CollectDepthApplyDisposables(MappaSettingsAttribute mappaSettingsAttribute)
+    {
+#pragma warning disable CA2000
+        return
+        [
+            this.maxRuntimeDepth.Apply(GetDepth(mappaSettingsAttribute.MaxRuntimeDepth, this.maxRuntimeDepth)),
+            this.maxCompileTimeDepth.Apply(GetDepth(mappaSettingsAttribute.MaxCompileTimeDepth, this.maxCompileTimeDepth)),
+            this.breakCompileTimeCycles.Apply(ApplyDefinedOrKeep(mappaSettingsAttribute.BreakCompileTimeCycles, BooleanSetting.Undefined, this.breakCompileTimeCycles)),
+        ];
+#pragma warning restore CA2000
+    }
 
     private sealed class PopActionDisposable
         : IDisposable

--- a/MappaVersion.targets
+++ b/MappaVersion.targets
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <MappaVersion>10.2.0-alpha.60</MappaVersion>
+        <MappaVersion>10.2.0-alpha.61</MappaVersion>
     </PropertyGroup>
 </Project>

--- a/Scripts/RunTestsAndReportCoverage.ps1
+++ b/Scripts/RunTestsAndReportCoverage.ps1
@@ -1,8 +1,13 @@
 param([switch]$AlwaysSuccess);
 
 [double]$Threshold = 80.00
+# Issue #238: maxima tuned above cleaned CC 15 / CRAP 30 DoD (ReportGenerator display defaults).
+[double]$MaximumCyclomaticComplexity = 20
+[double]$MaximumCrapScore = 35
 $MappaTestsAndCoveragePath = ".mappa-tests-and-coverage"
 $MappaGeneratorTestsDumpPath = ".mappa-generator-tests-dump"
+$SummaryXmlPath = Join-Path $MappaTestsAndCoveragePath "Summary.xml"
+$SummaryMarkdownPath = Join-Path $MappaTestsAndCoveragePath "Summary.md"
 
 function Get-CoverageColor
 {
@@ -26,6 +31,95 @@ function Get-ShieldsIoJson
     param([string]$Name, [double]$Value)
     $color = Get-CoverageColor -Value $Value
     return "{ `"schemaVersion`": 1, `"label`": `"$Name`", `"message`": `"$Value%`", `"color`": `"$color`" }"
+}
+
+function Write-CoverageArtifactsAndReport
+{
+    param(
+        [double]$LineCoverage,
+        [double]$BranchCoverage,
+        [double]$MethodCoverage
+    )
+
+    Get-ShieldsIoJson -Name "Line Coverage" -Value $LineCoverage | Out-File "./$MappaTestsAndCoveragePath/line-coverage-badge.json"
+    Get-ShieldsIoJson -Name "Branch Coverage" -Value $BranchCoverage | Out-File "./$MappaTestsAndCoveragePath/branch-coverage-badge.json"
+    Get-ShieldsIoJson -Name "Method Coverage" -Value $MethodCoverage | Out-File "./$MappaTestsAndCoveragePath/method-coverage-badge.json"
+
+    [xml]$currentVersionFile = Get-Content ./MappaVersion.targets
+    $currentMappaVersion = $currentVersionFile.Project.PropertyGroup.MappaVersion
+    $timestamp = Get-Date -Format "yyyy/MM/dd HH:mm:ss"
+    "| $timestamp | $currentMappaVersion | LINE | $LineCoverage |`n| $timestamp | $currentMappaVersion | BRANCH | $BranchCoverage |`n| $timestamp | $currentMappaVersion | METHOD | $MethodCoverage |" | Out-File "./$MappaTestsAndCoveragePath/history-table.md"
+
+    $coverageBelowThreshold = ($LineCoverage -lt $Threshold) -or ($BranchCoverage -lt $Threshold) -or ($MethodCoverage -lt $Threshold)
+    if ($coverageBelowThreshold)
+    {
+        Write-Host "Poor coverage:" -ForegroundColor Red
+        Write-Host " - Line Coverage: $LineCoverage" -ForegroundColor Red
+        Write-Host " - Branch Coverage: $BranchCoverage" -ForegroundColor Red
+        Write-Host " - Method Coverage: $MethodCoverage" -ForegroundColor Red
+    }
+    else
+    {
+        Write-Host "Coverage:" -ForegroundColor Green
+        Write-Host " - Line Coverage: $LineCoverage %" -ForegroundColor Green
+        Write-Host " - Branch Coverage: $BranchCoverage %" -ForegroundColor Green
+        Write-Host " - Method Coverage: $MethodCoverage %" -ForegroundColor Green
+    }
+
+    return $coverageBelowThreshold
+}
+
+function Get-RiskHotspotViolationsFromSummaryMarkdown
+{
+    param(
+        [string]$SummaryMarkdownPath,
+        [double]$MaximumCyclomaticComplexity,
+        [double]$MaximumCrapScore
+    )
+
+    if (-not (Test-Path $SummaryMarkdownPath))
+    {
+        throw "Summary markdown not found at '$SummaryMarkdownPath'."
+    }
+
+    $markdown = Get-Content -Raw $SummaryMarkdownPath
+    if ($markdown -notmatch '(?s)# Risk Hotspots\s*(.*?)(?:\r?\n# Coverage|\z)')
+    {
+        return @()
+    }
+
+    $riskSection = $Matches[1]
+    # Rows may be one-per-line or concatenated with "||" between rows (ReportGenerator MarkdownSummary).
+    $rowMatches = [regex]::Matches(
+        $riskSection,
+        '\|\s*(?<Assembly>[^|]+?)\s*\|\s*(?<Class>[^|]+?)\s*\|\s*(?<Method>[^|]+?)\s*\|\s*(?<Crap>\d+(?:\.\d+)?)\s*\|\s*(?<Cc>\d+(?:\.\d+)?)\s*\|')
+
+    $violations = @()
+    foreach ($rowMatch in $rowMatches)
+    {
+        $assembly = $rowMatch.Groups['Assembly'].Value.Trim()
+        if ($assembly -eq '**Assembly**' -or $assembly -eq ':---')
+        {
+            continue
+        }
+
+        $crap = [double]::Parse($rowMatch.Groups['Crap'].Value, [System.Globalization.CultureInfo]::InvariantCulture)
+        $cc = [double]::Parse($rowMatch.Groups['Cc'].Value, [System.Globalization.CultureInfo]::InvariantCulture)
+        if ($crap -le $MaximumCrapScore -and $cc -le $MaximumCyclomaticComplexity)
+        {
+            continue
+        }
+
+        $violations += [pscustomobject]@{
+            Assembly = $assembly
+            Class = $rowMatch.Groups['Class'].Value.Trim()
+            Method = $rowMatch.Groups['Method'].Value.Trim()
+            CrapScore = $crap
+            CyclomaticComplexity = $cc
+        }
+    }
+
+    return $violations
 }
 
 if (Test-Path $MappaTestsAndCoveragePath)
@@ -74,27 +168,41 @@ if (-not $?)
     Exit 1
 }
 
-[xml]$Report = Get-Content -Raw "./$MappaTestsAndCoveragePath/Summary.xml"
+if (-not (Test-Path $SummaryXmlPath))
+{
+    Write-Host "Report failed: Summary.xml was not generated." -ForegroundColor Red
+    Exit 1
+}
+
+[xml]$Report = Get-Content -Raw $SummaryXmlPath
 [double]$LineCoverage = [double]::Parse($Report.CoverageReport.Summary.LineCoverage)
 [double]$Branchcoverage = [double]::Parse($Report.CoverageReport.Summary.Branchcoverage)
 [double]$Methodcoverage = [double]::Parse($Report.CoverageReport.Summary.Methodcoverage)
 
-Get-ShieldsIoJson -Name "Line Coverage" -Value $LineCoverage | Out-File "./$MappaTestsAndCoveragePath/line-coverage-badge.json"
-Get-ShieldsIoJson -Name "Branch Coverage" -Value $Branchcoverage | Out-File "./$MappaTestsAndCoveragePath/branch-coverage-badge.json"
-Get-ShieldsIoJson -Name "Method Coverage" -Value $Methodcoverage | Out-File "./$MappaTestsAndCoveragePath/method-coverage-badge.json"
+$coverageBelowThreshold = Write-CoverageArtifactsAndReport `
+    -LineCoverage $LineCoverage `
+    -BranchCoverage $Branchcoverage `
+    -MethodCoverage $Methodcoverage
 
-[xml]$currentVersionFile = Get-Content ./MappaVersion.targets
-$currentMappaVersion = $currentVersionFile.Project.PropertyGroup.MappaVersion
-$timestamp = Get-Date -Format "yyyy/MM/dd HH:mm:ss"
-"| $timestamp | $currentMappaVersion | LINE | $LineCoverage |`n| $timestamp | $currentMappaVersion | BRANCH | $Branchcoverage |`n| $timestamp | $currentMappaVersion | METHOD | $Methodcoverage |" | Out-File "./$MappaTestsAndCoveragePath/history-table.md"
+# Issue #238: parse Risk Hotspots from Summary.md (avoids ReportGenerator PRO maximum-threshold settings).
+$riskHotspotViolations = Get-RiskHotspotViolationsFromSummaryMarkdown `
+    -SummaryMarkdownPath $SummaryMarkdownPath `
+    -MaximumCyclomaticComplexity $MaximumCyclomaticComplexity `
+    -MaximumCrapScore $MaximumCrapScore
 
-if (($LineCoverage -lt $Threshold) -or ($Branchcoverage -lt $Threshold) -or ($Methodcoverage -lt $Threshold))
+if ($riskHotspotViolations.Count -gt 0)
 {
-    Write-Host "Poor coverage:" -ForegroundColor Red
-    Write-Host " - Line Coverage: $LineCoverage" -ForegroundColor Red
-    Write-Host " - Branch Coverage: $Branchcoverage" -ForegroundColor Red
-    Write-Host " - Method Coverage: $Methodcoverage" -ForegroundColor Red
+    Write-Host "Risk Hotspot maxima exceeded (cyclomatic complexity > $MaximumCyclomaticComplexity and/or CRAP score > $MaximumCrapScore):" -ForegroundColor Red
+    foreach ($violation in ($riskHotspotViolations | Sort-Object -Property CrapScore -Descending))
+    {
+        Write-Host (" - CRAP={0} CC={1} | {2}.{3}" -f $violation.CrapScore, $violation.CyclomaticComplexity, $violation.Class, $violation.Method) -ForegroundColor Red
+    }
+    Write-Host "See Risk Hotspots in ./$MappaTestsAndCoveragePath/Summary.md and ./$MappaTestsAndCoveragePath/index.html." -ForegroundColor Red
+    Exit 1
+}
 
+if ($coverageBelowThreshold)
+{
     if ($AlwaysSuccess)
     {
         Exit 0
@@ -104,10 +212,5 @@ if (($LineCoverage -lt $Threshold) -or ($Branchcoverage -lt $Threshold) -or ($Me
         Exit 1
     }
 }
-
-Write-Host "Coverage:" -ForegroundColor Green
-Write-Host " - Line Coverage: $LineCoverage %" -ForegroundColor Green
-Write-Host " - Branch Coverage: $Branchcoverage %" -ForegroundColor Green
-Write-Host " - Method Coverage: $Methodcoverage %" -ForegroundColor Green
 
 Exit 0


### PR DESCRIPTION
## Summary
- Clear ReportGenerator Risk Hotspots in **Mappa.Generator** (DoD: no methods with CC > 15 or CRAP > 30) via Phase 1 coverage tests and structural refactors (helpers, partials, table-driven dispatch).
- Add CI guardrails in `Scripts/RunTestsAndReportCoverage.ps1` that fail when Risk Hotspot CC > 20 or CRAP > 35 (after printing coverage).
- Restore overall coverage above baseline (line **98.4%**, branch **90.8%**, method **100%**) and bump to **10.2.0-alpha.61**.

## Test plan
- [x] `.\Scripts\RunTestsAndReportCoverage.ps1` — 2954 tests passed, exit 0
- [x] Risk Hotspots: "No risk hotspots found."
- [x] Guardrails (max CC 20 / CRAP 35) pass
- [x] Coverage ≥ baseline (98.3% / 90.6% / 100%)

Closes #238