### PR TITLE
#287 Update outdated NuGet package dependencies

### DIFF
--- a/Mappa.Benchmark/Common/BenchmarkSeed.cs
+++ b/Mappa.Benchmark/Common/BenchmarkSeed.cs
@@ -16,8 +16,9 @@ internal static class BenchmarkSeed
     /// </summary>
     public static void Apply()
     {
-#pragma warning disable S3010
+        // Deterministic Bogus seed for reproducible benchmarks; not used for security.
+#pragma warning disable S2245, S3010
         Randomizer.Seed = new Random(BenchmarkConstants.RandomSeed);
-#pragma warning restore S3010
+#pragma warning restore S2245, S3010
     }
 }

--- a/Mappa.Benchmark/Mappa.Benchmark.csproj
+++ b/Mappa.Benchmark/Mappa.Benchmark.csproj
@@ -25,7 +25,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.18.0.131500">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.31.0.145097">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Mappa.Dependency.Bson.DependencyInjection.Tests/Mappa.Dependency.Bson.DependencyInjection.Tests.csproj
+++ b/Mappa.Dependency.Bson.DependencyInjection.Tests/Mappa.Dependency.Bson.DependencyInjection.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
@@ -10,11 +10,10 @@
         <AnalysisLevel>latest-all</AnalysisLevel>
         <OutputType>Exe</OutputType>
         <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
-        <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
         <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -25,13 +24,13 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.18.0.131500">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.31.0.145097">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
+        <PackageReference Include="AwesomeAssertions" Version="9.5.0" />
         <PackageReference Include="Xunit.OpenCategories.V3" Version="2.4.1.19" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
         <PackageReference Include="Comment.Todo.Analyzer" Version="1.2.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/Mappa.Dependency.Bson.DependencyInjection/Mappa.Dependency.Bson.DependencyInjection.csproj
+++ b/Mappa.Dependency.Bson.DependencyInjection/Mappa.Dependency.Bson.DependencyInjection.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <Import Project="$(MSBuildThisFileDirectory)../MappaVersion.targets" />
     <PropertyGroup>
@@ -35,12 +35,12 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
         <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.18.0.131500">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.31.0.145097">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Mappa.Dependency.Bson.Tests/Mappa.Dependency.Bson.Tests.csproj
+++ b/Mappa.Dependency.Bson.Tests/Mappa.Dependency.Bson.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
@@ -10,10 +10,9 @@
         <AnalysisLevel>latest-all</AnalysisLevel>
         <OutputType>Exe</OutputType>
         <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
-        <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
         <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -24,13 +23,13 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.18.0.131500">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.31.0.145097">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
+        <PackageReference Include="AwesomeAssertions" Version="9.5.0" />
         <PackageReference Include="Xunit.OpenCategories.V3" Version="2.4.1.19" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
         <PackageReference Include="Comment.Todo.Analyzer" Version="1.2.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/Mappa.Dependency.Bson/Mappa.Dependency.Bson.csproj
+++ b/Mappa.Dependency.Bson/Mappa.Dependency.Bson.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <Import Project="$(MSBuildThisFileDirectory)../MappaVersion.targets" />
     <PropertyGroup>
@@ -36,12 +36,12 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="Mappa" Version="$(MappaVersion)" />
-        <PackageReference Include="MongoDb.Bson" Version="3.6.0" />
+        <PackageReference Include="MongoDb.Bson" Version="3.10.0" />
         <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.18.0.131500">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.31.0.145097">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Mappa.Dependency.Protobuf.DependencyInjection.Tests/Mappa.Dependency.Protobuf.DependencyInjection.Tests.csproj
+++ b/Mappa.Dependency.Protobuf.DependencyInjection.Tests/Mappa.Dependency.Protobuf.DependencyInjection.Tests.csproj
@@ -10,11 +10,10 @@
         <AnalysisLevel>latest-all</AnalysisLevel>
         <OutputType>Exe</OutputType>
         <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
-        <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
         <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -25,13 +24,13 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.18.0.131500">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.31.0.145097">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
+        <PackageReference Include="AwesomeAssertions" Version="9.5.0" />
         <PackageReference Include="Xunit.OpenCategories.V3" Version="2.4.1.19" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
         <PackageReference Include="Comment.Todo.Analyzer" Version="1.2.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/Mappa.Dependency.Protobuf.DependencyInjection/Mappa.Dependency.Protobuf.DependencyInjection.csproj
+++ b/Mappa.Dependency.Protobuf.DependencyInjection/Mappa.Dependency.Protobuf.DependencyInjection.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <Import Project="$(MSBuildThisFileDirectory)../MappaVersion.targets" />
     <PropertyGroup>
@@ -35,12 +35,12 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
         <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.18.0.131500">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.31.0.145097">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Mappa.Dependency.Protobuf.Tests/Mappa.Dependency.Protobuf.Tests.csproj
+++ b/Mappa.Dependency.Protobuf.Tests/Mappa.Dependency.Protobuf.Tests.csproj
@@ -10,10 +10,9 @@
         <AnalysisLevel>latest-all</AnalysisLevel>
         <OutputType>Exe</OutputType>
         <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
-        <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
         <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -24,13 +23,13 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.18.0.131500">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.31.0.145097">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
+        <PackageReference Include="AwesomeAssertions" Version="9.5.0" />
         <PackageReference Include="Xunit.OpenCategories.V3" Version="2.4.1.19" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
         <PackageReference Include="Comment.Todo.Analyzer" Version="1.2.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/Mappa.Dependency.Protobuf.Tests/ProtobufDurationUnitTests.cs
+++ b/Mappa.Dependency.Protobuf.Tests/ProtobufDurationUnitTests.cs
@@ -51,7 +51,7 @@ public sealed class ProtobufDurationUnitTests
 
         // Assert
         actual.Should().NotBeNull();
-        actual!.ToTimeSpan().Should().Be(timespan);
+        actual.ToTimeSpan().Should().Be(timespan);
     }
 
     /// <summary>
@@ -124,7 +124,7 @@ public sealed class ProtobufDurationUnitTests
 
         // Assert
         actual.Should().NotBeNull();
-        actual!.Value.Should().Be(expected);
+        actual.Value.Should().Be(expected);
     }
 
     /// <summary>

--- a/Mappa.Dependency.Protobuf.Tests/ProtobufTimestampUnitTests.cs
+++ b/Mappa.Dependency.Protobuf.Tests/ProtobufTimestampUnitTests.cs
@@ -211,7 +211,7 @@ public sealed class ProtobufTimestampUnitTests
 
         // Assert
         actual.Should().NotBeNull();
-        actual!.Value.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc).Should().Be(expected);
+        actual.Value.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc).Should().Be(expected);
     }
 
     /// <summary>
@@ -284,7 +284,7 @@ public sealed class ProtobufTimestampUnitTests
 
         // Assert
         actual.Should().NotBeNull();
-        DateOnly.FromDateTime(now).ToDateTime(actual!.Value, DateTimeKind.Utc).Should().Be(expected);
+        DateOnly.FromDateTime(now).ToDateTime(actual.Value, DateTimeKind.Utc).Should().Be(expected);
     }
 
     /// <summary>
@@ -337,7 +337,7 @@ public sealed class ProtobufTimestampUnitTests
 
         // Assert
         actual.Should().NotBeNull();
-        actual!.ToDateTime().Should().Be(expected);
+        actual.ToDateTime().Should().Be(expected);
     }
 
     /// <summary>
@@ -392,7 +392,7 @@ public sealed class ProtobufTimestampUnitTests
 
         // Assert
         actual.Should().NotBeNull();
-        actual!.ToDateTimeOffset().Should().Be(expected);
+        actual.ToDateTimeOffset().Should().Be(expected);
     }
 
     /// <summary>
@@ -449,7 +449,7 @@ public sealed class ProtobufTimestampUnitTests
 
         // Assert
         actual.Should().NotBeNull();
-        DateOnly.FromDateTime(actual!.ToDateTime()).Should().Be(dateOnly);
+        DateOnly.FromDateTime(actual.ToDateTime()).Should().Be(dateOnly);
     }
 
     /// <summary>

--- a/Mappa.Dependency.Protobuf/Mappa.Dependency.Protobuf.csproj
+++ b/Mappa.Dependency.Protobuf/Mappa.Dependency.Protobuf.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <Import Project="$(MSBuildThisFileDirectory)../MappaVersion.targets"/>
     <PropertyGroup>
@@ -35,13 +35,13 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Google.Protobuf" Version="3.33.4" />
+        <PackageReference Include="Google.Protobuf" Version="3.35.1" />
         <PackageReference Include="Mappa" Version="$(MappaVersion)" />
         <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.18.0.131500">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.31.0.145097">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Mappa.Generator.Tests/AttributeDataExtensionsGetMappaSettingsAttributeTests.cs
+++ b/Mappa.Generator.Tests/AttributeDataExtensionsGetMappaSettingsAttributeTests.cs
@@ -90,7 +90,7 @@ public sealed class AttributeDataExtensionsGetMappaSettingsAttributeTests
         var settings = attributes.GetMappaSettingsAttribute(compilation);
 
         settings.Should().NotBeNull();
-        settings!.SByteFormat.Should().Be("sb");
+        settings.SByteFormat.Should().Be("sb");
         settings.UShortFormat.Should().Be("us");
         settings.UIntFormat.Should().Be("ui");
         settings.ULongFormat.Should().Be("ul");
@@ -131,7 +131,7 @@ public sealed class AttributeDataExtensionsGetMappaSettingsAttributeTests
         var settings = attributes.GetMappaSettingsAttribute(compilation);
 
         settings.Should().NotBeNull();
-        settings!.DateTimeStyle.Should().Be(MappaSettingsAttribute.UndefinedDateTimeStyle);
+        settings.DateTimeStyle.Should().Be(MappaSettingsAttribute.UndefinedDateTimeStyle);
         settings.IntStyle.Should().Be(MappaSettingsAttribute.UndefinedNumberStyle);
     }
 
@@ -169,7 +169,7 @@ public sealed class AttributeDataExtensionsGetMappaSettingsAttributeTests
         var settings = attributes.GetMappaSettingsAttribute(compilation);
 
         settings.Should().NotBeNull();
-        settings!.IntStyle.Should().Be(NumberStyles.AllowThousands | NumberStyles.AllowParentheses);
+        settings.IntStyle.Should().Be(NumberStyles.AllowThousands | NumberStyles.AllowParentheses);
     }
 
     /// <summary>
