### PR TITLE
#271 Release Mappa 10.2.0

### DIFF
--- a/Documentation/development.md
+++ b/Documentation/development.md
@@ -38,7 +38,7 @@ Reports are:
 Runs [BenchmarkDotNet](https://benchmarkdotnet.org/) in **Release** with job **Default** (same job used on `main` merge CI). Default uses more iterations/warmups than Short, so wall-clock time is longer but results are less noisy. Pull requests do not run benchmarks. Outputs land under the gitignored `.mappa-benchmark/` folder:
 
 - `Benchmark.Summary.md` — mean time (ns) and allocated bytes for AutoMapper / Mapster / Mapperly / Mappa
-- `Benchmark.Comparison.md` — winner table for the chart subset (best time / best memory; ties list Mappa first; non-Mappa winners include % delta vs Mappa; sole Mappa wins include smaller side delta + second-best mapper name when values differ)
+- `Benchmark.Comparison.md` — winner table for the chart subset (best time / best memory; ties list Mappa first with no delta; non-Mappa winners include unsigned `% vs Mappa`; sole Mappa wins include unsigned `% vs` second-best mapper when values differ)
 - `MAPPA-BENCHMARK-COMPARISON.svg` — SVG winner table for the same chart subset (memory winners are `n/a` for `StringToEnumBenchmark` / `EnumToStringBenchmark`, matching the memory charts)
 - `MAPPA-BENCHMARK-TIME.svg` / `MAPPA-BENCHMARK-MEMORY.svg` — grouped bar charts for the shared chart subset
 - `MAPPA-BENCHMARK-TIME-PERCENTAGES.svg` / `MAPPA-BENCHMARK-MEMORY-PERCENTAGES.svg` — competitor / Mappa percentage bar charts for the same subset

--- a/MappaVersion.targets
+++ b/MappaVersion.targets
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <MappaVersion>10.2.0-alpha.70</MappaVersion>
+        <MappaVersion>10.2.0</MappaVersion>
     </PropertyGroup>
 </Project>

--- a/Scripts/BenchmarkChartsSvg.ps1
+++ b/Scripts/BenchmarkChartsSvg.ps1
@@ -738,7 +738,7 @@ function Format-BenchmarkWinnerDeltaPercent
         return $null
     }
 
-    $delta = (($BestValue / $MappaValue) - 1.0) * 100.0
+    $delta = [Math]::Abs((($BestValue / $MappaValue) - 1.0) * 100.0)
     return $delta.ToString("0.#", [System.Globalization.CultureInfo]::InvariantCulture) + "%"
 }
 
@@ -754,15 +754,8 @@ function Format-BenchmarkSecondBestDeltaPercent
         return $null
     }
 
-    # Positive means the second-best mapper is worse than Mappa (higher time/memory).
-    $delta = (($SecondBestValue / $MappaValue) - 1.0) * 100.0
-    $formatted = $delta.ToString("0.#", [System.Globalization.CultureInfo]::InvariantCulture) + "%"
-    if (-not $formatted.StartsWith("-") -and -not $formatted.StartsWith("+"))
-    {
-        $formatted = "+" + $formatted
-    }
-
-    return $formatted
+    $delta = [Math]::Abs((($SecondBestValue / $MappaValue) - 1.0) * 100.0)
+    return $delta.ToString("0.#", [System.Globalization.CultureInfo]::InvariantCulture) + "%"
 }
 
 function Get-BenchmarkMappersWithMappaFirst
@@ -854,19 +847,13 @@ function Get-BenchmarkWinnerCell
         $mappaEntry = $Mappers["Mappa"]
         $mappaValue = if ($null -eq $mappaEntry) { $null } else { $mappaEntry.$MetricProperty }
         $deltaPercent = Format-BenchmarkWinnerDeltaPercent -BestValue $best.BestValue -MappaValue $mappaValue
+        $secondBestMapper = "Mappa"
     }
 
     $label = ($orderedWinners -join ", ")
-    if ($showDelta -and (-not [string]::IsNullOrWhiteSpace($deltaPercent)))
+    if ($showDelta -and (-not [string]::IsNullOrWhiteSpace($deltaPercent)) -and (-not [string]::IsNullOrWhiteSpace($secondBestMapper)))
     {
-        if (-not [string]::IsNullOrWhiteSpace($secondBestMapper))
-        {
-            $label = "$label ($deltaPercent $secondBestMapper)"
-        }
-        else
-        {
-            $label = "$label ($deltaPercent)"
-        }
+        $label = "$label ($deltaPercent vs $secondBestMapper)"
     }
 
     return [pscustomobject]@{
@@ -963,17 +950,22 @@ function Add-BenchmarkWinnerSvgText
         [void]$Builder.Append("<tspan font-weight=`"bold`" fill=`"$color`">$escapedMapper</tspan>")
     }
 
-    if ($WinnerCell.ShowDelta -and (-not [string]::IsNullOrWhiteSpace([string]$WinnerCell.DeltaPercent)))
+    if ($WinnerCell.ShowDelta -and
+        (-not [string]::IsNullOrWhiteSpace([string]$WinnerCell.DeltaPercent)) -and
+        (-not [string]::IsNullOrWhiteSpace([string]$WinnerCell.SecondBestMapper)))
     {
-        $sideText = " ($($WinnerCell.DeltaPercent)"
-        if (-not [string]::IsNullOrWhiteSpace([string]$WinnerCell.SecondBestMapper))
+        $vsMapper = [string]$WinnerCell.SecondBestMapper
+        $vsColor = "#555555"
+        if ($script:BenchmarkMapperColors.ContainsKey($vsMapper))
         {
-            $sideText += " $($WinnerCell.SecondBestMapper)"
+            $vsColor = $script:BenchmarkMapperColors[$vsMapper]
         }
 
-        $sideText += ")"
-        $escapedDelta = [System.Security.SecurityElement]::Escape($sideText)
-        [void]$Builder.Append("<tspan font-size=`"9`" fill=`"#555555`">$escapedDelta</tspan>")
+        $escapedPrefix = [System.Security.SecurityElement]::Escape(" ($($WinnerCell.DeltaPercent) vs ")
+        $escapedVsMapper = [System.Security.SecurityElement]::Escape($vsMapper)
+        [void]$Builder.Append("<tspan font-size=`"9`" fill=`"#555555`">$escapedPrefix</tspan>")
+        [void]$Builder.Append("<tspan font-size=`"9`" font-weight=`"bold`" fill=`"$vsColor`">$escapedVsMapper</tspan>")
+        [void]$Builder.Append('<tspan font-size="9" fill="#555555">)</tspan>')
     }
 
     [void]$Builder.AppendLine("</text>")


### PR DESCRIPTION
## Summary
- Bump `MappaVersion` to **10.2.0** for the release.
- Clarify benchmark winners SVG / comparison labels: unsigned `%`, `vs` before the other mapper, colored mapper name after `vs`, and `vs Mappa` when Mappa is not the winner (ties with Mappa unchanged).

## Test plan
- [ ] Confirm `MappaVersion.targets` is `10.2.0`
- [ ] Spot-check comparison SVG labels: sole Mappa win, non-Mappa win, and multi-winner ties
- [ ] CI green on the PR

