### PR TITLE
#331 Use Default BenchmarkDotNet job; skip PR benchmarks

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,9 +40,6 @@ jobs:
       - name: Test and code coverage
         shell: pwsh
         run: ./Scripts/RunTestsAndReportCoverage.ps1
-      - name: Run benchmarks
-        shell: pwsh
-        run: ./Scripts/RunBenchmarks.ps1 -ChartBenchmarksOnly
       - name: Comment pull request coverage
         shell: pwsh
         env:

--- a/Documentation/development.md
+++ b/Documentation/development.md
@@ -35,7 +35,7 @@ Reports are:
 ### Run benchmarks
 `./Scripts/RunBenchmarks.ps1`
 
-Runs [BenchmarkDotNet](https://benchmarkdotnet.org/) in **Release** with job **Default** (same job used by CI). Default uses more iterations/warmups than Short, so wall-clock time is longer but results are less noisy. Outputs land under the gitignored `.mappa-benchmark/` folder:
+Runs [BenchmarkDotNet](https://benchmarkdotnet.org/) in **Release** with job **Default** (same job used on `main` merge CI). Default uses more iterations/warmups than Short, so wall-clock time is longer but results are less noisy. Pull requests do not run benchmarks. Outputs land under the gitignored `.mappa-benchmark/` folder:
 
 - `Benchmark.Summary.md` — mean time (ns) and allocated bytes for AutoMapper / Mapster / Mapperly / Mappa
 - `Benchmark.Comparison.md` — winner table for the chart subset (best time / best memory; ties listed; non-Mappa winners include % delta vs Mappa)
@@ -45,7 +45,7 @@ Runs [BenchmarkDotNet](https://benchmarkdotnet.org/) in **Release** with job **D
 
 Useful switches:
 
-- `-ChartBenchmarksOnly` — run only the benchmarks used by the TIME/MEMORY/comparison SVGs (what CI uses)
+- `-ChartBenchmarksOnly` — run only the benchmarks used by the TIME/MEMORY/comparison SVGs (what `main` merge CI uses)
 - `-SkipRun` — regenerate markdown/SVG outputs from existing `BenchmarkDotNet.Artifacts/results`
 - `-Filter "<pattern>"` — custom BenchmarkDotNet filter (default `*`)
 - `-ListAvailable` — list matching benchmarks without running them

--- a/Documentation/development.md
+++ b/Documentation/development.md
@@ -35,7 +35,7 @@ Reports are:
 ### Run benchmarks
 `./Scripts/RunBenchmarks.ps1`
 
-Runs [BenchmarkDotNet](https://benchmarkdotnet.org/) in **Release** with job **Short** (same job used by CI). Outputs land under the gitignored `.mappa-benchmark/` folder:
+Runs [BenchmarkDotNet](https://benchmarkdotnet.org/) in **Release** with job **Default** (same job used by CI). Default uses more iterations/warmups than Short, so wall-clock time is longer but results are less noisy. Outputs land under the gitignored `.mappa-benchmark/` folder:
 
 - `Benchmark.Summary.md` — mean time (ns) and allocated bytes for AutoMapper / Mapster / Mapperly / Mappa
 - `Benchmark.Comparison.md` — winner table for the chart subset (best time / best memory; ties listed; non-Mappa winners include % delta vs Mappa)

--- a/Mappa.Benchmark/README.md
+++ b/Mappa.Benchmark/README.md
@@ -10,7 +10,7 @@ From the repository root (PowerShell):
 .\Scripts\RunBenchmarks.ps1
 ```
 
-CI uses the chart subset only:
+`main` merge CI uses the chart subset only (pull requests do not run benchmarks):
 
 ```powershell
 .\Scripts\RunBenchmarks.ps1 -ChartBenchmarksOnly

--- a/Mappa.Benchmark/README.md
+++ b/Mappa.Benchmark/README.md
@@ -16,7 +16,7 @@ CI uses the chart subset only:
 .\Scripts\RunBenchmarks.ps1 -ChartBenchmarksOnly
 ```
 
-Jobs use BenchmarkDotNet **Short** run mode. Prefer a Release rebuild first (`.\Scripts\RebuildUponVersionChange.ps1`).
+Jobs use BenchmarkDotNet **Default** run mode (more iterations/warmups than Short — longer wall-clock, lower noise). Prefer a Release rebuild first (`.\Scripts\RebuildUponVersionChange.ps1`).
 
 Outputs are written under `.mappa-benchmark/` (gitignored). See [Documentation/development.md](../Documentation/development.md) for the full list of artifacts and gist publishing via `UpdateBenchmarkGists.ps1`.
 

--- a/MappaVersion.targets
+++ b/MappaVersion.targets
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <MappaVersion>10.2.0-alpha.62</MappaVersion>
+        <MappaVersion>10.2.0-alpha.63</MappaVersion>
     </PropertyGroup>
 </Project>

--- a/MappaVersion.targets
+++ b/MappaVersion.targets
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <MappaVersion>10.2.0-alpha.63</MappaVersion>
+        <MappaVersion>10.2.0-alpha.64</MappaVersion>
     </PropertyGroup>
 </Project>

--- a/Scripts/CommentPullRequestCoverage.ps1
+++ b/Scripts/CommentPullRequestCoverage.ps1
@@ -1,8 +1,6 @@
 param(
     [string]$SummaryXmlPath = "./.mappa-tests-and-coverage/Summary.xml",
     [string]$GistId = "7f4a85bc809328b4821b03125f9190cb",
-    [string]$BenchmarkSummaryPath = "./.mappa-benchmark/Benchmark.Summary.md",
-    [string]$BenchmarkComparisonPath = "./.mappa-benchmark/Benchmark.Comparison.md",
     [double]$WarningDropPercent = 1.0,
     [double]$FailDropPercent = 5.0,
     [switch]$DryRun
@@ -246,33 +244,6 @@ if ($failMetrics.Count -gt 0)
 if (($warningMetrics.Count -eq 0) -and ($failMetrics.Count -eq 0))
 {
     [void]$bodyBuilder.AppendLine("No coverage metric dropped by more than $WarningDropPercent percentage point(s) versus baseline.")
-}
-
-[void]$bodyBuilder.AppendLine()
-[void]$bodyBuilder.AppendLine("## Benchmarks")
-[void]$bodyBuilder.AppendLine()
-
-if (Test-Path -LiteralPath $BenchmarkComparisonPath)
-{
-    $comparisonMarkdown = (Get-Content -Raw -LiteralPath $BenchmarkComparisonPath).Trim()
-    # Drop the leading H1 so the PR section heading remains ## Benchmarks.
-    $comparisonMarkdown = $comparisonMarkdown -replace '(?s)^#\s+Benchmark comparison\s*', ""
-    [void]$bodyBuilder.AppendLine("### Winners (chart subset)")
-    [void]$bodyBuilder.AppendLine()
-    [void]$bodyBuilder.AppendLine($comparisonMarkdown.Trim())
-    [void]$bodyBuilder.AppendLine()
-}
-
-if (Test-Path -LiteralPath $BenchmarkSummaryPath)
-{
-    $summaryMarkdown = (Get-Content -Raw -LiteralPath $BenchmarkSummaryPath).Trim()
-    # Drop the leading H1 so the PR section heading remains ## Benchmarks.
-    $summaryMarkdown = $summaryMarkdown -replace '(?s)^#\s+Benchmark summary\s*', ""
-    [void]$bodyBuilder.AppendLine($summaryMarkdown.Trim())
-}
-else
-{
-    [void]$bodyBuilder.AppendLine("Benchmark summary not found. Run Scripts/RunBenchmarks.ps1 before commenting.")
 }
 
 $commentBody = $bodyBuilder.ToString().TrimEnd() + "`n"

--- a/Scripts/RunBenchmarks.ps1
+++ b/Scripts/RunBenchmarks.ps1
@@ -325,7 +325,8 @@ try
         $filterArgs = Get-BenchmarkDotNetFilterArgs
         Write-Host "Running benchmarks (filter: $filterDescription)..."
         # Pass filters as separate args so PowerShell does not glob-expand "*".
-        dotnet run -c Release --project ./Mappa.Benchmark/ -- -j Short -e "Csv" "Html" "GitHub" @filterArgs
+        # Default job uses more iterations/warmups than Short (longer wall-clock, lower noise).
+        dotnet run -c Release --project ./Mappa.Benchmark/ -- -j Default -e "Csv" "Html" "GitHub" @filterArgs
         if (-not $?)
         {
             Write-Host "Benchmark run failed." -ForegroundColor Red


### PR DESCRIPTION
## Summary
- Switch BenchmarkDotNet from the **Short** job to **Default** in `Scripts/RunBenchmarks.ps1` for more stable results (longer wall-clock).
- Stop running benchmarks on pull requests and stop posting benchmark tables in the PR coverage comment; keep chart-subset runs on `main` merge CI only.
- Document the Default job / PR vs main behavior; bump `MappaVersion` to `10.2.0-alpha.64`.

Closes #331

## Test plan
- [x] `.\Scripts\RunBenchmarks.ps1 -ChartBenchmarksOnly` completed successfully with Default (~13 min)
- [ ] PR CI: version check, build, tests/coverage, coverage comment (no benchmarks)
- [ ] After merge: `main` workflow still runs ChartBenchmarksOnly + gist update