@@ -206,7 +206,7 @@ public sealed class AttributeDataExtensionsGetMappaSettingsAttributeTests
         var settings = attributes.GetMappaSettingsAttribute(compilation);
 
         settings.Should().NotBeNull();
-        settings!.PreventEnumerableCount.Should().Be(BooleanSetting.Enable);
+        settings.PreventEnumerableCount.Should().Be(BooleanSetting.Enable);
     }
 
     /// <summary>
@@ -243,7 +243,7 @@ public sealed class AttributeDataExtensionsGetMappaSettingsAttributeTests
         var settings = attributes.GetMappaSettingsAttribute(compilation);
 
         settings.Should().NotBeNull();
-        settings!.BreakCompileTimeCycles.Should().Be(BooleanSetting.Enable);
+        settings.BreakCompileTimeCycles.Should().Be(BooleanSetting.Enable);
     }
 
     /// <summary>
@@ -280,7 +280,7 @@ public sealed class AttributeDataExtensionsGetMappaSettingsAttributeTests
         var settings = attributes.GetMappaSettingsAttribute(compilation);
 
         settings.Should().NotBeNull();
-        settings!.CompatibleMapMethod.Should().Be(BooleanSetting.Enable);
+        settings.CompatibleMapMethod.Should().Be(BooleanSetting.Enable);
     }
 
     /// <summary>
@@ -319,7 +319,7 @@ public sealed class AttributeDataExtensionsGetMappaSettingsAttributeTests
         var settings = attributes.GetMappaSettingsAttribute(compilation);
 
         settings.Should().NotBeNull();
-        settings!.DateTimeStyle.Should().Be((DateTimeStyles)999);
+        settings.DateTimeStyle.Should().Be((DateTimeStyles)999);
         settings.IntStyle.Should().Be((NumberStyles)1048576);
     }
 
@@ -357,7 +357,7 @@ public sealed class AttributeDataExtensionsGetMappaSettingsAttributeTests
         var settings = attributes.GetMappaSettingsAttribute(compilation);
 
         settings.Should().NotBeNull();
-        settings!.DictionaryAssignment.Should().Be(DictionaryAssignmentSetting.Add);
+        settings.DictionaryAssignment.Should().Be(DictionaryAssignmentSetting.Add);
     }
 
     /// <summary>
@@ -393,7 +393,7 @@ public sealed class AttributeDataExtensionsGetMappaSettingsAttributeTests
         var settings = attributes.GetMappaSettingsAttribute(compilation);
 
         settings.Should().NotBeNull();
-        settings!.MaxRuntimeDepth.Should().Be((short)7);
+        settings.MaxRuntimeDepth.Should().Be((short)7);
         settings.MaxCompileTimeDepth.Should().Be((short)3);
     }
 
@@ -436,7 +436,7 @@ public sealed class AttributeDataExtensionsGetMappaSettingsAttributeTests
         var settings = attributes.GetMappaSettingsAttribute(compilation);
 
         settings.Should().NotBeNull();
-        settings!.DateTimeStyle.Should().Be(DateTimeStyles.RoundtripKind);
+        settings.DateTimeStyle.Should().Be(DateTimeStyles.RoundtripKind);
         settings.IntStyle.Should().Be(NumberStyles.Number);
         settings.MaxRuntimeDepth.Should().Be((short)-1);
         settings.MaxRuntimeDepth.Should().Be(MappaSettingsAttribute.UndefinedDepth);
@@ -477,7 +477,7 @@ public sealed class AttributeDataExtensionsGetMappaSettingsAttributeTests
         var settings = attributes.GetMappaSettingsAttribute(compilation);
 
         settings.Should().NotBeNull();
-        settings!.MaxRuntimeDepth.Should().Be((short)9);
+        settings.MaxRuntimeDepth.Should().Be((short)9);
         settings.MaxCompileTimeDepth.Should().Be((short)4);
     }
 }

--- a/Mappa.Generator.Tests/AttributeDataExtensionsTests.cs
+++ b/Mappa.Generator.Tests/AttributeDataExtensionsTests.cs
@@ -51,7 +51,7 @@ public sealed class AttributeDataExtensionsTests
         var attribute = attributes.GetMappaTypeMappingDefaultAttribute(compilation);
 
         attribute.Should().NotBeNull();
-        attribute!.MethodName.Should().Be("DefaultMap");
+        attribute.MethodName.Should().Be("DefaultMap");
         attribute.Behavior.Should().Be(MappaTypeMappingDefaultBehavior.InvokeMethod);
     }
 
@@ -88,7 +88,7 @@ public sealed class AttributeDataExtensionsTests
         var attribute = attributes.GetMappaTypeMappingDefaultAttribute(compilation);
 
         attribute.Should().NotBeNull();
-        attribute!.Behavior.Should().Be(MappaTypeMappingDefaultBehavior.Null);
+        attribute.Behavior.Should().Be(MappaTypeMappingDefaultBehavior.Null);
         attribute.MethodName.Should().BeNull();
     }
 
@@ -130,9 +130,9 @@ public sealed class AttributeDataExtensionsTests
         var attribute = attributes.GetMappaTypeMappingDefaultAttribute(compilation);
 
         attribute.Should().NotBeNull();
-        attribute!.MethodName.Should().Be("DefaultMap");
+        attribute.MethodName.Should().Be("DefaultMap");
         attribute.Type.Should().NotBeNull();
-        attribute.Type!.FullName.Should().Be("Mappa.Generator.Tests.UnitTests.SourceCode.Dependency");
+        attribute.Type.FullName.Should().Be("Mappa.Generator.Tests.UnitTests.SourceCode.Dependency");
     }
 
     /// <summary>
@@ -168,9 +168,9 @@ public sealed class AttributeDataExtensionsTests
         var attribute = attributes.GetMappaTypeMappingDefaultAttribute(compilation);
 
         attribute.Should().NotBeNull();
-        attribute!.Behavior.Should().Be(MappaTypeMappingDefaultBehavior.MapSourceType);
+        attribute.Behavior.Should().Be(MappaTypeMappingDefaultBehavior.MapSourceType);
         attribute.Type.Should().NotBeNull();
-        attribute.Type!.FullName.Should().Be("Mappa.Generator.Tests.UnitTests.SourceCode.Target");
+        attribute.Type.FullName.Should().Be("Mappa.Generator.Tests.UnitTests.SourceCode.Target");
     }
 
     /// <summary>
@@ -335,9 +335,9 @@ public sealed class AttributeDataExtensionsTests
         var attribute = attributes.GetMappaTypeMappingDefaultAttribute(compilation);
 
         attribute.Should().NotBeNull();
-        attribute!.Behavior.Should().Be(MappaTypeMappingDefaultBehavior.MapSourceType);
+        attribute.Behavior.Should().Be(MappaTypeMappingDefaultBehavior.MapSourceType);
         attribute.Type.Should().NotBeNull();
-        attribute.Type!.FullName.Should().Be("Mappa.Generator.Tests.UnitTests.SourceCode.DefaultTarget");
+        attribute.Type.FullName.Should().Be("Mappa.Generator.Tests.UnitTests.SourceCode.DefaultTarget");
         attribute.MethodName.Should().BeNull();
     }
 
@@ -561,7 +561,7 @@ public sealed class AttributeDataExtensionsTests
         var attribute = attributes.GetMappaDependencyInjectionAttributeData(compilation);
 
         attribute.Should().NotBeNull();
-        attribute!.ConstructorMethodName.Should().Be("RegisterFromCtor");
+        attribute.ConstructorMethodName.Should().Be("RegisterFromCtor");
         attribute.MethodName.Should().Be("RegisterFromProperty");
         attribute.ExtensionMethod.Should().BeFalse();
         attribute.Accessibility.Should().Be(MappaDependencyInjectionMethodAccessibility.Internal);
@@ -618,7 +618,7 @@ public sealed class AttributeDataExtensionsTests
         var attribute = attributes.GetMappaAllowInaccessibleSourceMembersAttribute(compilation);
 
         attribute.Should().NotBeNull();
-        attribute!.MemberNames.Should().Equal("First", "Second");
+        attribute.MemberNames.Should().Equal("First", "Second");
     }
 
     /// <summary>
@@ -661,7 +661,7 @@ public sealed class AttributeDataExtensionsTests
         var attribute = attributes.GetMappaAllowInaccessibleTargetMembersAttribute(compilation);
 
         attribute.Should().NotBeNull();
-        attribute!.MemberNames.Should().Equal("Allowed");
+        attribute.MemberNames.Should().Equal("Allowed");
     }
 
     /// <summary>
@@ -704,7 +704,7 @@ public sealed class AttributeDataExtensionsTests
         var attribute = attributes.GetMappaAllowInaccessibleSourceMembersAttribute(compilation);
 
         attribute.Should().NotBeNull();
-        attribute!.MemberNames.Should().BeEmpty();
+        attribute.MemberNames.Should().BeEmpty();
     }
 
     /// <summary>
@@ -736,7 +736,7 @@ public sealed class AttributeDataExtensionsTests
         var attribute = attributes.GetMappaDependencyInjectionAttributeData(compilation);
 
         attribute.Should().NotBeNull();
-        attribute!.IgnoreTypes.Should().BeEmpty();
+        attribute.IgnoreTypes.Should().BeEmpty();
         attribute.InjectFromAssemblies.Should().BeEmpty();
     }
 
@@ -1040,7 +1040,7 @@ public sealed class AttributeDataExtensionsTests
         var attribute = attributes.GetMappaAllowInaccessibleTargetMembersAttribute(compilation);
 
         attribute.Should().NotBeNull();
-        attribute!.AllowProperties.Should().BeFalse();
+        attribute.AllowProperties.Should().BeFalse();
         attribute.AllowConstructors.Should().BeFalse();
         attribute.MemberNames.Should().BeEmpty();
     }
@@ -1085,7 +1085,7 @@ public sealed class AttributeDataExtensionsTests
         var attribute = attributes.GetMappaAllowInaccessibleTargetMembersAttribute(compilation);
 
         attribute.Should().NotBeNull();
-        attribute!.MemberNames.Should().Equal("Allowed");
+        attribute.MemberNames.Should().Equal("Allowed");
     }
 
     /// <summary>

--- a/Mappa.Generator.Tests/ConstructorMapStrategyDetectorPropertyPathContextTests.cs
+++ b/Mappa.Generator.Tests/ConstructorMapStrategyDetectorPropertyPathContextTests.cs
@@ -36,7 +36,7 @@ public sealed class ConstructorMapStrategyDetectorPropertyPathContextTests
             ["Address", "City"]);
         var descended = ConstructorMapStrategyDetector.GetNestedTypeMappingPropertyPathContext("Address", remainingContext);
         descended.Should().NotBeNull();
-        descended!.RemainingTargetSegments.Should().Equal("City");
+        descended.RemainingTargetSegments.Should().Equal("City");
         descended.RemainingSourceSegments.Should().Equal("City");
 
         var passThrough = ConstructorMapStrategyDetector.GetNestedTypeMappingPropertyPathContext("ZipCode", remainingContext);
@@ -51,7 +51,7 @@ public sealed class ConstructorMapStrategyDetectorPropertyPathContextTests
             "Address",
             nestedOriginalEmptyRemaining);
         nestedScopeFromEmptyRemaining.Should().NotBeNull();
-        nestedScopeFromEmptyRemaining!.IsNestedAttributeScope.Should().BeTrue();
+        nestedScopeFromEmptyRemaining.IsNestedAttributeScope.Should().BeTrue();
         nestedScopeFromEmptyRemaining.OuterTargetSegment.Should().Be("Address");
 
         var nestedOriginalMismatch = new PropertyPathContext("Address.City", "Address.City", [], []);

--- a/Mappa.Generator.Tests/IQueryableProjectionEntityFrameworkIntegrationTests.cs
+++ b/Mappa.Generator.Tests/IQueryableProjectionEntityFrameworkIntegrationTests.cs
@@ -117,7 +117,7 @@ public sealed class IQueryableProjectionEntityFrameworkIntegrationTests
         var selectFinder = new SelectExpressionFinder();
         selectFinder.Visit(projectedQueryable.Expression);
         selectFinder.SelectCall.Should().NotBeNull();
-        selectFinder.SelectCall!.Arguments.Count.Should().Be(2);
+        selectFinder.SelectCall.Arguments.Count.Should().Be(2);
         var projectionLambda = selectFinder.SelectCall.Arguments[1] as LambdaExpression
             ?? (selectFinder.SelectCall.Arguments[1] as UnaryExpression)?.Operand as LambdaExpression;
         projectionLambda.Should().NotBeNull();

--- a/Mappa.Generator.Tests/IdentityMapStrategyDetectorTests.cs
+++ b/Mappa.Generator.Tests/IdentityMapStrategyDetectorTests.cs
@@ -1,0 +1,230 @@
+// <copyright file="IdentityMapStrategyDetectorTests.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using Mappa;
+using Mappa.Generator.Algorithm.StrategyDetectors;
+using Mappa.Generator.Diagnostics.Debug;
+using Mappa.Generator.Models;
+using Mappa.Generator.Models.Strategies;
+using Mappa.Generator.Tests.Abstractions;
+using Mappa.Generator.Tests.Helpers;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+using Xunit;
+using Xunit.OpenCategories.V3;
+
+namespace Mappa.Generator.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="IdentityMapStrategyDetector"/>.
+/// </summary>
+public sealed class IdentityMapStrategyDetectorTests
+    : MappaGeneratorAbstractUnitTests
+{
+    /// <summary>
+    /// Test nullable value types ignore deep-copy settings and still use identity mapping.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void TryDetectMapsNullableIntToNullableIntWithDeepCopySetting()
+    {
+        const string source = """
+                              using Mappa.Attributes;
+
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              [Mappa]
+                              public sealed partial class Mapper
+                              {
+                                  public partial int? Map(int? input);
+                              }
+                              """;
+
+        var (methodContext, compilation) = CreateMethodContext(source, "Map");
+        using (methodContext.MappaUserSettings.Apply(new MappaSettingsAttribute { IdentityMapDeepCopy = IdentityMapDeepCopySetting.DeepCopy }))
+        {
+            var detector = new IdentityMapStrategyDetector(methodContext, compilation, TestContext.Current.CancellationToken);
+
+            var detected = detector.TryDetect(out var mapStrategy);
+
+            detected.Should().BeTrue();
+            mapStrategy.Should().BeOfType<IdentityMapStrategy>();
+        }
+    }
+
+    /// <summary>
+    /// Test nested deep copy succeeds for a type with no accessible instance fields.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void TryDetectNestedDeepCopySucceedsForTypeWithoutInstanceFields()
+    {
+        const string source = """
+                              using Mappa.Attributes;
+
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              public sealed class Empty
+                              {
+                              }
+
+                              [Mappa]
+                              public sealed partial class Mapper
+                              {
+                                  public partial Empty Map(Empty input);
+                              }
+                              """;
+
+        var (methodContext, compilation) = CreateMethodContext(source, "Map");
+        using (methodContext.MappaUserSettings.Apply(new MappaSettingsAttribute { IdentityMapDeepCopy = IdentityMapDeepCopySetting.NestedDeepCopy }))
+        {
+            var detector = new IdentityMapStrategyDetector(methodContext, compilation, TestContext.Current.CancellationToken);
+
+            var detected = detector.TryDetect(out var mapStrategy);
+
+            detected.Should().BeTrue();
+            var identity = mapStrategy.Should().BeOfType<IdentityMapStrategy>().Subject;
+            identity.NestedFieldStrategies.Should().BeEmpty();
+        }
+    }
+
+    /// <summary>
+    /// Test nested deep copy fails when a nested field type cannot be mapped without identity.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void TryDetectNestedDeepCopyFailsWhenNestedFieldCannotBeMapped()
+    {
+        const string source = """
+                              using Mappa.Attributes;
+
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              public sealed class Nested
+                              {
+                                  public Nested Child;
+                              }
+
+                              [Mappa]
+                              public sealed partial class Mapper
+                              {
+                                  public partial Nested Map(Nested input);
+                              }
+                              """;
+
+        var (methodContext, compilation) = CreateMethodContext(source, "Map");
+        using (methodContext.MappaUserSettings.Apply(new MappaSettingsAttribute { IdentityMapDeepCopy = IdentityMapDeepCopySetting.NestedDeepCopy }))
+        {
+            var detector = new IdentityMapStrategyDetector(methodContext, compilation, TestContext.Current.CancellationToken);
+
+            var detected = detector.TryDetect(out var mapStrategy);
+
+            detected.Should().BeFalse();
+            mapStrategy.Should().BeOfType<NoMapStrategy>();
+        }
+    }
+
+    /// <summary>
+    /// Test nested deep copy fails for structs when a nested field type cannot be mapped.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void TryDetectNestedDeepCopyFailsForStructWhenNestedFieldCannotBeMapped()
+    {
+        const string source = """
+                              using Mappa.Attributes;
+
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              public struct NestedStruct
+                              {
+                                  public NestedStruct Child;
+                              }
+
+                              [Mappa]
+                              public sealed partial class Mapper
+                              {
+                                  public partial NestedStruct Map(NestedStruct input);
+                              }
+                              """;
+
+        var (methodContext, compilation) = CreateMethodContext(source, "Map");
+        using (methodContext.MappaUserSettings.Apply(new MappaSettingsAttribute { IdentityMapDeepCopy = IdentityMapDeepCopySetting.NestedDeepCopy }))
+        {
+            var detector = new IdentityMapStrategyDetector(methodContext, compilation, TestContext.Current.CancellationToken);
+
+            var detected = detector.TryDetect(out var mapStrategy);
+
+            detected.Should().BeFalse();
+            mapStrategy.Should().BeOfType<NoMapStrategy>();
+        }
+    }
+
+    /// <summary>
+    /// Test an unexpected identity deep-copy setting falls back to a plain identity strategy.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void TryDetectFallsBackToIdentityForUnexpectedDeepCopySetting()
+    {
+        const string source = """
+                              using Mappa.Attributes;
+
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              public sealed class Sample
+                              {
+                              }
+
+                              [Mappa]
+                              public sealed partial class Mapper
+                              {
+                                  public partial Sample Map(Sample input);
+                              }
+                              """;
+
+        var (methodContext, compilation) = CreateMethodContext(source, "Map");
+        using (methodContext.MappaUserSettings.Apply(new MappaSettingsAttribute { IdentityMapDeepCopy = (IdentityMapDeepCopySetting)999 }))
+        {
+            var detector = new IdentityMapStrategyDetector(methodContext, compilation, TestContext.Current.CancellationToken);
+
+            var detected = detector.TryDetect(out var mapStrategy);
+
+            detected.Should().BeTrue();
+            mapStrategy.Should().BeOfType<IdentityMapStrategy>();
+        }
+    }
+
+    private static (MappaMethodGeneratorContext MethodContext, Compilation Compilation) CreateMethodContext(
+        string source,
+        string methodName)
+    {
+        var compilation = BuildCompilation(source);
+        var syntaxTree = compilation.SyntaxTrees[0];
+        var classDeclarationSyntax = syntaxTree.GetRoot(TestContext.Current.CancellationToken)
+            .DescendantNodes()
+            .OfType<ClassDeclarationSyntax>()
+            .Single(classSyntax => classSyntax.Identifier.Text == "Mapper");
+        var globalOptions = new MappaGlobalOptions(
+            TestAnalyzerConfigOptionsProvider.FromEditorConfig("root = true"),
+            syntaxTree);
+        var classContext = new MappaClassGeneratorContext(
+            globalOptions,
+            new MappaDebug(globalOptions, _ => { }),
+            compilation,
+            classDeclarationSyntax);
+        var methodDeclarationSyntax = classDeclarationSyntax.DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .Single(methodSyntax => methodSyntax.Identifier.Text == methodName);
+        var mapMethod = new MapMethod(
+            methodDeclarationSyntax,
+            compilation.GetSemanticModel(syntaxTree),
+            nullableEnabled: true,
+            TestContext.Current.CancellationToken);
+        var methodContext = new MappaMethodGeneratorContext(classContext, new MappaUserSettings(globalOptions), mapMethod);
+        return (methodContext, compilation);
+    }
+}

--- a/Mappa.Generator.Tests/InaccessibleMembersCoverageTests.cs
+++ b/Mappa.Generator.Tests/InaccessibleMembersCoverageTests.cs
@@ -29,18 +29,18 @@ public sealed class InaccessibleMembersCoverageTests
     {
         var allowAll = InaccessibleTargetMemberOptions.FromAttribute(new MappaAllowInaccessibleTargetMembersAttribute());
         allowAll.Should().NotBeNull();
-        allowAll!.IsPropertyAllowed("Any").Should().BeTrue();
+        allowAll.IsPropertyAllowed("Any").Should().BeTrue();
 
         var whitelist = InaccessibleTargetMemberOptions.FromAttribute(
             new MappaAllowInaccessibleTargetMembersAttribute("Allowed"));
         whitelist.Should().NotBeNull();
-        whitelist!.IsPropertyAllowed("Allowed").Should().BeTrue();
+        whitelist.IsPropertyAllowed("Allowed").Should().BeTrue();
         whitelist.IsPropertyAllowed("Denied").Should().BeFalse();
 
         var propertiesDisabled = InaccessibleTargetMemberOptions.FromAttribute(
             new MappaAllowInaccessibleTargetMembersAttribute { AllowProperties = false });
         propertiesDisabled.Should().NotBeNull();
-        propertiesDisabled!.IsPropertyAllowed("Any").Should().BeFalse();
+        propertiesDisabled.IsPropertyAllowed("Any").Should().BeFalse();
 
         InaccessibleTargetMemberOptions.FromAttribute(null).Should().BeNull();
     }
@@ -54,12 +54,12 @@ public sealed class InaccessibleMembersCoverageTests
     {
         var allowAll = InaccessibleSourceMemberOptions.FromAttribute(new MappaAllowInaccessibleSourceMembersAttribute());
         allowAll.Should().NotBeNull();
-        allowAll!.IsMemberAllowed("Any").Should().BeTrue();
+        allowAll.IsMemberAllowed("Any").Should().BeTrue();
 
         var whitelist = InaccessibleSourceMemberOptions.FromAttribute(
             new MappaAllowInaccessibleSourceMembersAttribute("Allowed"));
         whitelist.Should().NotBeNull();
-        whitelist!.IsMemberAllowed("Allowed").Should().BeTrue();
+        whitelist.IsMemberAllowed("Allowed").Should().BeTrue();
         whitelist.IsMemberAllowed("Denied").Should().BeFalse();
 
         InaccessibleSourceMemberOptions.FromAttribute(null).Should().BeNull();
@@ -121,7 +121,7 @@ public sealed class InaccessibleMembersCoverageTests
         var targetType = compilation.GetTypeByMetadataName("Coverage.Target");
         targetType.Should().NotBeNull();
 
-        var indexer = targetType!.GetMembers().OfType<IPropertySymbol>().Single(property => property.IsIndexer);
+        var indexer = targetType.GetMembers().OfType<IPropertySymbol>().Single(property => property.IsIndexer);
         var getOnly = targetType.GetMembers("GetOnly").OfType<IPropertySymbol>().Single();
         var options = InaccessibleTargetMemberOptions.FromAttribute(new MappaAllowInaccessibleTargetMembersAttribute());
 
@@ -229,8 +229,8 @@ public sealed class InaccessibleMembersCoverageTests
         sourceType.Should().NotBeNull();
         targetType.Should().NotBeNull();
 
-        var sourceProperty = sourceType!.GetMembers("Value").OfType<IPropertySymbol>().Single();
-        var targetProperty = targetType!.GetMembers("Value").OfType<IPropertySymbol>().Single();
+        var sourceProperty = sourceType.GetMembers("Value").OfType<IPropertySymbol>().Single();
+        var targetProperty = targetType.GetMembers("Value").OfType<IPropertySymbol>().Single();
         var constructor = targetType.InstanceConstructors.Single(method => method.Parameters.Length == 0);
 
         var context = new MappaBuilderContext(compilation);

--- a/Mappa.Generator.Tests/InvokeMethodSourcePropertyUsageTests.cs
+++ b/Mappa.Generator.Tests/InvokeMethodSourcePropertyUsageTests.cs
@@ -43,10 +43,10 @@ public sealed class InvokeMethodSourcePropertyUsageTests
         var compilation = BuildCompilation(source);
         var mapper = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.Mapper");
         mapper.Should().NotBeNull();
-        var method = mapper!.GetMembers("GetValue").OfType<IMethodSymbol>().Single();
+        var method = mapper.GetMembers("GetValue").OfType<IMethodSymbol>().Single();
         var sourceType = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.Source");
         sourceType.Should().NotBeNull();
-        var fooProperty = sourceType!.GetMembers("Foo").OfType<IPropertySymbol>().Single();
+        var fooProperty = sourceType.GetMembers("Foo").OfType<IPropertySymbol>().Single();
 
         var result = method.UsesSourceProperty(compilation, fooProperty, sourceType, false);
 
@@ -78,10 +78,10 @@ public sealed class InvokeMethodSourcePropertyUsageTests
         var compilation = BuildCompilation(source);
         var mapper = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.Mapper");
         mapper.Should().NotBeNull();
-        var method = mapper!.GetMembers("GetValue").OfType<IMethodSymbol>().Single();
+        var method = mapper.GetMembers("GetValue").OfType<IMethodSymbol>().Single();
         var sourceType = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.Source");
         sourceType.Should().NotBeNull();
-        var fooProperty = sourceType!.GetMembers("Foo").OfType<IPropertySymbol>().Single();
+        var fooProperty = sourceType.GetMembers("Foo").OfType<IPropertySymbol>().Single();
 
         var result = method.UsesSourceProperty(compilation, fooProperty, sourceType, false);
 
@@ -113,11 +113,11 @@ public sealed class InvokeMethodSourcePropertyUsageTests
         var compilation = BuildCompilation(source);
         var mapper = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.Mapper");
         mapper.Should().NotBeNull();
-        var method = mapper!.GetMembers("GetValue").OfType<IMethodSymbol>().Single();
+        var method = mapper.GetMembers("GetValue").OfType<IMethodSymbol>().Single();
         var sourceType = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.Source");
         sourceType.Should().NotBeNull();
 
-        var result = method.UsesSourceProperty(compilation, null, sourceType!, false);
+        var result = method.UsesSourceProperty(compilation, null, sourceType, false);
 
         result.Should().BeFalse();
     }

--- a/Mappa.Generator.Tests/Mappa.Generator.Tests.csproj
+++ b/Mappa.Generator.Tests/Mappa.Generator.Tests.csproj
@@ -10,12 +10,11 @@
 		<AnalysisLevel>latest-all</AnalysisLevel>
 		<OutputType>Exe</OutputType>
 		<UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
-		<TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
 	</PropertyGroup>
 	<ItemGroup>
-        <PackageReference Include="Google.Protobuf" Version="3.33.4" />
+        <PackageReference Include="Google.Protobuf" Version="3.35.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.10" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -26,13 +25,13 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="SonarAnalyzer.CSharp" Version="10.18.0.131500">
+		<PackageReference Include="SonarAnalyzer.CSharp" Version="10.31.0.145097">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="AwesomeAssertions" Version="9.4.0" />
+		<PackageReference Include="AwesomeAssertions" Version="9.5.0" />
 		<PackageReference Include="Xunit.OpenCategories.V3" Version="2.4.1.19" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
 		<PackageReference Include="PrettyCode.StringBuilder" Version="1.0.0" />
         <PackageReference Include="Comment.Todo.Analyzer" Version="1.2.0">

--- a/Mappa.Generator.Tests/MappaMapAlgorithmContextTests.cs
+++ b/Mappa.Generator.Tests/MappaMapAlgorithmContextTests.cs
@@ -1,0 +1,223 @@
+// <copyright file="MappaMapAlgorithmContextTests.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using Mappa.Generator.Diagnostics.Debug;
+using Mappa.Generator.Exceptions;
+using Mappa.Generator.Models;
+using Mappa.Generator.Tests.Abstractions;
+using Mappa.Generator.Tests.Helpers;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+using Xunit;
+using Xunit.OpenCategories.V3;
+
+namespace Mappa.Generator.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="MappaMapAlgorithmContext"/> defensive and dispose paths.
+/// </summary>
+public sealed class MappaMapAlgorithmContextTests
+    : MappaGeneratorAbstractUnitTests
+{
+    /// <summary>
+    /// Test <see cref="MappaMapAlgorithmContext.GetMapMethod"/> throws when the map method is not defined.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void GetMapMethodThrowsWhenMapMethodIsNotDefined()
+    {
+        var (context, _) = CreateRecordingContext();
+
+        var act = () => context.GetMapMethod();
+
+        act.Should()
+            .Throw<MappaGeneratorException>()
+            .WithMessage("Map method is not defined.");
+    }
+
+    /// <summary>
+    /// Test <see cref="MappaMapAlgorithmContext.TryGetClassGeneratorContext"/> returns <c>false</c>
+    /// when the root context is not a method generator context.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void TryGetClassGeneratorContextReturnsFalseWhenRootIsNotMethodContext()
+    {
+        var (context, _) = CreateRecordingContext();
+
+        var found = context.TryGetClassGeneratorContext(out var classContext);
+
+        found.Should().BeFalse();
+        classContext.Should().BeNull();
+    }
+
+    /// <summary>
+    /// Test <see cref="MappaMapAlgorithmContext.TryGetClassGeneratorContext"/> returns the class context
+    /// when the root is a <see cref="MappaMethodGeneratorContext"/>.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void TryGetClassGeneratorContextReturnsTrueForMethodContext()
+    {
+        var (methodContext, _) = CreateMethodContext();
+
+        var found = methodContext.TryGetClassGeneratorContext(out var classContext);
+
+        found.Should().BeTrue();
+        classContext.Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// Test compile-time depth dispose is idempotent.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void IncreaseCompileTimeDepthDisposeIsIdempotent()
+    {
+        var (methodContext, _) = CreateMethodContext();
+        methodContext.CurrentDepth.Should().Be(-1);
+
+        var scope = methodContext.IncreaseCompileTimeDepth();
+        methodContext.CurrentDepth.Should().Be(0);
+        scope.Dispose();
+        methodContext.CurrentDepth.Should().Be(-1);
+        scope.Dispose();
+        methodContext.CurrentDepth.Should().Be(-1);
+    }
+
+    /// <summary>
+    /// Test mapping-type-pair dispose is idempotent.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void TryPushMappingTypePairDisposeIsIdempotent()
+    {
+        var (methodContext, sourceType) = CreateMethodContext();
+        var scope = methodContext.TryPushMappingTypePair(sourceType, sourceType);
+        scope.Should().NotBeNull();
+
+        scope.Dispose();
+        scope.Dispose();
+
+        var second = methodContext.TryPushMappingTypePair(sourceType, sourceType);
+        second.Should().NotBeNull();
+        second.Dispose();
+    }
+
+    private static (RecordingMapAlgorithmContext Context, ITypeSymbol SourceType) CreateRecordingContext()
+    {
+        var compilation = BuildCompilation("""
+                                           namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                                           public sealed class Source { }
+                                           """);
+        var sourceType = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.Source")
+            ?? throw new InvalidOperationException("Source type was not found.");
+        var context = new RecordingMapAlgorithmContext(sourceType, sourceType, compilation.SyntaxTrees[0]);
+        return (context, sourceType);
+    }
+
+    private static (MappaMethodGeneratorContext MethodContext, ITypeSymbol SourceType) CreateMethodContext()
+    {
+        const string source = """
+                              using Mappa.Attributes;
+
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              public sealed class Source { }
+
+                              public sealed class Target { }
+
+                              [Mappa]
+                              public sealed partial class Mapper
+                              {
+                                  public partial Target Map(Source input);
+                              }
+                              """;
+
+        var compilation = BuildCompilation(source);
+        var syntaxTree = compilation.SyntaxTrees[0];
+        var classDeclarationSyntax = syntaxTree.GetRoot(TestContext.Current.CancellationToken)
+            .DescendantNodes()
+            .OfType<ClassDeclarationSyntax>()
+            .Single(classSyntax => classSyntax.Identifier.Text == "Mapper");
+        var globalOptions = new MappaGlobalOptions(
+            TestAnalyzerConfigOptionsProvider.FromEditorConfig("root = true"),
+            syntaxTree);
+        var classContext = new MappaClassGeneratorContext(
+            globalOptions,
+            new MappaDebug(globalOptions, _ => { }),
+            compilation,
+            classDeclarationSyntax);
+        var methodDeclarationSyntax = classDeclarationSyntax.DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .Single(methodSyntax => methodSyntax.Identifier.Text == "Map");
+        var mapMethod = new MapMethod(
+            methodDeclarationSyntax,
+            compilation.GetSemanticModel(syntaxTree),
+            nullableEnabled: true,
+            TestContext.Current.CancellationToken);
+        var methodContext = new MappaMethodGeneratorContext(classContext, new MappaUserSettings(globalOptions), mapMethod);
+        var sourceType = compilation.GetTypeByMetadataName("Mappa.Generator.Tests.UnitTests.SourceCode.Source")
+            ?? throw new InvalidOperationException("Source type was not found.");
+        return (methodContext, sourceType);
+    }
+
+    private sealed class RecordingMapAlgorithmContext : MappaMapAlgorithmContext
+    {
+        public RecordingMapAlgorithmContext(ITypeSymbol sourceType, ITypeSymbol targetType, SyntaxTree syntaxTree)
+        {
+            this.SourceType = sourceType;
+            this.TargetType = targetType;
+            this.ParentSymbol = targetType;
+            this.AlgorithmSettings = new MappaMapAlgorithmContextSettings();
+            var globalOptions = new MappaGlobalOptions(
+                TestAnalyzerConfigOptionsProvider.FromEditorConfig("root = true"),
+                syntaxTree);
+            this.MappaUserSettings = new MappaUserSettings(globalOptions);
+        }
+
+        internal override ISymbol ParentSymbol { get; }
+
+        internal override ITypeSymbol SourceType { get; }
+
+        internal override ITypeSymbol TargetType { get; }
+
+        internal override MapMethod? MapMethod => null;
+
+        internal override MappaMapAlgorithmContextSettings AlgorithmSettings { get; }
+
+        internal override MappaUserSettings MappaUserSettings { get; }
+
+        internal override bool HasErrorDiagnostics => false;
+
+        internal override bool IsNullableEnabled() => true;
+
+        internal override bool TryGetMethod(ITypeSymbol targetType, ITypeSymbol sourceType, out MapMethod mapMethod)
+        {
+            mapMethod = null!;
+            return false;
+        }
+
+        internal override bool TryGetPolymorphicMethod(ITypeSymbol targetType, ITypeSymbol sourceType, IMappaUserSettings mappaUserSettings, out MapMethod mapMethod)
+        {
+            mapMethod = null!;
+            return false;
+        }
+
+        internal override bool TryGetCompatibleMethod(ITypeSymbol targetType, ITypeSymbol sourceType, Compilation compilation, out MapMethod? mapMethod)
+        {
+            mapMethod = null;
+            return false;
+        }
+
+        internal override void ReportDiagnostic(Diagnostic diagnostic)
+        {
+        }
+
+        internal override Location? GetLocation() => null;
+    }
+}

--- a/Mappa.Generator.Tests/PolymorphismMapStrategyBuilderTests.cs
+++ b/Mappa.Generator.Tests/PolymorphismMapStrategyBuilderTests.cs
@@ -1,0 +1,312 @@
+// <copyright file="PolymorphismMapStrategyBuilderTests.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using Mappa;
+using Mappa.Attributes;
+using Mappa.Generator.Builders.Strategies;
+using Mappa.Generator.Exceptions;
+using Mappa.Generator.Models;
+using Mappa.Generator.Models.Strategies;
+using Mappa.Generator.Tests.Abstractions;
+using Mappa.Generator.Tests.Helpers;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+using Xunit;
+using Xunit.OpenCategories.V3;
+
+namespace Mappa.Generator.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="PolymorphismMapStrategyBuilder"/> defensive default-branch paths.
+/// </summary>
+public sealed class PolymorphismMapStrategyBuilderTests
+    : MappaGeneratorAbstractUnitTests
+{
+    /// <summary>
+    /// Test undefined default behavior throws while building the default branch.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void BuildSourceThrowsForUndefinedDefaultBehavior()
+    {
+        var setup = CreateSetup(new MappaTypeMappingDefaultAttribute(MappaTypeMappingDefaultBehavior.Undefined));
+
+        using (setup.BuilderContext.PushMapMethod(setup.MapMethod))
+        {
+            var act = () => setup.Builder.BuildSource("input", setup.BuilderContext, setup.GlobalOptions);
+
+            act.Should()
+                .Throw<MappaGeneratorException>()
+                .WithMessage("Unexpected undefined behavior while generating default branch for type mapping.");
+        }
+    }
+
+    /// <summary>
+    /// Test an unsupported default behavior value throws <see cref="ArgumentOutOfRangeException"/>.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void BuildSourceThrowsForUnsupportedDefaultBehavior()
+    {
+        var setup = CreateSetup(new MappaTypeMappingDefaultAttribute((MappaTypeMappingDefaultBehavior)999));
+
+        using (setup.BuilderContext.PushMapMethod(setup.MapMethod))
+        {
+            var act = () => setup.Builder.BuildSource("input", setup.BuilderContext, setup.GlobalOptions);
+
+            act.Should().Throw<ArgumentOutOfRangeException>();
+        }
+    }
+
+    /// <summary>
+    /// Test throw behavior fails when the exception type has no suitable constructor.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void BuildSourceThrowsWhenExceptionTypeHasNoSuitableConstructor()
+    {
+        var setup = CreateSetup(
+            new MappaTypeMappingDefaultAttribute(MappaTypeMappingDefaultBehavior.Throw, typeof(TwoArgException)),
+            addTestAssemblyReference: true);
+
+        using (setup.BuilderContext.PushMapMethod(setup.MapMethod))
+        {
+            var act = () => setup.Builder.BuildSource("input", setup.BuilderContext, setup.GlobalOptions);
+
+            act.Should()
+                .Throw<MappaGeneratorException>()
+                .WithMessage("Cannot identify a suitable constructor to generate the exception");
+        }
+    }
+
+    /// <summary>
+    /// Test invoke-method behavior throws when the invoke method was not resolved.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void BuildSourceThrowsWhenInvokeMethodIsMissing()
+    {
+        var setup = CreateSetup(new MappaTypeMappingDefaultAttribute("MissingMethod"));
+
+        using (setup.BuilderContext.PushMapMethod(setup.MapMethod))
+        {
+            var act = () => setup.Builder.BuildSource("input", setup.BuilderContext, setup.GlobalOptions);
+
+            act.Should()
+                .Throw<MappaGeneratorException>()
+                .WithMessage("Cannot identify the method to be invoked.");
+        }
+    }
+
+    /// <summary>
+    /// Test invoke-method behavior throws when the invoke type cannot be resolved in the compilation.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void BuildSourceThrowsWhenInvokeTypeCannotBeResolved()
+    {
+        var setup = CreateSetup(
+            new MappaTypeMappingDefaultAttribute(typeof(string[]), "Map"),
+            useMapAsInvokeMethod: true);
+
+        using (setup.BuilderContext.PushMapMethod(setup.MapMethod))
+        {
+            var act = () => setup.Builder.BuildSource("input", setup.BuilderContext, setup.GlobalOptions);
+
+            act.Should()
+                .Throw<MappaGeneratorException>()
+                .WithMessage("Cannot identify the type on which the method is being invoked on.");
+        }
+    }
+
+    /// <summary>
+    /// Test invoke-method behavior throws when a two-parameter method is selected but context is missing.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void BuildSourceThrowsWhenTwoParameterInvokeMethodHasNoContext()
+    {
+        const string source = """
+                              using Mappa;
+                              using Mappa.Attributes;
+
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              public class Source { }
+
+                              public class Target { }
+
+                              [Mappa]
+                              public sealed partial class Mapper
+                              {
+                                  public partial Target Map(Source input);
+
+                                  public static Target DefaultMap(Source input, MappaContext context) => new Target();
+                              }
+                              """;
+
+        var compilation = BuildCompilation(source);
+        var sourceType = RequireType(compilation, "Mappa.Generator.Tests.UnitTests.SourceCode.Source");
+        var targetType = RequireType(compilation, "Mappa.Generator.Tests.UnitTests.SourceCode.Target");
+        var mapperType = RequireType(compilation, "Mappa.Generator.Tests.UnitTests.SourceCode.Mapper");
+        var invokeMethod = mapperType.GetMembers("DefaultMap").OfType<IMethodSymbol>().Single();
+        var setup = CreateSetup(
+            compilation,
+            sourceType,
+            targetType,
+            new MappaTypeMappingDefaultAttribute("DefaultMap"),
+            invokeMethod,
+            contextParameterName: null);
+
+        using (setup.BuilderContext.PushMapMethod(setup.MapMethod))
+        {
+            var act = () => setup.Builder.BuildSource("input", setup.BuilderContext, setup.GlobalOptions);
+
+            act.Should()
+                .Throw<MappaGeneratorException>()
+                .WithMessage("Default mapping method requires to parameters but context on original mapping is not provided.");
+        }
+    }
+
+    /// <summary>
+    /// Test invoke-method behavior throws when the invoke method has an unsupported parameter count.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void BuildSourceThrowsWhenInvokeMethodHasUnexpectedParameterCount()
+    {
+        const string source = """
+                              using Mappa.Attributes;
+
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              public class Source { }
+
+                              public class Target { }
+
+                              [Mappa]
+                              public sealed partial class Mapper
+                              {
+                                  public partial Target Map(Source input);
+
+                                  public static Target DefaultMap(Source input, int extra, string another) => new Target();
+                              }
+                              """;
+
+        var compilation = BuildCompilation(source);
+        var sourceType = RequireType(compilation, "Mappa.Generator.Tests.UnitTests.SourceCode.Source");
+        var targetType = RequireType(compilation, "Mappa.Generator.Tests.UnitTests.SourceCode.Target");
+        var mapperType = RequireType(compilation, "Mappa.Generator.Tests.UnitTests.SourceCode.Mapper");
+        var invokeMethod = mapperType.GetMembers("DefaultMap").OfType<IMethodSymbol>().Single();
+        var setup = CreateSetup(
+            compilation,
+            sourceType,
+            targetType,
+            new MappaTypeMappingDefaultAttribute("DefaultMap"),
+            invokeMethod,
+            contextParameterName: "context");
+
+        using (setup.BuilderContext.PushMapMethod(setup.MapMethod))
+        {
+            var act = () => setup.Builder.BuildSource("input", setup.BuilderContext, setup.GlobalOptions);
+
+            act.Should().Throw<ArgumentOutOfRangeException>();
+        }
+    }
+
+    private static Setup CreateSetup(
+        MappaTypeMappingDefaultAttribute attribute,
+        bool useMapAsInvokeMethod = false,
+        bool addTestAssemblyReference = false)
+    {
+        const string source = """
+                              using Mappa.Attributes;
+
+                              namespace Mappa.Generator.Tests.UnitTests.SourceCode;
+
+                              public class Source { }
+
+                              public class Target { }
+
+                              [Mappa]
+                              public sealed partial class Mapper
+                              {
+                                  public partial Target Map(Source input);
+                              }
+                              """;
+
+        var compilation = BuildCompilation(source);
+        if (addTestAssemblyReference)
+        {
+            compilation = compilation.AddReferences(
+                MetadataReference.CreateFromFile(typeof(TwoArgException).Assembly.Location));
+        }
+
+        var sourceType = RequireType(compilation, "Mappa.Generator.Tests.UnitTests.SourceCode.Source");
+        var targetType = RequireType(compilation, "Mappa.Generator.Tests.UnitTests.SourceCode.Target");
+        IMethodSymbol? invokeMethod = null;
+        if (useMapAsInvokeMethod)
+        {
+            var mapperType = RequireType(compilation, "Mappa.Generator.Tests.UnitTests.SourceCode.Mapper");
+            invokeMethod = mapperType.GetMembers("Map").OfType<IMethodSymbol>().Single();
+        }
+
+        return CreateSetup(compilation, sourceType, targetType, attribute, invokeMethod, contextParameterName: null);
+    }
+
+    private static Setup CreateSetup(
+        CSharpCompilation compilation,
+        ITypeSymbol sourceType,
+        ITypeSymbol targetType,
+        MappaTypeMappingDefaultAttribute attribute,
+        IMethodSymbol? defaultInvokeMethod,
+        string? contextParameterName)
+    {
+        var identity = new IdentityMapStrategy(targetType, sourceType);
+        var strategy = new PolymorphismMapStrategy(
+            targetType,
+            sourceType,
+            [],
+            attribute,
+            identity,
+            nullableEnabled: true,
+            mapMethodContextParameterName: contextParameterName,
+            defaultInvokeMethod: defaultInvokeMethod);
+        var builder = new PolymorphismMapStrategyBuilder(strategy);
+        var builderContext = new MappaBuilderContext(compilation);
+        var globalOptions = new MappaGlobalOptions(
+            TestAnalyzerConfigOptionsProvider.FromEditorConfig("root = true"),
+            compilation.SyntaxTrees[0]);
+        var mapMethod = CreateMapMethod(compilation, "Map");
+        return new Setup(builder, builderContext, globalOptions, mapMethod);
+    }
+
+    private static MapMethod CreateMapMethod(Compilation compilation, string methodName)
+    {
+        var syntaxTree = compilation.SyntaxTrees.Single(tree =>
+            tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Any(methodSyntax => methodSyntax.Identifier.Text == methodName));
+        var methodDeclarationSyntax = syntaxTree.GetRoot()
+            .DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .Single(methodSyntax => methodSyntax.Identifier.Text == methodName);
+        var semanticModel = compilation.GetSemanticModel(syntaxTree);
+        return new MapMethod(
+            methodDeclarationSyntax,
+            semanticModel,
+            nullableEnabled: true,
+            CancellationToken.None);
+    }
+
+    private static INamedTypeSymbol RequireType(Compilation compilation, string metadataName)
+        => compilation.GetTypeByMetadataName(metadataName)
+           ?? throw new InvalidOperationException($"Type '{metadataName}' was not found.");
+
+    private sealed record Setup(
+        PolymorphismMapStrategyBuilder Builder,
+        MappaBuilderContext BuilderContext,
+        MappaGlobalOptions GlobalOptions,
+        MapMethod MapMethod);
+}

--- a/Mappa.Generator.Tests/StringToGuidMapStrategyBuilderTests.cs
+++ b/Mappa.Generator.Tests/StringToGuidMapStrategyBuilderTests.cs
@@ -1,0 +1,96 @@
+// <copyright file="StringToGuidMapStrategyBuilderTests.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+using Mappa;
+using Mappa.Generator.Builders.Strategies;
+using Mappa.Generator.Exceptions;
+using Mappa.Generator.Models;
+using Mappa.Generator.Models.Strategies;
+using Mappa.Generator.Tests.Abstractions;
+using Mappa.Generator.Tests.Helpers;
+
+using Xunit;
+using Xunit.OpenCategories.V3;
+
+namespace Mappa.Generator.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="StringToGuidMapStrategyBuilder"/>.
+/// </summary>
+public sealed class StringToGuidMapStrategyBuilderTests
+    : MappaGeneratorAbstractUnitTests
+{
+    /// <summary>
+    /// Test building with a user-defined culture and culture name emits <c>GetCultureInfo</c>.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void BuildSourceEmitsGetCultureInfoForUserDefinedCulture()
+    {
+        var (builder, builderContext, globalOptions) = CreateBuilder(
+            CultureInfoSetting.UserDefined,
+            cultureName: "it-IT",
+            format: null);
+
+        var (_, code) = builder.BuildSource("input", builderContext, globalOptions);
+
+        code.Should().Contain("Guid.Parse(input, System.Globalization.CultureInfo.GetCultureInfo(\"it-IT\"))");
+    }
+
+    /// <summary>
+    /// Test building with a user-defined culture but missing culture name throws.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void BuildSourceThrowsWhenUserDefinedCultureIsMissingCultureName()
+    {
+        var (builder, builderContext, globalOptions) = CreateBuilder(
+            CultureInfoSetting.UserDefined,
+            cultureName: null,
+            format: null);
+
+        var act = () => builder.BuildSource("input", builderContext, globalOptions);
+
+        act.Should()
+            .Throw<MappaGeneratorException>()
+            .WithMessage("Reached the scenario where we are trying to build using user defined custom culture without culture name.");
+    }
+
+    /// <summary>
+    /// Test building with an unexpected culture setting throws.
+    /// </summary>
+    [Fact]
+    [UnitTest]
+    public void BuildSourceThrowsForUnexpectedCultureSetting()
+    {
+        var (builder, builderContext, globalOptions) = CreateBuilder(
+            (CultureInfoSetting)999,
+            cultureName: null,
+            format: null);
+
+        var act = () => builder.BuildSource("input", builderContext, globalOptions);
+
+        act.Should()
+            .Throw<MappaGeneratorException>()
+            .WithMessage("Unexpected culture info setting '999'.");
+    }
+
+    private static (StringToGuidMapStrategyBuilder Builder, MappaBuilderContext BuilderContext, MappaGlobalOptions GlobalOptions) CreateBuilder(
+        CultureInfoSetting cultureInfoSetting,
+        string? cultureName,
+        string? format)
+    {
+        var compilation = BuildCompilation("namespace Mappa.Generator.Tests.UnitTests.SourceCode { internal class Placeholder { } }");
+        var stringType = compilation.GetSpecialType(SpecialType.System_String);
+        var guidType = compilation.GetTypeByMetadataName("System.Guid")
+            ?? throw new InvalidOperationException("Guid type was not found.");
+        var strategy = new StringToGuidMapStrategy(guidType, stringType, format, cultureInfoSetting, cultureName);
+        var builder = new StringToGuidMapStrategyBuilder(strategy);
+        var builderContext = new MappaBuilderContext(compilation);
+        var globalOptions = new MappaGlobalOptions(
+            TestAnalyzerConfigOptionsProvider.FromEditorConfig("root = true"),
+            compilation.SyntaxTrees[0]);
+        return (builder, builderContext, globalOptions);
+    }
+}

--- a/Mappa.Generator.Tests/SyntheticMapMethodNamingTests.cs
+++ b/Mappa.Generator.Tests/SyntheticMapMethodNamingTests.cs
@@ -193,7 +193,7 @@ public sealed class SyntheticMapMethodNamingTests
         var compilation = BuildCompilation("public class Holder { }");
         var dictionaryOpen = compilation.GetTypeByMetadataName("System.Collections.Generic.Dictionary`2");
         dictionaryOpen.Should().NotBeNull();
-        var dictionaryType = dictionaryOpen!.Construct(
+        var dictionaryType = dictionaryOpen.Construct(
             compilation.GetSpecialType(SpecialType.System_String),
             compilation.GetSpecialType(SpecialType.System_Int32));
 

--- a/Mappa.Generator.Tests/TwoArgException.cs
+++ b/Mappa.Generator.Tests/TwoArgException.cs
@@ -1,0 +1,24 @@
+// <copyright file="TwoArgException.cs" company="Stefano Anelli">
+// Copyright (c) Stefano Anelli. All rights reserved.
+// </copyright>
+
+namespace Mappa.Generator.Tests;
+
+/// <summary>
+/// Fixture type with only a two-argument constructor so polymorphism throw generation rejects it.
+/// </summary>
+#pragma warning disable CA1812
+internal sealed class TwoArgException
+#pragma warning restore CA1812
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TwoArgException"/> class.
+    /// </summary>
+    /// <param name="first">First argument.</param>
+    /// <param name="second">Second argument.</param>
+    public TwoArgException(int first, int second)
+    {
+        _ = first;
+        _ = second;
+    }
+}

--- a/Mappa.Generator/Algorithm/TypeMapIdentifierWithMapMethodAlgorithm.cs
+++ b/Mappa.Generator/Algorithm/TypeMapIdentifierWithMapMethodAlgorithm.cs
@@ -81,7 +81,8 @@ internal sealed class TypeMapIdentifierWithMapMethodAlgorithm
             return null;
         }
 
-        if (!this.Context.TryGetCompatibleMethod(this.Context.TargetType, this.Context.SourceType, this.Compilation, out var mapMethod))
+        if (!this.Context.TryGetCompatibleMethod(this.Context.TargetType, this.Context.SourceType, this.Compilation, out var mapMethod)
+            || mapMethod is null)
         {
             return null;
         }

--- a/Mappa.Generator/Extensions/TypeSymbolExtensions.cs
+++ b/Mappa.Generator/Extensions/TypeSymbolExtensions.cs
@@ -1197,7 +1197,7 @@ internal static class TypeSymbolExtensions
             .Select(sourceEnumValue => (SourceName: sourceEnumValue.Name, TargetName: targetMemberNames.FirstOrDefault(targetName => string.Equals(sourceEnumValue.Name, targetName, StringComparison.OrdinalIgnoreCase))))
             .Where(pair => pair.TargetName is not null)
             .OrderBy(pair => pair.SourceName)
-            .Select(pair => (pair.SourceName, pair.TargetName!))
+            .Select(pair => (pair.SourceName, pair.TargetName))
             .ToArray();
     }
 

--- a/Mappa.Generator/Mappa.Generator.csproj
+++ b/Mappa.Generator/Mappa.Generator.csproj
@@ -29,12 +29,12 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.18.0.131500">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.31.0.145097">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0">
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.6.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/Mappa.Generator/Models/DerivedMappaMapAlgorithmContext.cs
+++ b/Mappa.Generator/Models/DerivedMappaMapAlgorithmContext.cs
@@ -64,7 +64,7 @@ internal sealed class DerivedMappaMapAlgorithmContext(
         => this.ParentContext.TryGetPolymorphicMethod(targetType, sourceType, mappaUserSettings, out mapMethod);
 
     /// <inheritdoc/>
-    internal override bool TryGetCompatibleMethod(ITypeSymbol targetType, ITypeSymbol sourceType, Compilation compilation, out MapMethod mapMethod)
+    internal override bool TryGetCompatibleMethod(ITypeSymbol targetType, ITypeSymbol sourceType, Compilation compilation, out MapMethod? mapMethod)
         => this.ParentContext.TryGetCompatibleMethod(targetType, sourceType, compilation, out mapMethod);
 
     /// <inheritdoc/>

--- a/Mappa.Generator/Models/MappaClassGeneratorContext.cs
+++ b/Mappa.Generator/Models/MappaClassGeneratorContext.cs
@@ -209,7 +209,7 @@ internal sealed class MappaClassGeneratorContext
         ITypeSymbol sourceType,
         bool requireStaticContext,
         Compilation compilation,
-        out MapMethod mapMethod)
+        out MapMethod? mapMethod)
     {
         var foundMethod = this.mapMethods.Find(method =>
         {
@@ -221,7 +221,7 @@ internal sealed class MappaClassGeneratorContext
             return method.IsCompatibleMapFor(targetType, sourceType, compilation);
         });
 
-        mapMethod = foundMethod!;
+        mapMethod = foundMethod;
         return foundMethod is not null;
     }
 

--- a/Mappa.Generator/Models/MappaMapAlgorithmContext.cs
+++ b/Mappa.Generator/Models/MappaMapAlgorithmContext.cs
@@ -111,7 +111,7 @@ internal abstract class MappaMapAlgorithmContext
         ITypeSymbol targetType,
         ITypeSymbol sourceType,
         Compilation compilation,
-        out MapMethod mapMethod);
+        out MapMethod? mapMethod);
 
     /// <summary>
     /// Report a diagnostic.

--- a/Mappa.Generator/Models/MappaMethodGeneratorContext.cs
+++ b/Mappa.Generator/Models/MappaMethodGeneratorContext.cs
@@ -67,7 +67,7 @@ internal sealed class MappaMethodGeneratorContext
         => this.ClassContext.TryGetPolymorphicMethod(targetType, sourceType, this.IsNullableEnabled(), this.GetRootMapMethod().CanBeUsedByStaticMethod, mappaUserSettings, out mapMethod);
 
     /// <inheritdoc/>
-    internal override bool TryGetCompatibleMethod(ITypeSymbol targetType, ITypeSymbol sourceType, Compilation compilation, out MapMethod mapMethod)
+    internal override bool TryGetCompatibleMethod(ITypeSymbol targetType, ITypeSymbol sourceType, Compilation compilation, out MapMethod? mapMethod)
         => this.ClassContext.TryGetCompatibleMethod(targetType, sourceType, this.GetRootMapMethod().CanBeUsedByStaticMethod, compilation, out mapMethod);
 
     /// <inheritdoc/>

--- a/Mappa.Samples.Aot/Mappa.Samples.Aot.csproj
+++ b/Mappa.Samples.Aot/Mappa.Samples.Aot.csproj
@@ -20,7 +20,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.18.0.131500">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.31.0.145097">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Mappa.Samples.Tests/BreakCompileTimeCyclesMapperUnitTests.cs
+++ b/Mappa.Samples.Tests/BreakCompileTimeCyclesMapperUnitTests.cs
@@ -32,7 +32,7 @@ public sealed class BreakCompileTimeCyclesMapperUnitTests
         // Assert
         result.Id.Should().Be(1);
         result.Address.Should().NotBeNull();
-        result.Address!.Id.Should().Be(2);
+        result.Address.Id.Should().Be(2);
         result.Address.Owner.Should().BeSameAs(result);
     }
 
@@ -57,7 +57,7 @@ public sealed class BreakCompileTimeCyclesMapperUnitTests
         // Assert
         result.Id.Should().Be(1);
         result.Address.Should().NotBeNull();
-        result.Address!.Id.Should().Be(2);
+        result.Address.Id.Should().Be(2);
         result.Address.Owner.Should().BeNull();
     }
 }

--- a/Mappa.Samples.Tests/Mappa.Samples.Tests.csproj
+++ b/Mappa.Samples.Tests/Mappa.Samples.Tests.csproj
@@ -10,11 +10,10 @@
         <AnalysisLevel>latest-all</AnalysisLevel>
         <OutputType>Exe</OutputType>
         <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
-        <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
@@ -22,14 +21,14 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="coverlet.MTP" Version="10.0.1" />
-        <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
+        <PackageReference Include="AwesomeAssertions" Version="9.5.0" />
         <PackageReference Include="Xunit.OpenCategories.V3" Version="2.4.1.19" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
         <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.18.0.131500">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.31.0.145097">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Mappa.Samples.Tests/ReferenceHandlingMapperUnitTests.cs
+++ b/Mappa.Samples.Tests/ReferenceHandlingMapperUnitTests.cs
@@ -33,7 +33,7 @@ public sealed class ReferenceHandlingMapperUnitTests
         // Assert
         result.Id.Should().Be(1);
         result.Address.Should().NotBeNull();
-        result.Address!.Id.Should().Be(2);
+        result.Address.Id.Should().Be(2);
         result.Address.Owner.Should().BeSameAs(result);
     }
 
@@ -58,7 +58,7 @@ public sealed class ReferenceHandlingMapperUnitTests
         // Assert
         result.Id.Should().Be(1);
         result.Address.Should().NotBeNull();
-        result.Address!.Id.Should().Be(2);
+        result.Address.Id.Should().Be(2);
         result.Address.Owner.Should().BeNull();
     }
 

--- a/Mappa.Samples.Tests/ReferenceNullableToReferenceNullableMapperUnitTest.cs
+++ b/Mappa.Samples.Tests/ReferenceNullableToReferenceNullableMapperUnitTest.cs
@@ -28,7 +28,7 @@ public sealed class ReferenceNullableToReferenceNullableMapperUnitTest
 
         // Arrange
         target.Should().NotBeNull();
-        target!.ParamA.Should().Be($"{source.ParamA}");
+        target.ParamA.Should().Be($"{source.ParamA}");
         target.ParamB.Should().Be((int)source.ParamB);
     }
 
@@ -65,7 +65,7 @@ public sealed class ReferenceNullableToReferenceNullableMapperUnitTest
 
         // Arrange
         target.Should().NotBeNull();
-        target!.ParamA.Should().Be($"{source.ParamA}");
+        target.ParamA.Should().Be($"{source.ParamA}");
         target.ParamB.Should().Be((int)source.ParamB);
     }
 

--- a/Mappa.Samples/Mappa.Samples.csproj
+++ b/Mappa.Samples/Mappa.Samples.csproj
@@ -15,8 +15,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Google.Protobuf" Version="3.33.4" />
-        <PackageReference Include="Grpc.Tools" Version="2.76.0">
+        <PackageReference Include="Google.Protobuf" Version="3.35.1" />
+        <PackageReference Include="Grpc.Tools" Version="2.83.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
@@ -32,7 +32,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.18.0.131500">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.31.0.145097">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Mappa.Tests/Mappa.Tests.csproj
+++ b/Mappa.Tests/Mappa.Tests.csproj
@@ -10,10 +10,9 @@
         <AnalysisLevel>latest-all</AnalysisLevel>
         <OutputType>Exe</OutputType>
         <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
-        <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
         <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -24,13 +23,13 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.18.0.131500">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="10.31.0.145097">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
+        <PackageReference Include="AwesomeAssertions" Version="9.5.0" />
         <PackageReference Include="Xunit.OpenCategories.V3" Version="2.4.1.19" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
         <PackageReference Include="Comment.Todo.Analyzer" Version="1.2.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/Mappa/Mappa.csproj
+++ b/Mappa/Mappa.csproj
@@ -21,7 +21,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="SonarAnalyzer.CSharp" Version="10.18.0.131500">
+		<PackageReference Include="SonarAnalyzer.CSharp" Version="10.31.0.145097">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/Mappa/MappaContext.cs
+++ b/Mappa/MappaContext.cs
@@ -50,7 +50,7 @@ public sealed class MappaContext
     /// <summary>
     /// Gets the keys.
     /// </summary>
-    public IReadOnlyCollection<string> Keys => new List<string>(this.items.Keys);
+    public IReadOnlyCollection<string> Keys => this.items.Keys;
 
     /// <summary>
     /// Gets the reference manager used for reference reuse and runtime depth tracking.

--- a/MappaVersion.targets
+++ b/MappaVersion.targets
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <MappaVersion>10.2.0-alpha.69</MappaVersion>
+        <MappaVersion>10.2.0-alpha.70</MappaVersion>
     </PropertyGroup>
 </Project>

--- a/Scripts/BenchmarkChartsSvg.ps1
+++ b/Scripts/BenchmarkChartsSvg.ps1
@@ -217,6 +217,9 @@ function New-BenchmarkGroupedBarSvg
         # When set, force the Y-axis maximum (overflowing bars use a broken-top stub).
         [Nullable[double]]$YAxisMax = $null,
 
+        # When set with YAxisMax, continuous scale / break line ends here; YAxisMax is labeled at the overflow top.
+        [Nullable[double]]$YAxisBreakAt = $null,
+
         # When set with overflow stubs, scale stub height by overflow amount (max keeps OverflowStubMaxHeight).
         [switch]$ProportionalOverflowStubs,
 
@@ -282,10 +285,36 @@ function New-BenchmarkGroupedBarSvg
     $overflowStubMinHeight = 4.0
     $breakGap = 8.0
     $useAxisCap = ($null -ne $YAxisMax) -and ([double]$YAxisMax -gt 0)
-    $hasOverflow = $useAxisCap -and ($maxValue -gt [double]$YAxisMax)
-    $scaleHeight = if ($hasOverflow) { $plotHeight - $overflowStubMaxHeight - $breakGap } else { $plotHeight }
+    $useAxisBreak = ($null -ne $YAxisBreakAt) -and ([double]$YAxisBreakAt -gt 0)
+    if ($useAxisBreak -and -not $useAxisCap)
+    {
+        throw "YAxisBreakAt requires YAxisMax."
+    }
 
-    if ($useAxisCap)
+    if ($useAxisBreak -and ([double]$YAxisBreakAt -ge [double]$YAxisMax))
+    {
+        throw "YAxisBreakAt must be less than YAxisMax."
+    }
+
+    # Continuous scale ends at the break (when set) or at YAxisMax / auto max.
+    if ($useAxisBreak)
+    {
+        $axisMax = [double]$YAxisBreakAt
+        $tickCount = [int][Math]::Ceiling($axisMax / $YAxisTickStep)
+        if ($tickCount -lt 1)
+        {
+            $tickCount = 1
+        }
+
+        $axisMax = $tickCount * $YAxisTickStep
+        if ($axisMax -ge [double]$YAxisMax)
+        {
+            throw "YAxisBreakAt snapped to $axisMax which is not below YAxisMax ($([double]$YAxisMax)). Adjust YAxisTickStep."
+        }
+
+        $chartMax = [double]$YAxisMax
+    }
+    elseif ($useAxisCap)
     {
         $axisMax = [double]$YAxisMax
         $tickCount = [int][Math]::Ceiling($axisMax / $YAxisTickStep)
@@ -295,6 +324,7 @@ function New-BenchmarkGroupedBarSvg
         }
 
         $axisMax = $tickCount * $YAxisTickStep
+        $chartMax = $axisMax
     }
     else
     {
@@ -305,12 +335,18 @@ function New-BenchmarkGroupedBarSvg
         }
 
         $axisMax = $tickCount * $YAxisTickStep
+        $chartMax = $axisMax
     }
+
+    $overflowThreshold = $axisMax
+    $hasOverflow = ($useAxisCap -or $useAxisBreak) -and ($maxValue -gt $overflowThreshold)
+    $scaleHeight = if ($hasOverflow) { $plotHeight - $overflowStubMaxHeight - $breakGap } else { $plotHeight }
 
     $maxOverflowAmount = 0.0
     if ($hasOverflow)
     {
-        $maxOverflowAmount = $maxValue - $axisMax
+        $overflowCeiling = [Math]::Max($maxValue, $chartMax)
+        $maxOverflowAmount = $overflowCeiling - $overflowThreshold
         if ($maxOverflowAmount -lt 0)
         {
             $maxOverflowAmount = 0.0
@@ -367,6 +403,19 @@ function New-BenchmarkGroupedBarSvg
             [void]$builder.AppendLine("  <line x1=`"$leftMargin`" y1=`"$([Math]::Round($y, 2))`" x2=`"$([Math]::Round($leftMargin + $plotWidth, 2))`" y2=`"$([Math]::Round($y, 2))`" stroke=`"#dddddd`" stroke-width=`"1`"/>")
             [void]$builder.AppendLine("  <text x=`"$([Math]::Round($leftMargin - 8, 2))`" y=`"$([Math]::Round($y + 4, 2))`" text-anchor=`"end`" font-family=`"Segoe UI, Arial, sans-serif`" font-size=`"11`" fill=`"#555555`">$label</text>")
         }
+    }
+
+    # When the continuous scale breaks below YAxisMax, label the overflow top with the chart max.
+    if ($hasOverflow -and $useAxisBreak -and ($chartMax -gt $axisMax))
+    {
+        $topLabel = if ($YAxisTickStep -ge 1.0) {
+            Format-BenchmarkChartNumber -Value $chartMax -Format "0"
+        } else {
+            Format-BenchmarkChartNumber -Value $chartMax -Format "0.##"
+        }
+
+        [void]$builder.AppendLine("  <line x1=`"$leftMargin`" y1=`"$topMargin`" x2=`"$([Math]::Round($leftMargin + $plotWidth, 2))`" y2=`"$topMargin`" stroke=`"#dddddd`" stroke-width=`"1`"/>")
+        [void]$builder.AppendLine("  <text x=`"$([Math]::Round($leftMargin - 8, 2))`" y=`"$([Math]::Round($topMargin + 4, 2))`" text-anchor=`"end`" font-family=`"Segoe UI, Arial, sans-serif`" font-size=`"11`" fill=`"#555555`">$topLabel</text>")
     }
 
     # Draw EmphasizeGuideAt even when it is not on a tick (e.g. 100% with 500-step ticks).

--- a/Scripts/CodeCoverageHistorySvg.ps1
+++ b/Scripts/CodeCoverageHistorySvg.ps1
@@ -264,7 +264,8 @@ function New-CodeCoverageHistorySvg
     $yLabelMid = [Math]::Round(($y100 + $y80) / 2, 1)
 
     $svg = @"
-<svg version="1.2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="height: 500px; width: 800px;font-family:'Open Sans', sans-serif;background:white" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="800" height="500" viewBox="0 0 800 500" style="font-family:'Open Sans', sans-serif;" role="img">
+    <rect width="100%" height="100%" fill="#ffffff"/>
     <title id="title">Mappa Code Coverage</title>
     <g style="stroke:#CCCCCC;stroke-width: 2;"><line x1="90" x2="90" y1="$yAxisTop" y2="$y80"></line></g>
     <g style="stroke:#CCCCCC;stroke-width: 2;"><line x1="90" x2="705" y1="$y80" y2="$y80"></line></g>

--- a/Scripts/RunBenchmarks.ps1
+++ b/Scripts/RunBenchmarks.ps1
@@ -462,7 +462,7 @@ try
         -YAxisLabel "Mean time (us)" `
         -Title "Benchmark mean time" `
         -OutputPath $timeSvgPath `
-        -YAxisTickStep 25 `
+        -YAxisTickStep 50 `
         -ValueLabelFormat "0.###"
 
     if ($memoryChartBenchmarks.Count -gt 0)
@@ -524,8 +524,8 @@ try
                 -YAxisLabel "Competitor / Mappa (%)" `
                 -Title "Benchmark mean time vs Mappa" `
                 -OutputPath $timePercentSvgPath `
-                -YAxisTickStep 500 `
-                -YAxisMax 2500 `
+                -YAxisTickStep 250 `
+                -YAxisMax 1500 `
                 -ValueLabelFormat "0.#" `
                 -ValueLabelSuffix "%" `
                 -MapperNames $percentageMappers `


### PR DESCRIPTION
## Summary
- Bump outdated NuGet packages solution-wide to latest stable (SonarAnalyzer 10.31, Roslyn 5.6, AwesomeAssertions 9.5, Microsoft.NET.Test.Sdk 18.8.1, Google.Protobuf 3.35.1, Grpc.Tools 2.83.0, MongoDB.Bson 3.10.0, DI 10.0.10); keep StyleCop.Analyzers.Unstable on 1.2.0.556.
- Remove `TestingPlatformDotnetTestSupport` for Test.Sdk 18.8.1 + MTP compatibility; fix new Sonar findings (S8969, S2245, S2365).
- Add targeted unit tests for pre-existing generator coverage gaps; bump to `10.2.0-alpha.70`.
- Tune benchmark SVG Y-axis scales (mean time ticks 50; vs-Mappa top 1500% with 250/125 guides) and coverage-history SVG sizing.

## Test plan
- [x] `.\Scripts\RunTestsAndReportCoverage.ps1` — 3012 tests passed
- [x] Coverage ≥ baseline (line 98.8%, branch 92.3%, method 100% vs 98.6 / 91.8 / 100)
- [x] `dotnet package list --outdated` — no remaining updates on current sources
- [x] Regenerate benchmark SVGs with `-SkipRun`